### PR TITLE
docs: Rebrand server plugin to Moonbase and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<h1 align="center">Moonfin for Jellyfin Web and Mobile</h1>
-<h3 align="center">A Jellyfin server plugin that serves the Moonfin Flutter web app, provides cross-client settings synchronization, and includes optional Seerr proxy integration.</h3>
+<h1 align="center">Moonbase *for* Moonfin!</h1>
+<h3 align="center">Moonbase is a multi-purpose Jellyfin server plugin that provides structural elements for all Moonfin clients.</h3>
 
 ---
 
@@ -9,44 +9,44 @@
 
 [![License](https://img.shields.io/github/license/Moonfin-Client/Plugin.svg)](https://github.com/Moonfin-Client/Plugin) [![Release](https://img.shields.io/github/release/Moonfin-Client/Plugin.svg)](https://github.com/Moonfin-Client/Plugin/releases)
 
-## What is this?
+## What is Moonbase?
 
-Moonfin is a Jellyfin server plugin that serves the Moonfin Flutter app at `/Moonfin/Web/` and provides server APIs used by Moonfin clients across web, mobile, and desktop.
+Moonbase is a Jellyfin server plugin that provides infrastructure for **all** Moonfin clients. The plugin handles settings synchronization, runtime web config/discovery pages, media bar and home row data preferences, enhanced Administrative pages, media rating integrations, and handles Seerr proxy/SSO configurations. User settings follow a profiled model (global profile with optional desktop/mobile/tv overrides), and admins can define and push server-wide defaults for many of Moonfin's preferences. 
 
-The plugin handles settings sync, runtime web config/discovery, media bar and home row data, ratings integrations, and Seerr proxy/SSO. User settings follow a profiled model (global plus optional desktop/mobile/tv overrides), and admins can define server-wide defaults.
+The plugin now also serves a **new Moonfin Flutter web interface** that can be opened directly from `/Moonfin/Web/` and has been optimized for in-browser navigation and viewing. This allows for the Moonfin web interface to run side-by-side with Jellyfin's. If desired, a link to the Moonbase web interface can be included in the stock Jellyfin Web header through the [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) bridge detailed below.
 
-Moonfin can be opened directly at `/Moonfin/Web/`. A stock Jellyfin Web header button is optional and available through the [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) bridge.
+> **Note:** The rebrand from "Plug-in" to Moonbase emphasizes the central role this component plays. It is **highly recommended** that all users of any Moonfin client install and set-up Moonbase on their server to get the best possible Moonfin experience!
 
-## Opening Moonfin
+## Opening the Moonbase Web Interface
 
-Primary path: open `https://your-jellyfin-host/Moonfin/Web/` directly.
+The Moonbase Web UI can be accessed and book-marked through it's primary path: `https://your-jellyfin-host/Moonfin/Web/`
 
-Optional path: install File Transformation and use the header Moonfin button next to SyncPlay inside stock Jellyfin Web.
+Optionally: If you install the [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plug-in, a Moonfin icon will appear in the header (next to SyncPlay) inside stock Jellyfin Web that can be used as a direct link to the web interface.
 <img width="1521" height="164" alt="image" src="https://github.com/user-attachments/assets/bcb69e4b-edbe-4d1f-b9f1-dc81822d55d9" />
 
-> **Tip for admins:** Use *Dashboard → Plugins → Moonfin* to set default user settings and web runtime options (forced/default server URL, WebRTC scan toggle).
+> **Tip for Admins:** The Plug-in Settings panel (under *Dashboard → Plugins → Moonfin*) can be used to set default user settings, web runtime options (forced/default server URL, WebRTC scan toggle), and many other server-side settings!
 
 ## Features
 
-### Moonfin App (`frontend/`)
+### The Moonbase Web UI (`frontend/`)
 - **Cross-Platform Moonfin UI** - One app surface used across web, TV, mobile, and desktop with adaptive navigation and layout behavior
 - **Full Library Browsing** - Home, search, favorites, genres, folder/collection views, and unified multi-server library support
 - **Multiple Playback Surfaces** - Video, audio, photo, book, trailer, next-up, and still-watching playback routes
 - **Live TV and DVR Screens** - Live TV browse, guide, schedule, recordings, series recordings, and live TV player routes
-- **Integrated Admin Screens** - In-app admin routes for users, libraries, tasks, settings, plugins, logs, devices, analytics, and more
+- **Integrated Admin Screens** - In-app (and themed) admin routes for users, libraries, tasks, settings, plugins, logs, devices, analytics, and more
 - **Built-In Seerr Screens** - Discover, requests, browse, media detail, and person detail flows in Moonfin
 - **Web Diagnostics Route** - Dedicated diagnostics view for web startup and routing issues
 - **Per-User Settings Profiles** - Global plus optional desktop/mobile/tv overrides with server sync
 
-### Server Plugin (`backend/`)
+### The Moonbase Server Plugin (`backend/`)
 - **Settings Sync API** - Per-user preference storage with resolved profiles, profile-specific writes, and admin-configurable defaults
 - **Live Sync Events (SSE)** - Optional real-time settings/theme refresh events through `/Moonfin/Settings/Stream`
-- **Admin Defaults Operations** - Push current defaults to all existing users and broadcast admin messages/events
+- **Admin Defaults Operations** - Push current defaults to all existing users
 - **Admin Broadcast Messages** - Admins can send announcements to all connected users at any time for in-client display
 - **Runtime Web Config and Discovery** - `/Moonfin/Web/config.json` plus `/Moonfin/Discovery` endpoints for same-origin plugin mode startup
 - **Theme Upload and Validation APIs** - Admin upload/delete endpoints with strict schema validation and metadata tracking
 - **Media Bar and Genre APIs** - Server-resolved media bar content and genre filters shared across clients
-- **MDBList and TMDB Proxies** - Ratings endpoints that keep API keys server-side
+- **MDBList and TMDB Proxies** - Ratings endpoints that keep API keys server-side for users to incorporate additional ratings in their client displays
 - **Seerr Proxy and SSO** - Authenticated API proxy endpoints with session handling and variant-aware config
 - **Web Asset Hosting** - Serves Flutter web build output under `/Moonfin/Web/` with SPA fallback routing
 - **Optional Header Bridge** - Lightweight File Transformation integration for one-click entry from stock Jellyfin Web
@@ -104,7 +104,7 @@ Optional path: install File Transformation and use the header Moonfin button nex
 Moonfin serves its web app at `/Moonfin/Web/`.
 
 1. Open `/Moonfin/Web/` directly on your Jellyfin server.
-2. If assets do not appear after a fresh install, run the **Moonfin Startup** scheduled task once, then refresh the page.
+2. If assets do not appear after a fresh install, run the **Moonfin Startup** task from Jellyfin Dashboard → Administration → Scheduled Tasks once, then refresh the page.
 
 Optional one-click stock web entry:
 
@@ -118,7 +118,7 @@ Optional one-click stock web entry:
 > **UI not loading?** Go to *Dashboard → Scheduled Tasks* and run the **Moonfin Startup** task once, then refresh your browser.
 
 ### **Hide the optional header logo**
-Add these CSS lines on Branding/Custom CSS:
+If you have the File Transformation plug-in installed but do *not* want the Moonfin icon to appear, add these CSS lines to the Branding → Custom CSS settings on the Jellyfin Administrative Dashboard:
 
 ```
 .headerMoonfinButton {
@@ -142,13 +142,14 @@ Jellyfin Dashboard → Administration → Plugins → **Moonfin** to configure:
 
 ### Theme Editor and Custom Themes
 
-- Built-in editor is available at `/Moonfin/Web/theme/` for visual token editing, validation, and JSON export.
-- Admins can upload exported themes in the plugin config page, and clients can fetch uploaded themes through `/Moonfin/Themes`.
+- Custom theming is here! A built-in theme editor for Moonfin clients is available at `/Moonfin/Web/theme/`
+- This editor allows for visual token editing, validation, and JSON export.
+- Admins can upload exported themes in the plugin config page, and clients can fetch uploaded themes from within the Settings menu on their Moonfin client of choice.
 - Uploaded themes are schema-validated server-side and tracked with metadata (display name, checksum, uploader, upload time).
 
 # User Settings
 
-Open Moonfin at `/Moonfin/Web/`, then use the in-app settings page to customize navbar/media bar behavior, details screen settings, ratings integrations, and other synced preferences.
+Open the Moonbase Web UI at `/Moonfin/Web/`, then use the in-app settings page to customize navbar/media bar behavior, details screen settings, ratings integrations, and other synced preferences the same way you would on any other Moonfin client.
 
 Settings support **device profiles**: a shared global profile plus optional overrides for desktop, mobile, and TV. Device profiles only store values that differ from global, so changes to global automatically flow to all devices unless explicitly overridden. A sync toggle lets you enable or disable server synchronization per-user.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<h1 align="center">Moonbase *for* Moonfin!</h1>
+<h1 align="center">Moonbase, the server plugin for Moonfin!</h1>
 <h3 align="center">Moonbase is a multi-purpose Jellyfin server plugin that provides structural elements for all Moonfin clients.</h3>
 
 ---
 
 <p align="center">
-   <img width="1920" height="1080" alt="Moonfin Logo" src="https://github.com/user-attachments/assets/8a22192b-1481-4d96-a832-0579a348943c" />
+   <img width="1920" height="1080" alt="Moonbase" src="https://github.com/user-attachments/assets/5d67e8d0-5972-49f2-89d5-376357c8997b" />
 </p>
 
 [![License](https://img.shields.io/github/license/Moonfin-Client/Plugin.svg)](https://github.com/Moonfin-Client/Plugin) [![Release](https://img.shields.io/github/release/Moonfin-Client/Plugin.svg)](https://github.com/Moonfin-Client/Plugin/releases)
@@ -13,9 +13,9 @@
 
 Moonbase is a Jellyfin server plugin that provides infrastructure for **all** Moonfin clients. The plugin handles settings synchronization, runtime web config/discovery pages, media bar and home row data preferences, enhanced Administrative pages, media rating integrations, and handles Seerr proxy/SSO configurations. User settings follow a profiled model (global profile with optional desktop/mobile/tv overrides), and admins can define and push server-wide defaults for many of Moonfin's preferences. 
 
-The plugin now also serves a **new Moonfin Flutter web interface** that can be opened directly from `/Moonfin/Web/` and has been optimized for in-browser navigation and viewing. This allows for the Moonfin web interface to run side-by-side with Jellyfin's. If desired, a link to the Moonbase web interface can be included in the stock Jellyfin Web header through the [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) bridge detailed below.
+The plugin also serves a **new Moonfin Flutter web interface** that can be opened directly from `/Moonfin/Web/` and has been optimized for in-browser navigation and viewing. This allows for the Moonfin web interface to run side-by-side with Jellyfin's. If desired, a link to the Moonbase web interface can be included in the stock Jellyfin Web header through the [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) bridge detailed below.
 
-> **Note:** The rebrand from "Plug-in" to Moonbase emphasizes the central role this component plays. It is **highly recommended** that all users of any Moonfin client install and set-up Moonbase on their server to get the best possible Moonfin experience!
+> **Note:** It is **highly recommended** that all users of any Moonfin client install and set-up Moonbase on their server to get the best possible experience!
 
 ## Opening the Moonbase Web Interface
 
@@ -50,30 +50,6 @@ Optionally: If you install the [File Transformation](https://github.com/IAmParad
 - **Seerr Proxy and SSO** - Authenticated API proxy endpoints with session handling and variant-aware config
 - **Web Asset Hosting** - Serves Flutter web build output under `/Moonfin/Web/` with SPA fallback routing
 - **Optional Header Bridge** - Lightweight File Transformation integration for one-click entry from stock Jellyfin Web
-----
-# Screenshots
-
-## Web UI
-<img width="48%" alt="Home" src="https://github.com/user-attachments/assets/e71a5447-31c2-47e9-bfa8-3bd902ca7a50" />
-<img width="48%" alt="Media Bar" src="https://github.com/user-attachments/assets/3dffe616-829c-4b2e-9275-d24506b6481d" />
-<img width="48%" alt="Details" src="https://github.com/user-attachments/assets/bf9fd6df-d0b5-4eff-9557-5a9ec2acc0ad" />
-<img width="48%" alt="Jellyseerr" src="https://github.com/user-attachments/assets/cf3f371b-0ad0-43c0-ba98-4ddce67950d3" />
-<img width="48%" alt="Navbar" src="https://github.com/user-attachments/assets/bad74e17-e5f6-4654-b0bb-fed10d3b46ae" />
-<img width="48%" alt="Settings" src="https://github.com/user-attachments/assets/e31f1f15-b754-415c-a1fd-46f729964b79" />
-<img width="48%" alt="Genres" src="https://github.com/user-attachments/assets/8683d2e8-a096-4f5a-be74-9c0eea922e4e" />
-
-## Mobile UI
-<img width="23%" alt="Mobile Home" src="https://github.com/user-attachments/assets/ffdc52ea-b153-4518-9c3b-22870b463a83" />
-<img width="23%" alt="Mobile Details" src="https://github.com/user-attachments/assets/e0da8bc2-13ea-4c3c-86fc-7dadfa7be529" />
-<img width="23%" alt="Mobile Browse" src="https://github.com/user-attachments/assets/e33b196f-7ba5-469e-bc09-da7612b22f96" />
-<img width="23%" alt="Mobile Player" src="https://github.com/user-attachments/assets/4ff4292f-c4b3-409f-8dfd-0d97d9eff45e" />
-<img width="23%" alt="Mobile Settings" src="https://github.com/user-attachments/assets/3da56213-3c8b-4b9a-b736-4055acb10714" />
-<img width="23%" alt="Mobile Jellyseerr" src="https://github.com/user-attachments/assets/3cc8f260-e1f9-4cb9-bc7a-8e2359f473cf" />
-<img width="23%" alt="Mobile Navbar" src="https://github.com/user-attachments/assets/df6408d7-3883-4838-8228-f97d989f15d6" />
-
----
-
-**Disclaimer:** Screenshots shown in this documentation feature media content, artwork, and actor likenesses for demonstration purposes only. None of the media, studios, actors, or other content depicted are affiliated with, sponsored by, or endorsing the Moonfin client or the Jellyfin project. All rights to the portrayed content belong to their respective copyright holders. These screenshots are used solely to demonstrate the functionality and interface of the application.
 
 ---
 
@@ -249,7 +225,7 @@ Output: `Moonfin.Server-{VERSION}.zip` in the repo root.
 | `/Moonfin/Discovery` and `/Moonfin/Discovery/discover` | GET | No | Same-origin discovery response for web mode |
 | `/Moonfin/Web/{**path}` | GET | No | Serve Moonfin Flutter web assets and SPA routes |
 
-### Jellyseerr/Seerr Config Response
+### Seerr Config Response
 
 ```json
 {
@@ -343,17 +319,6 @@ Settings stored on the server per-user and shared across all Moonfin clients. Ea
 | `tmdbEpisodeRatingsEnabled` | bool | Enable TMDB episode ratings |
 | `homeRowOrder` | list | Ordered list of enabled home screen sections |
 
-### Web-Only Settings (Not Synced)
-
-These settings are stored in localStorage only and do not sync across clients:
-
-| Setting | Description |
-|---------|-------------|
-| `detailsPageEnabled` | Enable custom details screen |
-| `mediaBarAutoAdvance` | Auto-advance media bar slides |
-| `mediaBarIntervalMs` | Auto-advance interval in milliseconds |
-| `backdropEnabled` | Enable backdrop images |
-
 ### On Startup
 
 - Pings `GET /Moonfin/Ping` to check if the server plugin is installed and sync is enabled
@@ -373,7 +338,7 @@ These settings are stored in localStorage only and do not sync across clients:
 
 ### Cross-Client Behavior
 
-- When you open Jellyfin on a **new device/browser** with no local settings, it pulls from the server and your settings follow you
+- When you open Moonfin on a **new device/browser** with no local settings, it pulls from the server and your settings follow you
 - If you change settings on **Client A**, they push to server. When **Client B** next loads (page refresh/login), it syncs but Client B's local settings win in the merge, so it won't overwrite unsaved local preferences
 - Clients subscribed to `/Moonfin/Settings/Stream` receive live events (`settingsUpdated`, `themesChanged`, admin messages) and can refresh without waiting for restart/login
 - Admin broadcasts are delivered to connected clients through the same stream so users can see announcements immediately in-app
@@ -411,10 +376,9 @@ We welcome contributions to Moonfin for Jellyfin Web!
 
 ## Credits
 
-Moonfin for Jellyfin Web is built upon the excellent work of:
+Moonfin is built upon the excellent work of:
 
 - **[Jellyfin Project](https://jellyfin.org)** - The foundation and upstream codebase
-- **[MakD](https://github.com/MakD)** - Original Jellyfin-Media-Bar concept that inspired our featured media bar
 - **[Druidblack](https://github.com/Druidblack)** - Original MDBList Ratings plugin
 - **Moonfin Contributors** - Everyone who has contributed to this project
 
@@ -425,6 +389,6 @@ This project is licensed under GPL-3.0. See the [LICENSE](LICENSE) file for deta
 ---
 
 <p align="center">
-   <strong>Moonfin for Jellyfin Web</strong> is an independent project and is not affiliated with the Jellyfin project.<br>
+   <strong>Moonfin </strong> is an independent project and is not affiliated with the Jellyfin project.<br>
    <a href="https://github.com/Moonfin-Client">← Back to main Moonfin project</a>
 </p>


### PR DESCRIPTION
# Pull Request for Moonbase README Edits
## Summary
Rebrands plugin references in the documentation to "Moonbase" and performs a comprehensive update to the project's README for better clarity, coverage of theme features, and detailed installation steps.
## Related Issues
None.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [x] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- Rebranded server plugin references to "Moonbase" to distinguish it from front-end clients.
- Expanded instructions on opening the Moonbase Web UI and configuring the optional header logo.
- Clarified the Scheduled Task startup requirement for new installations.
- Polished the theme editor and custom theme installation instructions.
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code
## Testing
- Manual review of Markdown formatting and validation of absolute paths/links.
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
