### PR TITLE
more setting sync

### DIFF
--- a/backend/Models/MoonfinSettingsProfile.cs
+++ b/backend/Models/MoonfinSettingsProfile.cs
@@ -251,8 +251,35 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("displaySinceYouWatchedRows")]
     public bool? DisplaySinceYouWatchedRows { get; set; }
 
+    [JsonPropertyName("sinceYouWatchedSource")]
+    public string? SinceYouWatchedSource { get; set; }
+
+    [JsonPropertyName("sinceYouWatchedSourceType")]
+    public string? SinceYouWatchedSourceType { get; set; }
+
+    [JsonPropertyName("sinceYouWatchedSourceItem")]
+    public string? SinceYouWatchedSourceItem { get; set; }
+
+    [JsonPropertyName("sinceYouWatchedNumRows")]
+    public int? SinceYouWatchedNumRows { get; set; }
+
+    [JsonPropertyName("sinceYouWatchedIncludeWatched")]
+    public bool? SinceYouWatchedIncludeWatched { get; set; }
+
     [JsonPropertyName("displayRewatchRow")]
     public bool? DisplayRewatchRow { get; set; }
+
+    [JsonPropertyName("rewatchSortBy")]
+    public string? RewatchSortBy { get; set; }
+
+    [JsonPropertyName("rewatchIncludeMovies")]
+    public bool? RewatchIncludeMovies { get; set; }
+
+    [JsonPropertyName("rewatchIncludeShows")]
+    public bool? RewatchIncludeShows { get; set; }
+
+    [JsonPropertyName("rewatchIncludeCollections")]
+    public bool? RewatchIncludeCollections { get; set; }
 
     [JsonPropertyName("favoritesRowSortBy")]
     public string? FavoritesRowSortBy { get; set; }

--- a/backend/Models/MoonfinSettingsProfile.cs
+++ b/backend/Models/MoonfinSettingsProfile.cs
@@ -84,7 +84,7 @@ public class MoonfinSettingsProfile
     public string? DetailScreenStyle { get; set; }
 
     [JsonPropertyName("detailExpandedTabs")]
-    public string? DetailExpandedTabs { get; set; }
+    public bool? DetailExpandedTabs { get; set; }
 
     [JsonPropertyName("visualTheme")]
     public string? VisualTheme { get; set; }

--- a/backend/Models/MoonfinSettingsProfile.cs
+++ b/backend/Models/MoonfinSettingsProfile.cs
@@ -83,6 +83,9 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("detailScreenStyle")]
     public string? DetailScreenStyle { get; set; }
 
+    [JsonPropertyName("detailExpandedTabs")]
+    public string? DetailExpandedTabs { get; set; }
+
     [JsonPropertyName("visualTheme")]
     public string? VisualTheme { get; set; }
 

--- a/backend/Pages/configPage.html
+++ b/backend/Pages/configPage.html
@@ -641,7 +641,7 @@
                                 <option value="true">Yes</option>
                                 <option value="false">No</option>
                             </select>
-                            <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
+                            <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals their content without pressing select. When off, tabs start collapsed and open on press. Keep Not set to let users choose.</div>
                         </div>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="DefaultFocusColor">Focus Highlight Color</label>

--- a/backend/Pages/configPage.html
+++ b/backend/Pages/configPage.html
@@ -635,6 +635,15 @@
                             <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
                         </div>
                         <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="DefaultDetailExpandedTabs">Detail Screen Expanded Tabs</label>
+                            <select id="DefaultDetailExpandedTabs" is="emby-select">
+                                <option value="">Not set (user decides)</option>
+                                <option value="true">Yes</option>
+                                <option value="false">No</option>
+                            </select>
+                            <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
+                        </div>
+                        <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="DefaultFocusColor">Focus Highlight Color</label>
                             <select id="DefaultFocusColor" is="emby-select">
                                 <option value="">Not set (user decides)</option>
@@ -2704,6 +2713,7 @@
                     var defaults = config.DefaultUserSettings || {};
                     setSelectValue('#DefaultVisualTheme', defaults.visualTheme, 'Configured theme');
                     setSelectValue('#DefaultDetailScreenStyle', defaults.detailScreenStyle, 'Configured style');
+                    setNullableBoolSelect('#DefaultDetailExpandedTabs', defaults.detailExpandedTabs);
                     setSelectValue('#DefaultFocusColor', defaults.focusColor, 'Configured color');
                     setNullableIntInput('#DefaultBrowsingBlur', defaults.browsingBlur);
                     setNullableIntInput('#DefaultDetailsScreenBlur', defaults.detailsScreenBlur);
@@ -3063,6 +3073,7 @@
                         config.DefaultUserSettings = config.DefaultUserSettings || {};
                         config.DefaultUserSettings.visualTheme = document.querySelector('#DefaultVisualTheme').value || null;
                         config.DefaultUserSettings.detailScreenStyle = document.querySelector('#DefaultDetailScreenStyle').value || null;
+                        config.DefaultUserSettings.detailExpandedTabs = getNullableBoolSelect('#DefaultDetailExpandedTabs');
                         config.DefaultUserSettings.focusColor = document.querySelector('#DefaultFocusColor').value || null;
                         config.DefaultUserSettings.browsingBlur = getNullableIntInput('#DefaultBrowsingBlur');
                         config.DefaultUserSettings.detailsScreenBlur = getNullableIntInput('#DefaultDetailsScreenBlur');


### PR DESCRIPTION
# Pull Request

## Summary
Update settings sync now that other repos are more up to date

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- add missing syncable keys
- add detailExpandedTabs to default config page
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/810, https://github.com/Moonfin-Client/Roku/pull/153, smarttv is up to date already
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.
<img width="1416" height="979" alt="image" src="https://github.com/user-attachments/assets/c719a55f-648c-4e8a-93a5-582d7897d966" />
anything green that says "missing" is what I am adding in this PR

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
