### PR TITLE
ci: Auto-update manifest.json on new releases

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: update-manifest
+  cancel-in-progress: false
+
 jobs:
   update-manifest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that **automatically updates `manifest.json`** whenever a GitHub Release is published, edited, or deleted — no more manual edits to the versions array.

## How It Works

The workflow triggers on three `release` event types:

### `published` — New version added
1. **Extracts the version** from the release tag (e.g. `1.7.0` → `1.7.0.0`), stripping any `v` prefix and appending `.0` if needed
2. **Reads `targetAbi`** from the `Jellyfin.Controller` PackageReference in `backend/Moonfin.Server.csproj`
3. **Downloads the `Moonfin.Server-*.zip` asset** attached to the release and computes its **MD5 checksum** (uppercase)
4. **Sanitizes the changelog** — strips markdown formatting (badges, bold, links, headers, code ticks, horizontal rules) from the release body to produce clean plain text suitable for Jellyfin's UI
5. **Formats the timestamp** from the release `created_at` field
6. **Prepends a new version entry** to `.[0].versions` in `manifest.json` using `jq`
7. **Commits and pushes** the updated manifest back to the default branch

### `edited` — Version entry updated
When a release is edited (e.g. release notes changed), the workflow **upserts** the version entry — it removes the existing entry with the matching version and prepends a freshly built one. This also handles edge cases where assets were re-uploaded.

### `deleted` — Version entry removed
When a release is deleted, the workflow removes the matching version entry from the `versions` array.

### Field Mapping

| Field | Source |
|---|---|
| `version` | Release tag (e.g. `1.7.0` → `1.7.0.0`) |
| `changelog` | Release body, sanitized to plain text |
| `targetAbi` | `Jellyfin.Controller` version from `.csproj` + `.0` |
| `sourceUrl` | `Moonfin.Server-*.zip` asset download URL from the release |
| `checksum` | MD5 of the downloaded zip (uppercase) |
| `timestamp` | Release `created_at` → `YYYY-MM-DDTHH:MM:SS` |
| `dependencies` | Always `[]` |

### Changelog Sanitization

GitHub release bodies use rich markdown (headers, bold, badges, links, code ticks), but Jellyfin renders the changelog as **plain text**. The workflow automatically strips markdown to produce clean output:

**Before (raw release body):**
```
## Moonfin v1.6.0 Release Notes [![github](https://img.shields.io/...)](...)
### Bug Fixes
- **Fixed proxy navigation** — Search, sidebar links...
- `MDBList` batch task refactored
```

**After (sanitized for manifest):**
```
Bug Fixes
- Fixed proxy navigation — Search, sidebar links...
- MDBList batch task refactored
```

## Benefits

- **Zero manual work** — just write your release notes, attach the zip, and publish
- **No drift** — manifest stays in sync with releases automatically
- **Full lifecycle** — handles new releases, edits to release notes, and release deletions
- **Clean changelogs** — markdown is automatically stripped to plain text for Jellyfin's UI
- **Injection-safe** — all GitHub expression interpolation uses `env:` variables
- **Stable asset detection** — specifically matches `Moonfin.Server-*.zip` rather than any `.zip`
- **Race-condition safe** — uses `git pull --rebase` before push

## Tested

All event types and changelog sanitization tested on a fork:

| Event | Run | Result |
|---|---|---|
| `published` | [22817606235](https://github.com/enyineer/moonfin-plugin/actions/runs/22817606235) | ✅ Version prepended correctly |
| `edited` | [22817618274](https://github.com/enyineer/moonfin-plugin/actions/runs/22817618274) | ✅ Changelog updated in-place |
| `deleted` | [22817634272](https://github.com/enyineer/moonfin-plugin/actions/runs/22817634272) | ✅ Version entry removed |
| `published` + sanitization | [22817876277](https://github.com/enyineer/moonfin-plugin/actions/runs/22817876277) | ✅ Markdown stripped to plain text |