### PR TITLE
fix: Moonfin plugin URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 1. Jellyfin Dashboard → Administration → Plugins → Repositories
 2. Add repository:
    - **Name:** `Moonfin`
-   - **URL:** `https://raw.githubusercontent.com/Moonfin-Client/Plugin/main/manifest.json`
+   - **URL:** `https://raw.githubusercontent.com/Moonfin-Client/Plugin/refs/heads/master/manifest.json`
 3. Go to Catalog → find **Moonfin** → Install
 4. Restart Jellyfin
 


### PR DESCRIPTION
Fixed Moonfin manifest URL.
Old URL was returning a '404: Not found'
<img width="620" height="74" alt="image" src="https://github.com/user-attachments/assets/647bd5af-a466-4ffd-bdf0-2ac701feeae0" />
