### PR TITLE
Mediabar redesign and optimization (#85)

### DIFF
--- a/frontend/src/styles/mediabar.css
+++ b/frontend/src/styles/mediabar.css
@@ -8,10 +8,8 @@
 .moonfin-mediabar {
     position: absolute;
     top: 0;
-    left: 0;
-    right: 0;
     width: 100%;
-    height: 850px;
+    height: 100dvh;
     overflow: hidden;
     cursor: pointer;
     z-index: 100;
@@ -19,7 +17,7 @@
 
 body.moonfin-mediabar-active .homeSectionsContainer {
     position: relative;
-    top: 775px;
+    top: 90dvh;
     z-index: 6;
 }
 


### PR DESCRIPTION
Before:
<img width="1919" height="918" alt="Before" src="https://github.com/user-attachments/assets/2eae35f5-c1d3-4384-9395-28f9583fb712" />

After:
<img width="1919" height="918" alt="image" src="https://github.com/user-attachments/assets/8334d902-9105-41a6-aa2c-b1670212a0a2" />
