### PR TITLE
Fix Jellyseerr button not appearing in sidebar/navbar after settings sync

### DIFF
--- a/frontend/src/plugin.js
+++ b/frontend/src/plugin.js
@@ -1010,10 +1010,16 @@ const Plugin = {
             if (navEnabled) {
                 if (navPosition === 'left') {
                     if (Navbar.initialized) Navbar.destroy();
-                    if (!Sidebar.initialized) Sidebar.init();
+                    if (!Sidebar.initialized) {
+                        Sidebar.init();
+                        if (Jellyseerr.config) Sidebar.updateJellyseerrButton(Jellyseerr.config);
+                    }
                 } else {
                     if (Sidebar.initialized) Sidebar.destroy();
-                    if (!Navbar.initialized) Navbar.init();
+                    if (!Navbar.initialized) {
+                        Navbar.init();
+                        if (Jellyseerr.config) Navbar.updateJellyseerrButton(Jellyseerr.config);
+                    }
                 }
             } else {
                 if (Navbar.initialized) Navbar.destroy();


### PR DESCRIPTION
## Summary

- When navbar/sidebar is not in local storage but enabled on the server, the `moonfin-settings-changed` event initializes the sidebar/navbar **after** `Jellyseerr.init()` has already dispatched the `moonfin-jellyseerr-config` event
- This causes the Jellyseerr button to remain permanently hidden since the sidebar/navbar wasn't listening yet when the event fired
- Affects all clients (web, desktop app, webOS TV app)

## Root Cause

In `plugin.js`, the `moonfin-settings-changed` handler calls `Sidebar.init()` / `Navbar.init()` but never updates the Jellyseerr button state afterwards. Since `Jellyseerr.init()` already ran and dispatched its config event before the sidebar was ready, the button stays hidden.

## Fix

After `Sidebar.init()` or `Navbar.init()` is called from the settings-changed handler, explicitly call `updateJellyseerrButton(Jellyseerr.config)` if config is available.

## How to reproduce

1. Enable Jellyseerr in the Moonfin server plugin settings
2. Clear local storage (or use a fresh browser/device)
3. Load Jellyfin — the Jellyseerr button will not appear in the sidebar/navbar
4. Workaround that confirms the timing issue: `setTimeout(() => window.dispatchEvent(new CustomEvent('moonfin-jellyseerr-config', { detail: { enabled: true, url: '...', displayName: 'Jellyseerr', variant: 'jellyseerr' } })), 3000)` makes the button appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)