### PR TITLE
fix: normalize Letterboxd ratings to 0-5 scale in MdbListController

### DIFF
--- a/backend/Api/MdbListController.cs
+++ b/backend/Api/MdbListController.cs
@@ -172,25 +172,18 @@ public class MdbListController : ControllerBase
 
                 // Letterboxd: MDBList's value field is on an ambiguous 0-10 scale.
                 // Normalize to the native 0-5 scale so all clients receive a correct value
-                // without mutating the underlying cache.
+                // without mutating the underlying cache. Keep it as a double so clients
+                // can parse it cleanly and append "/5" for display.
                 if (string.Equals(ratingClone.Source, "letterboxd", StringComparison.OrdinalIgnoreCase))
                 {
-                    var isAlreadyFormatted = ratingClone.Value != null && ratingClone.Value.ToString()?.Contains("/5") == true;
-
-                    if (!isAlreadyFormatted)
+                    if (ratingClone.Score.HasValue)
                     {
-                        if (ratingClone.Score.HasValue)
-                        {
-                            var normalizedValue = ratingClone.Score.Value / 20.0;
-                            ratingClone.Value = $"{normalizedValue:0.0}/5";
-                            ratingClone.Score = normalizedValue;
-                        }
-                        else if (ratingClone.Value != null && double.TryParse(ratingClone.Value.ToString(), out var val))
-                        {
-                            var normalizedValue = val > 5.0 ? val / 2.0 : val;
-                            ratingClone.Value = $"{normalizedValue:0.0}/5";
-                            ratingClone.Score = normalizedValue;
-                        }
+                        ratingClone.Value = Math.Round(ratingClone.Score.Value / 20.0, 1);
+                    }
+                    else if (ratingClone.Value.HasValue)
+                    {
+                        var val = ratingClone.Value.Value;
+                        ratingClone.Value = val > 5.0 ? Math.Round(val / 2.0, 1) : val;
                     }
                 }
                 result.Add(ratingClone);
@@ -261,7 +254,7 @@ public class MdbListRating
 
     /// <summary>Provider's native rating value.</summary>
     [JsonPropertyName("value")]
-    public object? Value { get; set; }
+    public double? Value { get; set; }
 
     /// <summary>Normalized score (0-100).</summary>
     [JsonPropertyName("score")]

--- a/backend/Api/MdbListController.cs
+++ b/backend/Api/MdbListController.cs
@@ -160,7 +160,40 @@ public class MdbListController : ControllerBase
         {
             if (ratingsBySource.TryGetValue(source, out var rating))
             {
-                result.Add(rating);
+                // Clone the rating object to prevent mutating the cached instance in memory
+                var ratingClone = new MdbListRating
+                {
+                    Source = rating.Source,
+                    Value = rating.Value,
+                    Score = rating.Score,
+                    Votes = rating.Votes,
+                    Url = rating.Url
+                };
+
+                // Letterboxd: MDBList's value field is on an ambiguous 0-10 scale.
+                // Normalize to the native 0-5 scale so all clients receive a correct value
+                // without mutating the underlying cache.
+                if (string.Equals(ratingClone.Source, "letterboxd", StringComparison.OrdinalIgnoreCase))
+                {
+                    var isAlreadyFormatted = ratingClone.Value != null && ratingClone.Value.ToString()?.Contains("/5") == true;
+
+                    if (!isAlreadyFormatted)
+                    {
+                        if (ratingClone.Score.HasValue)
+                        {
+                            var normalizedValue = ratingClone.Score.Value / 20.0;
+                            ratingClone.Value = $"{normalizedValue:0.0}/5";
+                            ratingClone.Score = normalizedValue;
+                        }
+                        else if (ratingClone.Value != null && double.TryParse(ratingClone.Value.ToString(), out var val))
+                        {
+                            var normalizedValue = val > 5.0 ? val / 2.0 : val;
+                            ratingClone.Value = $"{normalizedValue:0.0}/5";
+                            ratingClone.Score = normalizedValue;
+                        }
+                    }
+                }
+                result.Add(ratingClone);
             }
         }
 
@@ -228,7 +261,7 @@ public class MdbListRating
 
     /// <summary>Provider's native rating value.</summary>
     [JsonPropertyName("value")]
-    public double? Value { get; set; }
+    public object? Value { get; set; }
 
     /// <summary>Normalized score (0-100).</summary>
     [JsonPropertyName("score")]


### PR DESCRIPTION
## Summary

Fixes Letterboxd ratings displaying as doubled values in all clients.

MDBList's `value` field for Letterboxd is on an ambiguous 0-10 scale
(doubled from the native 0-5 scale). The previous client-side `value > 5`
halving guard failed silently for any film scoring **2.5/5 or below** ? those
values after doubling are ? 5 and are indistinguishable from a real low-end
score, so they passed through un-halved and displayed incorrectly. Since
clients receive `value` directly from this API, no client can reliably self-correct.

The fix normalizes in `FilterAndOrderRatings()` using `score / 20`, where
`score` is MDBList's unambiguous 0?100 field, before the data is returned.
All clients receive a correct 0?5 value without needing their own workarounds.

## Type of Change
- [x] Bug fix

## Changes Made

- **`MdbListController.cs`**: Added a Letterboxd-specific normalization step
  in `FilterAndOrderRatings()`. When a Letterboxd rating is about to be
  returned, `Value` is replaced with `Score / 20.0`. The raw MDBList data
  in the cache is left untouched; normalization happens on the way out only.

## Testing

Verified on physical device (NVIDIA Shield Pro) via the Moonfin Android TV
beta client. Letterboxd badges now display as X.X/5 with correct values
across the full rating range, including films scoring below 2.5/5.

- Confirmed *Sorry to Bother You* shows 3.7/5 (was 7.4)
- Confirmed *The Descent: Part 2* shows 2.4/5 (matches Letterboxd.com)

### Screenshots
Current build:
<img width="500" alt="Shield_Screenshot_2026-05-31_22-14-45" src="https://github.com/user-attachments/assets/4ef05d83-9d8c-43e1-ae21-b9ef5ba1df32" />

Fixed:
<img width="500" alt="Shield_Screenshot_2026-05-31_22-11-49" src="https://github.com/user-attachments/assets/b10377e7-0de1-4ab0-b5ea-7303c5b67d0d" />

Low Score (undeserved!):
<img width="500" alt="Shield_Screenshot_2026-05-31_22-29-34" src="https://github.com/user-attachments/assets/f8097733-07cb-417e-9a1d-eb6d6e1f9a00" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
