### PR TITLE
Fix Rotten Tomatoes Audience rating source mismatch

### DIFF
--- a/backend/Api/MdbListController.cs
+++ b/backend/Api/MdbListController.cs
@@ -158,12 +158,19 @@ public class MdbListController : ControllerBase
         var result = new List<MdbListRating>();
         foreach (var source in sources)
         {
-            if (ratingsBySource.TryGetValue(source, out var rating))
+            var lookupSource = source;
+            if (string.Equals(source, "rtAudience", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(source, "tomatoes_audience", StringComparison.OrdinalIgnoreCase))
+            {
+                lookupSource = "popcorn";
+            }
+
+            if (ratingsBySource.TryGetValue(lookupSource, out var rating))
             {
                 // Clone the rating object to prevent mutating the cached instance in memory
                 var ratingClone = new MdbListRating
                 {
-                    Source = rating.Source,
+                    Source = source,
                     Value = rating.Value,
                     Score = rating.Score,
                     Votes = rating.Votes,

--- a/backend/Pages/configPage.html
+++ b/backend/Pages/configPage.html
@@ -1017,7 +1017,7 @@
 
             var RATING_SOURCES = [
                 { id: 'tomatoes',       label: 'Rotten Tomatoes' },
-                { id: 'rtAudience',     label: 'RT Audience Score' },
+                { id: 'tomatoes_audience', label: 'RT Audience Score' },
                 { id: 'imdb',           label: 'IMDb' },
                 { id: 'tmdb',           label: 'TMDB' },
                 { id: 'metacritic',     label: 'Metacritic' },
@@ -1044,6 +1044,7 @@
                 var ordered = [];
                 if (selectedIds && selectedIds.length > 0) {
                     selectedIds.forEach(function(id) {
+                        if (id === 'rtAudience') id = 'tomatoes_audience';
                         var src = RATING_SOURCES.find(function(s) { return s.id === id; });
                         if (src) { ordered.push({ id: src.id, label: src.label, checked: true }); selectedSet[id] = true; }
                     });

--- a/backend/Services/MoonfinSettingsService.cs
+++ b/backend/Services/MoonfinSettingsService.cs
@@ -117,6 +117,17 @@ public class MoonfinSettingsService
             }
         }
 
+        if (resolved.MdblistRatingSources != null)
+        {
+            for (var i = 0; i < resolved.MdblistRatingSources.Count; i++)
+            {
+                if (string.Equals(resolved.MdblistRatingSources[i], "rtAudience", StringComparison.OrdinalIgnoreCase))
+                {
+                    resolved.MdblistRatingSources[i] = "tomatoes_audience";
+                }
+            }
+        }
+
         return resolved;
     }
 


### PR DESCRIPTION
Rotten Tomatoes audience rating scores (the "popcornometer") were not rendering in the UI because of divergent source keys across the system: MDBList API returns the score source as `popcorn`, while the client app requests `tomatoes_audience`, and the server plugin configuration page used `rtAudience`. This mismatch caused the server's rating proxy to filter out the audience rating.

This pull request resolves the issue by normalizing the keys on the server side:
- Maps both `rtAudience` and `tomatoes_audience` to `popcorn` when querying the MDBList API.
- Returns the rating with the expected `tomatoes_audience` key so that client apps receive it correctly.
- Normalizes `rtAudience` to `tomatoes_audience` in memory inside the resolved settings profiles.
- Updates the server configuration page's source ID from `rtAudience` to `tomatoes_audience`, with compatibility to map legacy configs on load.

## Changes Made
- Modified `MdbListController.cs` to handle key translation for API lookups and returns.
- Modified `MoonfinSettingsService.cs` to normalize rating source profiles.
- Modified `configPage.html` to update picker source IDs and load mapping.