### PR TITLE
feat: add library write-access check endpoint

### DIFF
--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Collections.Generic;
 using System.Net.Mime;
 using System.Reflection;

--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -147,7 +147,7 @@ public class MoonfinController : ControllerBase
             {
                 report.Add(new LibraryWriteAccessReport
                 {
-                    LibraryId = folder.ItemId.ToString(),
+                    LibraryId = folder.ItemId,
                     LibraryName = folder.Name,
                     FailedPaths = failedPaths
                 });

--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -87,7 +87,8 @@ public class MoonfinController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public ActionResult<List<LibraryWriteAccessReport>> CheckLibrariesWriteAccess()
     {
-        var userId = this.GetUserIdFromClaims();
+        var report = new List<LibraryWriteAccessReport>();
+        var virtualFolders = _libraryManager.GetVirtualFolders();
         if (userId == null)
         {
             return Unauthorized(new { Error = "User not authenticated" });

--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -89,26 +89,6 @@ public class MoonfinController : ControllerBase
     {
         var report = new List<LibraryWriteAccessReport>();
         var virtualFolders = _libraryManager.GetVirtualFolders();
-        if (userId == null)
-        {
-            return Unauthorized(new { Error = "User not authenticated" });
-        }
-
-        var user = ResolveQueryUser(userId.Value);
-        if (user == null)
-        {
-            return Unauthorized(new { Error = "User not found" });
-        }
-
-        var policy = user.GetType().GetProperty("Policy")?.GetValue(user);
-        var isAdministrator = policy?.GetType().GetProperty("IsAdministrator")?.GetValue(policy) is bool isAdmin && isAdmin;
-        if (!isAdministrator)
-        {
-            return Forbid();
-        }
-
-        var report = new List<LibraryWriteAccessReport>();
-        var virtualFolders = _libraryManager.GetVirtualFolders();
 
         foreach (var folder in virtualFolders)
         {

--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -81,7 +81,7 @@ public class MoonfinController : ControllerBase
     /// Checks server-side write permissions for all libraries that have SaveLocalMetadata enabled.
     /// </summary>
     [HttpGet("Libraries/CheckWriteAccess")]
-    [Authorize]
+    [Authorize(Policy = "RequiresElevation")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -1,6 +1,10 @@
+using System.IO;
+using System.Collections.Generic;
 using System.Net.Mime;
 using System.Reflection;
 using System.Text.Json;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -73,6 +77,85 @@ public class MoonfinController : ControllerBase
             TmdbAvailable = !string.IsNullOrWhiteSpace(config?.TmdbApiKey),
             DefaultSettings = config?.DefaultUserSettings
         });
+    }
+
+    /// <summary>
+    /// Checks server-side write permissions for all libraries that have SaveLocalMetadata enabled.
+    /// </summary>
+    [HttpGet("Libraries/CheckWriteAccess")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public ActionResult<List<LibraryWriteAccessReport>> CheckLibrariesWriteAccess()
+    {
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { Error = "User not authenticated" });
+        }
+
+        var user = ResolveQueryUser(userId.Value);
+        if (user == null)
+        {
+            return Unauthorized(new { Error = "User not found" });
+        }
+
+        var policy = user.GetType().GetProperty("Policy")?.GetValue(user);
+        var isAdministrator = policy?.GetType().GetProperty("IsAdministrator")?.GetValue(policy) is bool isAdmin && isAdmin;
+        if (!isAdministrator)
+        {
+            return Forbid();
+        }
+
+        var report = new List<LibraryWriteAccessReport>();
+        var virtualFolders = _libraryManager.GetVirtualFolders();
+
+        foreach (var folder in virtualFolders)
+        {
+            var options = folder.LibraryOptions;
+            if (options == null || !options.SaveLocalMetadata)
+            {
+                continue;
+            }
+
+            var failedPaths = new List<string>();
+            foreach (var location in folder.Locations)
+            {
+                if (string.IsNullOrWhiteSpace(location)) continue;
+
+                bool hasWriteAccess = false;
+                string testFile = Path.Combine(location, $"moonfin_write_test_{Guid.NewGuid():N}.tmp");
+                try
+                {
+                    // Attempt to create, write, and delete a temporary file
+                    System.IO.File.WriteAllText(testFile, "test");
+                    System.IO.File.Delete(testFile);
+                    hasWriteAccess = true;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Jellyfin lacks write access to library path: {Path}", location);
+                }
+
+                if (!hasWriteAccess)
+                {
+                    failedPaths.Add(location);
+                }
+            }
+
+            if (failedPaths.Count > 0)
+            {
+                report.Add(new LibraryWriteAccessReport
+                {
+                    LibraryId = folder.ItemId.ToString(),
+                    LibraryName = folder.Name,
+                    FailedPaths = failedPaths
+                });
+            }
+        }
+
+        return Ok(report);
     }
 
     [HttpGet("Settings/Stream")]
@@ -1500,4 +1583,25 @@ public class MoonfinDetailsScreenOpacitySaveResponse : MoonfinDetailsScreenOpaci
 public class MoonfinBroadcastRequest
 {
     public string? Message { get; set; }
+}
+
+/// <summary>
+/// Report on write access for a media library.
+/// </summary>
+public class LibraryWriteAccessReport
+{
+    /// <summary>
+    /// Gets or sets the library's unique identifier.
+    /// </summary>
+    public string LibraryId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the library's name.
+    /// </summary>
+    public string LibraryName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a list of locations where write access failed.
+    /// </summary>
+    public List<string> FailedPaths { get; set; } = new();
 }

--- a/backend/Api/MoonfinController.cs
+++ b/backend/Api/MoonfinController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Net.Mime;
 using System.Reflection;
 using System.Text.Json;


### PR DESCRIPTION
### Summary
This PR adds a new controller endpoint `/Moonfin/Libraries/CheckWriteAccess` that allows the client to verify if the Jellyfin process has write access to the library directories where metadata/artwork is saved.

### Changes
- **MoonfinController.cs**: Implemented endpoint to resolve physical library paths, verify if they require local saving, and test directory writability.
