### PR TITLE
 Fix asset paths in theme editor

### DIFF
--- a/frontend/theme/index.html
+++ b/frontend/theme/index.html
@@ -4,14 +4,14 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Moonfin Theme Editor</title>
-  <link rel="icon" type="image/png" href="../favicon.png">
-  <link rel="stylesheet" href="css/styles.css">
+  <link rel="icon" type="image/png" href="theme/favicon.png">
+  <link rel="stylesheet" href="theme/css/styles.css">
 </head>
 <body>
 
 <div class="topbar">
   <div class="topbar-logo">
-    <img class="topbar-logo-mark" src="../assets/icons/moonfin_logo.svg" alt="Moonfin">
+    <img class="topbar-logo-mark" src="assets/assets/icons/moonfin_logo.svg" alt="Moonfin">
     <span>Theme Editor</span>
   </div>
   <div class="tf"><label>ID</label><input id="tId" value="my-theme" maxlength="40" style="width:100px" oninput="onMeta()"></div>
@@ -80,6 +80,6 @@
     <div class="pframe" id="pf-settings"><div class="pdevice" id="pd-settings"></div></div>
   </div>
 </div>
-  <script src="js/app.js"></script>
+  <script src="theme/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Updates static asset references in frontend/theme/index.html to use correct relative paths when served from the plugin's subpath. Fixes broken CSS, JS, and logo loading in the theme editor.

---
Note: The build process outputs a nested assets folder (`assets/assets/...`)
<img width="1494" height="775" alt="Screenshot 2026-06-16 at 2 03 21 AM" src="https://github.com/user-attachments/assets/6ec71016-a9c0-4422-ab73-f585bab0c45a" />

---