### PR TITLE
fix: use ParentId per library instead of TopParentIds for mediabar

### DIFF
--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -576,6 +576,13 @@ public class MoonfinController : ControllerBase
             }
         }
 
+        // Shuffle merged results for fair representation across libraries
+        for (var i = allItems.Count - 1; i > 0; i--)
+        {
+            var j = Random.Shared.Next(i + 1);
+            (allItems[i], allItems[j]) = (allItems[j], allItems[i]);
+        }
+
         return allItems.Take(limit).ToList();
     }
 


### PR DESCRIPTION
Found another bug when selecting specific libraries, introduced by the `TopParentIds` usage.

The fix queries each selected library individually via `ParentId`, with `OrderBy=Random` + `Limit` at the DB level. Results are merged, shuffled for fair representation across libraries, then trimmed to the requested limit. At most `limit + selectedLibraryCount` items are held in memory (e.g. 13 items for limit=10 with 3 libraries).

This fixes the issue in my local testing.