### PR TITLE
feat: add settings profile properties for syncing hidden items

### DIFF
--- a/backend/Models/MoonfinSettingsProfile.cs
+++ b/backend/Models/MoonfinSettingsProfile.cs
@@ -250,7 +250,14 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("genresRowItemFilter")]
     public string? GenresRowItemFilter { get; set; }
+
+    [JsonPropertyName("hiddenContinueWatchingItems")]
+    public string? HiddenContinueWatchingItems { get; set; }
+
+    [JsonPropertyName("hiddenNextUpSeries")]
+    public string? HiddenNextUpSeries { get; set; }
 }
+
 
 /// <summary>
 /// A Moonfin home section entry. Built-in sections only need Type/Enabled/Order.


### PR DESCRIPTION
# Pull Request

## Summary
Adds support for storing and syncing the user's hidden Continue Watching and Next Up item lists on the server.

## Related Issues
- Will be related to Moonbase-Core PR that will be posted shortly

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `HiddenContinueWatchingItems` and `HiddenNextUpSeries` nullable string properties to `MoonfinSettingsProfile.cs`.
- These properties automatically integrate with `MoonfinSettingsService`'s reflection-based profile merging, allowing setting sync between clients without changes to backend service endpoints.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built and deployed the plugin backend to the NAS Jellyfin server.
2. Logged into Moonfin client and triggered setting synchronization.
3. Verified settings mapped correctly on the server database profile without exceptions or warnings.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced