### PR TITLE
bugfix-seerr - Fix Seerr session eviction on 403 responses

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Services/SeerrSessionService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/SeerrSessionService.cs
@@ -461,7 +461,7 @@ namespace Emby.Plugins.Moonfin.Services
                 return upstreamFailure;
 
             if (evictUserIdOn401.HasValue &&
-                (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden))
+                (response.StatusCode == HttpStatusCode.Unauthorized))
             {
                 await ClearSessionAsync(evictUserIdOn401.Value).ConfigureAwait(false);
                 return ErrorResponse(401, "Seerr session expired", "SESSION_EXPIRED");

--- a/Jellyfin/backend/Services/SeerrSessionService.cs
+++ b/Jellyfin/backend/Services/SeerrSessionService.cs
@@ -624,8 +624,7 @@ public class SeerrSessionService
             }
 
             // If auth expired, clear session
-            if (response.StatusCode == HttpStatusCode.Unauthorized ||
-                response.StatusCode == HttpStatusCode.Forbidden)
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 _logger.LogInformation("Seerr session expired for user {UserId}", userId);
                 await ClearSessionAsync(userId);

--- a/Jellyfin/manifest.json
+++ b/Jellyfin/manifest.json
@@ -1,200 +1,166 @@
 [
-    {
-        "guid":  "8c5d0e91-4f2a-4b6d-9e3f-1a7c8d9e0f2b",
-        "name":  "Moonbase",
-        "overview":  "Moonfin server plugin for Jellyfin with web app hosting, settings sync, theming, and Seerr integrations",
-        "description":  "Moonbase is the Moonfin server plugin for Jellyfin, powering settings sync, the Moonfin Web app at /Moonfin/Web/, a built-in theme editor with custom theme APIs, media bar and ratings integrations, and Seerr proxy/SSO with admin defaults and broadcasts across Moonfin clients.",
-        "owner":  "RadicalMuffinMan",
-        "category":  "General",
-        "imageUrl":  "https://raw.githubusercontent.com/Moonfin-Client/Plugin/master/backend/assets/logo.png",
-        "versions":  [
-                         {
-                             "version":  "2.0.0.0",
-                             "changelog":  "Features:\n\n- The web theme editor gained a random theme generator that builds a complete, coherent palette from a random base and accent hue, while keeping your theme id, name, and description. The theme id validation message was also clarified.\n\nBug Fixes:\n\n- Media Bar trailers on web were reworked so YouTube trailer playback and advancing to the next slide now work correctly.\n- Web playback sessions are now reported as stopped when you close or navigate away from the browser tab, using a page exit beacon, so they no longer linger as active on the server.\n- The sidebar now follows desktop behavior in desktop browsers, instead of using the mobile layout.\n- Preferences are now parsed and type coerced more robustly for web compatibility, fixing settings that could fail to load or save when stored as browser strings.\n- The refresh rate switching and audio output mode settings are now hidden on the web build, where they do not apply.\n- ASS and PGS subtitles now render correctly on web, with the necessary fonts bundled.",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.1/Moonfin.Server-2.0.0.0.zip",
-                             "checksum":  "0925200A45D9FD6892F3394FB9F5E5D5",
-                             "timestamp":  "2026-07-18T16:09:52",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.9.0.0",
-                             "changelog":  "## Features\n\n- Refreshed the Moonfin plugin, now called Moonbase, experience with the Moonfin Flutter web app, now served from `/Moonfin/Web/`.\n- Replaced the older JavaScript overlay frontend with a proper web client bundled from the Flutter web project at the Moonfin-Core repo and theme assets for a smoother setup.\n- Added a built-in theme editor at `/Moonfin/Web/theme/`, including admin-managed custom theme uploads and validation.\n- Added discovery endpoints for plugin web startup: `/Moonfin/Discovery` and `/Moonfin/Discovery/discover`.\n- Added custom theme APIs and services for listing, retrieving, uploading or replacing, deleting, and validating themes.\n- Improved settings sync and admin tools with better global/profile behavior and admin broadcast support.",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.0/Moonfin.Server-1.9.0.0.zip",
-                             "checksum":  "BCFEC3007BCCA81F535594FA8332FD3F",
-                             "timestamp":  "2026-06-01T02:47:41",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.8.2.0",
-                             "changelog":  "## Features\n\n- Added Media Bar Enhanced support in desktop media bar settings. (#98)\n- Clicking a row item now navigates to the correct library, and playback from the Continue Watching row works properly again. (#60)\n\n## Bug Fixes\n\n- Details page buttons were too large on some screens — they\u0027ve been resized to something more reasonable. (#100)\n- Clicking items from third-party home screen section plugins no longer incorrectly triggers Moonfin\u0027s custom detail page. (#96)\n- Admin default settings now correctly propagate to existing users when changed. (#101)\n- The Jellyseerr discover page was crashing to an error screen because the proxy was wrapping responses in an unexpected JSON envelope. That\u0027s fixed now. (#108)\n- The global profile now saves reliably, the media bar state persists correctly across Moonfin and Paradox themes, and users no longer see genres or library sections they don\u0027t have access to. (#87)",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.2/Moonfin.Server-1.8.2.0.zip",
-                             "checksum":  "C559FB46DFE70DD27F151FB928D2F604",
-                             "timestamp":  "2026-04-19T20:07:23",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.8.1.0",
-                             "changelog":  "## Bug Fixes\n\n- Fixed Moonfin UI not loading on Jellyfin instances deployed under a reverse proxy sub-path\n- Fixed Moonfin login detection using private Jellyfin API internals that could return falsy values depending on Jellyfin version, causing the plugin to never initialize\n- Fixed Jellyseerr proxy (cookies, HTML/CSS rewrites, injected script) using hardcoded root-relative paths that broke under reverse proxy sub-path deployments\n- Fixed Letterboxd ratings showing doubled values for entries cached prior to v1.7.0",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.1/Moonfin.Server-1.8.1.0.zip",
-                             "checksum":  "7B8C49B2D56C554818D402CD7D8DD583",
-                             "timestamp":  "2026-04-07T18:09:53",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.8.0.0",
-                             "changelog":  "## Features\n\n- Added compatibility with @IAmParadox27 \u0027s  [media bar](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/) and [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) rows\n- Added support for @ranaldsgift \u0027s  [KefinTweaks](https://github.com/ranaldsgift/KefinTweaks) rows\n\u003e [!NOTE]  \n\u003e The rows are not yet implemented in the other clients. This is a manual method that will take time but the framework for implementation is done. The media bar compatibility is for web UI only under the desktop profile\n\n- Media bar went full screen like other clients\n- Added sync mode clarity dialog box\n- Added trailer overlay in details screen\n- Added details blur/opacity controls and new endpoints so it syncs with clients\n- Added special features, chapters, and collections in details\n- Added back button and fixed details tint behavior\n- Added favorite button for people details\n- Added favorite/watched indicators in details and library\n- Updated libraries UI\n- Updated collections to display contents in release order\n- Updated Moonfin plugin logo\n\n## Bug Fixes\n\n- Fixed details tint behavior that was causing the original jellyfin ui\u0027s backdrop image to look black\n- Fixed header bar glitch that was causing the library title to scroll with users in the library\n- Fixed plugin and UI not applying correctly (#60, #66, #76)\n- Fixed removed media bar items that did not have a backdrop and removed items that users did not have access to.\n- Fixed HDR badge truthy logic and expanded HDR range handling\n- Fixed trailer button forwards to home page\n- Fixed special features not showing with new details page\n- Fixed Seerr invalid CSRF token (#53, #63)\n- Fixed Seerr icon not showing on toolbar\n- Fixed Seerr integration slowness\n- Fixed /Moonfin/Settings returns 404 via reverse proxy",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.0/Moonfin.Server-1.8.0.0.zip",
-                             "checksum":  "BF2DA2868F49C577F14F2D61354F6281",
-                             "timestamp":  "2026-04-01T16:05:10",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.7.1.0",
-                             "changelog":  "New Features:\n- Media Bar Genre Exclusions - exclude specific genres from the media bar so items from those genres won\u0027t appear, configurable per-user and as admin defaults\n- GET /Moonfin/Genres endpoint - returns all genre IDs and localized names for the genre picker\n\nBug Fixes:\n- Fixed Jellyseerr CSRF token errors causing failed authentication and proxy requests\n- Fixed Jellyseerr button not appearing when navbar/sidebar initializes after config is dispatched\n- Fixed media bar showing loading state indefinitely when no items are returned\n- Fixed media bar active class being added when there are no items to display\n- Fixed unnecessary Content-Type header on GET requests\n- Fixed duplicate event listeners on collection/library picker re-renders\n\nImprovements:\n- CSRF tokens are now fetched and sent for all Jellyseerr write operations with a fallback for IP-based URLs\n- Media bar loading class is now removed in error and empty states",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.1/Moonfin.Server-1.7.1.0.zip",
-                             "checksum":  "ECD1DE99E2A7CC34A4A7BD856848E073",
-                             "timestamp":  "2026-03-16T18:02:45",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.7.0.0",
-                             "changelog":  "New Features:\n- Home Screen Row Ordering - drag and drop to reorder or hide home screen sections like Continue Watching, Next Up, and Latest Media\n- Media Bar Collections - choose specific collections or playlists to show in the media bar instead of pulling from all libraries\n- MDBList rating source labels can now be shown or hidden\n- Automatic settings change when switching between users on the same device\n\nNew Endpoint:\n- GET /Moonfin/MediaBar - returns media bar items based on user settings\n\nBug Fixes:\n- Fixed playback not working from the details page\n- Fixed media bar showing on pages other than the home screen\n- Fixed Seerr/Jellyseerr button not appearing after settings sync\n- Fixed details page interfering with media selection dialogs\n- Fixed incorrect Letterboxd rating values\n\nImprovements:\n- Reusable drag-and-drop sortable list component",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.0/Moonfin.Server-1.7.0.0.zip",
-                             "checksum":  "B698F944D017AD4675C16C222F8BB25D",
-                             "timestamp":  "2026-03-15T03:21:44",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.6.0.0",
-                             "changelog":  "Bug Fixes:\n- Fixed Seerr/Jellyseerr proxy navigation - search, sidebar links, and in-app navigation no longer load indefinitely\n- Fixed user settings not saving correctly - refactored settings mapping for consistency\n- Fixed navbar background to use a gradient\n- Fixed admin config page not appearing in Jellyfin admin sidebar\n\nImprovements:\n- Media version/quality information now displayed on details overlay\n- Authentication now requires only a username for passwordless Jellyfin users\n- MDBList batch task refactored for better memory management with stream-based JSON I/O",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.6.0/Moonfin.Server-1.6.0.0.zip",
-                             "checksum":  "1764D016C791637BA0182F5662456B54",
-                             "timestamp":  "2026-03-14T12:47:13",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.5.1.0",
-                             "changelog":  "Bug Fixes:\n- Fixed MDBList and TMDB user API keys not being read from v2 settings profiles (only admin keys worked)\n- Fixed user-selected MDBList rating sources being ignored after v1-to-v2 settings migration (only default 4 sources were returned)",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.1/Moonfin.Server-1.5.1.0.zip",
-                             "checksum":  "14CAC55434728A5E92CD2481E85DE152",
-                             "timestamp":  "2026-02-23T04:33:48",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.5.0.0",
-                             "changelog":  "Features:\n- Device-specific settings profiles (global, desktop, mobile, TV) with inheritance and sync\n- Admin-configurable default user settings with per-user overrides\n- Sync toggle for enabling/disabling server settings synchronization\n\nImprovements:\n- Season posters fall back to series poster when unavailable (#15)\n- Lazy trailer fetching per displayed item instead of bulk RemoteTrailers query\n\nBug Fixes:\n- Fixed media bar auto-advance and trailer playback continuing after navigating away from home\n- Fixed media bar not stopping on admin pages and video player",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.0/Moonfin.Server-1.5.0.0.zip",
-                             "checksum":  "43D12A1CC3EBF5CDED1BC974BC925492",
-                             "timestamp":  "2026-02-22T18:33:27",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.4.0.0",
-                             "changelog":  "Features:\n- Media bar trailer previews using YouTube IFrame API with SponsorBlock integration\n- Media bar redesign with logos, rating badges, and genre pills\n\nImprovements:\n- Seerr v3 support with auto-detection and direct iframe URL option\n- Server-wide TMDB API key with user notifications\n- Dynamic icon swapping for Jellyseerr/Seerr\n- Sidebar: settings moved under libraries with separator\n- Admin panel no longer blocked by plugin (whitelist-based route detection)\n- Sensitive data masked in console logs",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.4.0/Moonfin.Server-1.4.0.0.zip",
-                             "checksum":  "9E826973350BC5B2B56957F45D19EC56",
-                             "timestamp":  "2026-02-19T05:32:55",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.3.1.0",
-                             "changelog":  "- Seerr v3 support with auto-detection (version-based)\n- Direct iframe URL option for Seerr behind reverse proxies\n- Server-wide TMDB API key with user notifications\n- Removed Rotten Tomatoes rating from details page\n- Added dynamic icon swapping for Jellyseerr/Seerr\n- Updated README with Seerr v3 reverse proxy documentation",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.1/Moonfin.Server-1.3.1.0.zip",
-                             "checksum":  "CAEF64ED665CD3C324F83B3EA490D281",
-                             "timestamp":  "2026-02-15T12:50:46",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.3.0.0",
-                             "changelog":  "- Left sidebar navigation (configurable via navbarPosition)\n- Three-way settings merge with snapshot-based conflict resolution\n- MDBList server-side caching and batch pre-fetching\n\nImprovements:\n- PNG to SVG migration for all rating icons\n- Updated README and admin config page\n\nBug Fixes:\n- Fixed Jellyseerr session persistence (JSON deserialization)\n- Fixed Jellyseerr sessions on local IP addresses\n- Fixed Jellyseerr cookie rotation causing unexpected logouts\n- Fixed mobile media bar overlapping first library row",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.0/Moonfin.Server-1.3.0.0.zip",
-                             "checksum":  "39CC6BA712E02E2E5552A792CC1BF280",
-                             "timestamp":  "2026-02-14T22:00:16",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.2.0.0",
-                             "changelog":  "- TMDB episode ratings with server-side caching\n- Drag \u0026 drop sortable rating sources\n- Jellyseerr dual login (Jellyfin + local accounts)\n- Edit Metadata/Images/Subtitles/Identify open as native dialogs\n- Create New Playlist from details page\n- Fixed homescreen context menu interception\n- Fixed subtitle picker triggering details overlay during playback",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.2.0/Moonfin.Server-1.2.0.0.zip",
-                             "checksum":  "FEBE25F651728978B685E8734E8B4953",
-                             "timestamp":  "2026-02-12T22:27:49",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.1.1.0",
-                             "changelog":  "- Fixed Jellyseerr 404 when clicking links in iframe\n- Plugin now auto-registers file transformations on load (no manual task needed after updates)",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.1/Moonfin.Server-1.1.1.0.zip",
-                             "checksum":  "6F034F273541D5103C59B85346B275D4",
-                             "timestamp":  "2026-02-11T08:02:04",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.1.0.0",
-                             "changelog":  "- Integrated File Transformation plugin for automatic web UI injection\n- Fixed bug where media bar did not load right away\n- Added server-wide MDBList API key support\n- Updated user settings and UI",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.0/Moonfin.Server-1.1.0.0.zip",
-                             "checksum":  "E635BA9B123DD5C8EB9AA32140FBA43D",
-                             "timestamp":  "2026-02-09T22:58:42",
-                             "dependencies":  [
-
-                                              ]
-                         },
-                         {
-                             "version":  "1.0.0.0",
-                             "changelog":  "Initial release with core features: navbar, media bar, custom details screens, IMDBList integration, Jellyseerr integration, and settings sync.\n Hope you like it!",
-                             "targetAbi":  "10.10.0.0",
-                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.0.0/Moonfin.Server-1.0.0.0.zip",
-                             "checksum":  "D96BC4F769AC38BA298258C0EF21F300",
-                             "timestamp":  "2026-02-11T07:59:01",
-                             "dependencies":  [
-
-                                              ]
-                         }
-                     ]
-    }
+  {
+    "guid": "8c5d0e91-4f2a-4b6d-9e3f-1a7c8d9e0f2b",
+    "name": "Moonbase",
+    "overview": "Moonfin server plugin for Jellyfin with web app hosting, settings sync, theming, and Seerr integrations",
+    "description": "Moonbase is the Moonfin server plugin for Jellyfin, powering settings sync, the Moonfin Web app at /Moonfin/Web/, a built-in theme editor with custom theme APIs, media bar and ratings integrations, and Seerr proxy/SSO with admin defaults and broadcasts across Moonfin clients.",
+    "owner": "RadicalMuffinMan",
+    "category": "General",
+    "imageUrl": "https://raw.githubusercontent.com/Moonfin-Client/Plugin/master/backend/assets/logo.png",
+    "versions": [
+      {
+        "version": "2.0.0.0",
+        "changelog": "Features:\n\n- The web theme editor gained a random theme generator that builds a complete, coherent palette from a random base and accent hue, while keeping your theme id, name, and description. The theme id validation message was also clarified.\n\nBug Fixes:\n\n- Media Bar trailers on web were reworked so YouTube trailer playback and advancing to the next slide now work correctly.\n- Web playback sessions are now reported as stopped when you close or navigate away from the browser tab, using a page exit beacon, so they no longer linger as active on the server.\n- The sidebar now follows desktop behavior in desktop browsers, instead of using the mobile layout.\n- Preferences are now parsed and type coerced more robustly for web compatibility, fixing settings that could fail to load or save when stored as browser strings.\n- The refresh rate switching and audio output mode settings are now hidden on the web build, where they do not apply.\n- ASS and PGS subtitles now render correctly on web, with the necessary fonts bundled.",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.1/Moonfin.Server-2.0.0.0.zip",
+        "checksum": "0C6EB7D9693C8F841C58F96210F3AD21",
+        "timestamp": "2026-07-16T20:03:35",
+        "dependencies": []
+      },
+      {
+        "version": "1.9.0.0",
+        "changelog": "## Features\n\n- Refreshed the Moonfin plugin, now called Moonbase, experience with the Moonfin Flutter web app, now served from `/Moonfin/Web/`.\n- Replaced the older JavaScript overlay frontend with a proper web client bundled from the Flutter web project at the Moonfin-Core repo and theme assets for a smoother setup.\n- Added a built-in theme editor at `/Moonfin/Web/theme/`, including admin-managed custom theme uploads and validation.\n- Added discovery endpoints for plugin web startup: `/Moonfin/Discovery` and `/Moonfin/Discovery/discover`.\n- Added custom theme APIs and services for listing, retrieving, uploading or replacing, deleting, and validating themes.\n- Improved settings sync and admin tools with better global/profile behavior and admin broadcast support.",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.0/Moonfin.Server-1.9.0.0.zip",
+        "checksum": "BCFEC3007BCCA81F535594FA8332FD3F",
+        "timestamp": "2026-06-01T02:47:41",
+        "dependencies": []
+      },
+      {
+        "version": "1.8.2.0",
+        "changelog": "## Features\n\n- Added Media Bar Enhanced support in desktop media bar settings. (#98)\n- Clicking a row item now navigates to the correct library, and playback from the Continue Watching row works properly again. (#60)\n\n## Bug Fixes\n\n- Details page buttons were too large on some screens — they've been resized to something more reasonable. (#100)\n- Clicking items from third-party home screen section plugins no longer incorrectly triggers Moonfin's custom detail page. (#96)\n- Admin default settings now correctly propagate to existing users when changed. (#101)\n- The Jellyseerr discover page was crashing to an error screen because the proxy was wrapping responses in an unexpected JSON envelope. That's fixed now. (#108)\n- The global profile now saves reliably, the media bar state persists correctly across Moonfin and Paradox themes, and users no longer see genres or library sections they don't have access to. (#87)",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.2/Moonfin.Server-1.8.2.0.zip",
+        "checksum": "C559FB46DFE70DD27F151FB928D2F604",
+        "timestamp": "2026-04-19T20:07:23",
+        "dependencies": []
+      },
+      {
+        "version": "1.8.1.0",
+        "changelog": "## Bug Fixes\n\n- Fixed Moonfin UI not loading on Jellyfin instances deployed under a reverse proxy sub-path\n- Fixed Moonfin login detection using private Jellyfin API internals that could return falsy values depending on Jellyfin version, causing the plugin to never initialize\n- Fixed Jellyseerr proxy (cookies, HTML/CSS rewrites, injected script) using hardcoded root-relative paths that broke under reverse proxy sub-path deployments\n- Fixed Letterboxd ratings showing doubled values for entries cached prior to v1.7.0",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.1/Moonfin.Server-1.8.1.0.zip",
+        "checksum": "7B8C49B2D56C554818D402CD7D8DD583",
+        "timestamp": "2026-04-07T18:09:53",
+        "dependencies": []
+      },
+      {
+        "version": "1.8.0.0",
+        "changelog": "## Features\n\n- Added compatibility with @IAmParadox27 's  [media bar](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/) and [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) rows\n- Added support for @ranaldsgift 's  [KefinTweaks](https://github.com/ranaldsgift/KefinTweaks) rows\n> [!NOTE]  \n> The rows are not yet implemented in the other clients. This is a manual method that will take time but the framework for implementation is done. The media bar compatibility is for web UI only under the desktop profile\n\n- Media bar went full screen like other clients\n- Added sync mode clarity dialog box\n- Added trailer overlay in details screen\n- Added details blur/opacity controls and new endpoints so it syncs with clients\n- Added special features, chapters, and collections in details\n- Added back button and fixed details tint behavior\n- Added favorite button for people details\n- Added favorite/watched indicators in details and library\n- Updated libraries UI\n- Updated collections to display contents in release order\n- Updated Moonfin plugin logo\n\n## Bug Fixes\n\n- Fixed details tint behavior that was causing the original jellyfin ui's backdrop image to look black\n- Fixed header bar glitch that was causing the library title to scroll with users in the library\n- Fixed plugin and UI not applying correctly (#60, #66, #76)\n- Fixed removed media bar items that did not have a backdrop and removed items that users did not have access to.\n- Fixed HDR badge truthy logic and expanded HDR range handling\n- Fixed trailer button forwards to home page\n- Fixed special features not showing with new details page\n- Fixed Seerr invalid CSRF token (#53, #63)\n- Fixed Seerr icon not showing on toolbar\n- Fixed Seerr integration slowness\n- Fixed /Moonfin/Settings returns 404 via reverse proxy",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.0/Moonfin.Server-1.8.0.0.zip",
+        "checksum": "BF2DA2868F49C577F14F2D61354F6281",
+        "timestamp": "2026-04-01T16:05:10",
+        "dependencies": []
+      },
+      {
+        "version": "1.7.1.0",
+        "changelog": "New Features:\n- Media Bar Genre Exclusions - exclude specific genres from the media bar so items from those genres won't appear, configurable per-user and as admin defaults\n- GET /Moonfin/Genres endpoint - returns all genre IDs and localized names for the genre picker\n\nBug Fixes:\n- Fixed Jellyseerr CSRF token errors causing failed authentication and proxy requests\n- Fixed Jellyseerr button not appearing when navbar/sidebar initializes after config is dispatched\n- Fixed media bar showing loading state indefinitely when no items are returned\n- Fixed media bar active class being added when there are no items to display\n- Fixed unnecessary Content-Type header on GET requests\n- Fixed duplicate event listeners on collection/library picker re-renders\n\nImprovements:\n- CSRF tokens are now fetched and sent for all Jellyseerr write operations with a fallback for IP-based URLs\n- Media bar loading class is now removed in error and empty states",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.1/Moonfin.Server-1.7.1.0.zip",
+        "checksum": "ECD1DE99E2A7CC34A4A7BD856848E073",
+        "timestamp": "2026-03-16T18:02:45",
+        "dependencies": []
+      },
+      {
+        "version": "1.7.0.0",
+        "changelog": "New Features:\n- Home Screen Row Ordering - drag and drop to reorder or hide home screen sections like Continue Watching, Next Up, and Latest Media\n- Media Bar Collections - choose specific collections or playlists to show in the media bar instead of pulling from all libraries\n- MDBList rating source labels can now be shown or hidden\n- Automatic settings change when switching between users on the same device\n\nNew Endpoint:\n- GET /Moonfin/MediaBar - returns media bar items based on user settings\n\nBug Fixes:\n- Fixed playback not working from the details page\n- Fixed media bar showing on pages other than the home screen\n- Fixed Seerr/Jellyseerr button not appearing after settings sync\n- Fixed details page interfering with media selection dialogs\n- Fixed incorrect Letterboxd rating values\n\nImprovements:\n- Reusable drag-and-drop sortable list component",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.0/Moonfin.Server-1.7.0.0.zip",
+        "checksum": "B698F944D017AD4675C16C222F8BB25D",
+        "timestamp": "2026-03-15T03:21:44",
+        "dependencies": []
+      },
+      {
+        "version": "1.6.0.0",
+        "changelog": "Bug Fixes:\n- Fixed Seerr/Jellyseerr proxy navigation - search, sidebar links, and in-app navigation no longer load indefinitely\n- Fixed user settings not saving correctly - refactored settings mapping for consistency\n- Fixed navbar background to use a gradient\n- Fixed admin config page not appearing in Jellyfin admin sidebar\n\nImprovements:\n- Media version/quality information now displayed on details overlay\n- Authentication now requires only a username for passwordless Jellyfin users\n- MDBList batch task refactored for better memory management with stream-based JSON I/O",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.6.0/Moonfin.Server-1.6.0.0.zip",
+        "checksum": "1764D016C791637BA0182F5662456B54",
+        "timestamp": "2026-03-14T12:47:13",
+        "dependencies": []
+      },
+      {
+        "version": "1.5.1.0",
+        "changelog": "Bug Fixes:\n- Fixed MDBList and TMDB user API keys not being read from v2 settings profiles (only admin keys worked)\n- Fixed user-selected MDBList rating sources being ignored after v1-to-v2 settings migration (only default 4 sources were returned)",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.1/Moonfin.Server-1.5.1.0.zip",
+        "checksum": "14CAC55434728A5E92CD2481E85DE152",
+        "timestamp": "2026-02-23T04:33:48",
+        "dependencies": []
+      },
+      {
+        "version": "1.5.0.0",
+        "changelog": "Features:\n- Device-specific settings profiles (global, desktop, mobile, TV) with inheritance and sync\n- Admin-configurable default user settings with per-user overrides\n- Sync toggle for enabling/disabling server settings synchronization\n\nImprovements:\n- Season posters fall back to series poster when unavailable (#15)\n- Lazy trailer fetching per displayed item instead of bulk RemoteTrailers query\n\nBug Fixes:\n- Fixed media bar auto-advance and trailer playback continuing after navigating away from home\n- Fixed media bar not stopping on admin pages and video player",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.0/Moonfin.Server-1.5.0.0.zip",
+        "checksum": "43D12A1CC3EBF5CDED1BC974BC925492",
+        "timestamp": "2026-02-22T18:33:27",
+        "dependencies": []
+      },
+      {
+        "version": "1.4.0.0",
+        "changelog": "Features:\n- Media bar trailer previews using YouTube IFrame API with SponsorBlock integration\n- Media bar redesign with logos, rating badges, and genre pills\n\nImprovements:\n- Seerr v3 support with auto-detection and direct iframe URL option\n- Server-wide TMDB API key with user notifications\n- Dynamic icon swapping for Jellyseerr/Seerr\n- Sidebar: settings moved under libraries with separator\n- Admin panel no longer blocked by plugin (whitelist-based route detection)\n- Sensitive data masked in console logs",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.4.0/Moonfin.Server-1.4.0.0.zip",
+        "checksum": "9E826973350BC5B2B56957F45D19EC56",
+        "timestamp": "2026-02-19T05:32:55",
+        "dependencies": []
+      },
+      {
+        "version": "1.3.1.0",
+        "changelog": "- Seerr v3 support with auto-detection (version-based)\n- Direct iframe URL option for Seerr behind reverse proxies\n- Server-wide TMDB API key with user notifications\n- Removed Rotten Tomatoes rating from details page\n- Added dynamic icon swapping for Jellyseerr/Seerr\n- Updated README with Seerr v3 reverse proxy documentation",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.1/Moonfin.Server-1.3.1.0.zip",
+        "checksum": "CAEF64ED665CD3C324F83B3EA490D281",
+        "timestamp": "2026-02-15T12:50:46",
+        "dependencies": []
+      },
+      {
+        "version": "1.3.0.0",
+        "changelog": "- Left sidebar navigation (configurable via navbarPosition)\n- Three-way settings merge with snapshot-based conflict resolution\n- MDBList server-side caching and batch pre-fetching\n\nImprovements:\n- PNG to SVG migration for all rating icons\n- Updated README and admin config page\n\nBug Fixes:\n- Fixed Jellyseerr session persistence (JSON deserialization)\n- Fixed Jellyseerr sessions on local IP addresses\n- Fixed Jellyseerr cookie rotation causing unexpected logouts\n- Fixed mobile media bar overlapping first library row",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.0/Moonfin.Server-1.3.0.0.zip",
+        "checksum": "39CC6BA712E02E2E5552A792CC1BF280",
+        "timestamp": "2026-02-14T22:00:16",
+        "dependencies": []
+      },
+      {
+        "version": "1.2.0.0",
+        "changelog": "- TMDB episode ratings with server-side caching\n- Drag & drop sortable rating sources\n- Jellyseerr dual login (Jellyfin + local accounts)\n- Edit Metadata/Images/Subtitles/Identify open as native dialogs\n- Create New Playlist from details page\n- Fixed homescreen context menu interception\n- Fixed subtitle picker triggering details overlay during playback",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.2.0/Moonfin.Server-1.2.0.0.zip",
+        "checksum": "FEBE25F651728978B685E8734E8B4953",
+        "timestamp": "2026-02-12T22:27:49",
+        "dependencies": []
+      },
+      {
+        "version": "1.1.1.0",
+        "changelog": "- Fixed Jellyseerr 404 when clicking links in iframe\n- Plugin now auto-registers file transformations on load (no manual task needed after updates)",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.1/Moonfin.Server-1.1.1.0.zip",
+        "checksum": "6F034F273541D5103C59B85346B275D4",
+        "timestamp": "2026-02-11T08:02:04",
+        "dependencies": []
+      },
+      {
+        "version": "1.1.0.0",
+        "changelog": "- Integrated File Transformation plugin for automatic web UI injection\n- Fixed bug where media bar did not load right away\n- Added server-wide MDBList API key support\n- Updated user settings and UI",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.0/Moonfin.Server-1.1.0.0.zip",
+        "checksum": "E635BA9B123DD5C8EB9AA32140FBA43D",
+        "timestamp": "2026-02-09T22:58:42",
+        "dependencies": []
+      },
+      {
+        "version": "1.0.0.0",
+        "changelog": "Initial release with core features: navbar, media bar, custom details screens, IMDBList integration, Jellyseerr integration, and settings sync.\n Hope you like it!",
+        "targetAbi": "10.10.0.0",
+        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.0.0/Moonfin.Server-1.0.0.0.zip",
+        "checksum": "D96BC4F769AC38BA298258C0EF21F300",
+        "timestamp": "2026-02-11T07:59:01",
+        "dependencies": []
+      }
+    ]
+  }
 ]

--- a/Jellyfin/manifest.json
+++ b/Jellyfin/manifest.json
@@ -1,166 +1,200 @@
 [
-  {
-    "guid": "8c5d0e91-4f2a-4b6d-9e3f-1a7c8d9e0f2b",
-    "name": "Moonbase",
-    "overview": "Moonfin server plugin for Jellyfin with web app hosting, settings sync, theming, and Seerr integrations",
-    "description": "Moonbase is the Moonfin server plugin for Jellyfin, powering settings sync, the Moonfin Web app at /Moonfin/Web/, a built-in theme editor with custom theme APIs, media bar and ratings integrations, and Seerr proxy/SSO with admin defaults and broadcasts across Moonfin clients.",
-    "owner": "RadicalMuffinMan",
-    "category": "General",
-    "imageUrl": "https://raw.githubusercontent.com/Moonfin-Client/Plugin/master/backend/assets/logo.png",
-    "versions": [
-      {
-        "version": "2.0.0.0",
-        "changelog": "Features:\n\n- The web theme editor gained a random theme generator that builds a complete, coherent palette from a random base and accent hue, while keeping your theme id, name, and description. The theme id validation message was also clarified.\n\nBug Fixes:\n\n- Media Bar trailers on web were reworked so YouTube trailer playback and advancing to the next slide now work correctly.\n- Web playback sessions are now reported as stopped when you close or navigate away from the browser tab, using a page exit beacon, so they no longer linger as active on the server.\n- The sidebar now follows desktop behavior in desktop browsers, instead of using the mobile layout.\n- Preferences are now parsed and type coerced more robustly for web compatibility, fixing settings that could fail to load or save when stored as browser strings.\n- The refresh rate switching and audio output mode settings are now hidden on the web build, where they do not apply.\n- ASS and PGS subtitles now render correctly on web, with the necessary fonts bundled.",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.1/Moonfin.Server-2.0.0.0.zip",
-        "checksum": "0C6EB7D9693C8F841C58F96210F3AD21",
-        "timestamp": "2026-07-16T20:03:35",
-        "dependencies": []
-      },
-      {
-        "version": "1.9.0.0",
-        "changelog": "## Features\n\n- Refreshed the Moonfin plugin, now called Moonbase, experience with the Moonfin Flutter web app, now served from `/Moonfin/Web/`.\n- Replaced the older JavaScript overlay frontend with a proper web client bundled from the Flutter web project at the Moonfin-Core repo and theme assets for a smoother setup.\n- Added a built-in theme editor at `/Moonfin/Web/theme/`, including admin-managed custom theme uploads and validation.\n- Added discovery endpoints for plugin web startup: `/Moonfin/Discovery` and `/Moonfin/Discovery/discover`.\n- Added custom theme APIs and services for listing, retrieving, uploading or replacing, deleting, and validating themes.\n- Improved settings sync and admin tools with better global/profile behavior and admin broadcast support.",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.0/Moonfin.Server-1.9.0.0.zip",
-        "checksum": "BCFEC3007BCCA81F535594FA8332FD3F",
-        "timestamp": "2026-06-01T02:47:41",
-        "dependencies": []
-      },
-      {
-        "version": "1.8.2.0",
-        "changelog": "## Features\n\n- Added Media Bar Enhanced support in desktop media bar settings. (#98)\n- Clicking a row item now navigates to the correct library, and playback from the Continue Watching row works properly again. (#60)\n\n## Bug Fixes\n\n- Details page buttons were too large on some screens — they've been resized to something more reasonable. (#100)\n- Clicking items from third-party home screen section plugins no longer incorrectly triggers Moonfin's custom detail page. (#96)\n- Admin default settings now correctly propagate to existing users when changed. (#101)\n- The Jellyseerr discover page was crashing to an error screen because the proxy was wrapping responses in an unexpected JSON envelope. That's fixed now. (#108)\n- The global profile now saves reliably, the media bar state persists correctly across Moonfin and Paradox themes, and users no longer see genres or library sections they don't have access to. (#87)",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.2/Moonfin.Server-1.8.2.0.zip",
-        "checksum": "C559FB46DFE70DD27F151FB928D2F604",
-        "timestamp": "2026-04-19T20:07:23",
-        "dependencies": []
-      },
-      {
-        "version": "1.8.1.0",
-        "changelog": "## Bug Fixes\n\n- Fixed Moonfin UI not loading on Jellyfin instances deployed under a reverse proxy sub-path\n- Fixed Moonfin login detection using private Jellyfin API internals that could return falsy values depending on Jellyfin version, causing the plugin to never initialize\n- Fixed Jellyseerr proxy (cookies, HTML/CSS rewrites, injected script) using hardcoded root-relative paths that broke under reverse proxy sub-path deployments\n- Fixed Letterboxd ratings showing doubled values for entries cached prior to v1.7.0",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.1/Moonfin.Server-1.8.1.0.zip",
-        "checksum": "7B8C49B2D56C554818D402CD7D8DD583",
-        "timestamp": "2026-04-07T18:09:53",
-        "dependencies": []
-      },
-      {
-        "version": "1.8.0.0",
-        "changelog": "## Features\n\n- Added compatibility with @IAmParadox27 's  [media bar](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/) and [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) rows\n- Added support for @ranaldsgift 's  [KefinTweaks](https://github.com/ranaldsgift/KefinTweaks) rows\n> [!NOTE]  \n> The rows are not yet implemented in the other clients. This is a manual method that will take time but the framework for implementation is done. The media bar compatibility is for web UI only under the desktop profile\n\n- Media bar went full screen like other clients\n- Added sync mode clarity dialog box\n- Added trailer overlay in details screen\n- Added details blur/opacity controls and new endpoints so it syncs with clients\n- Added special features, chapters, and collections in details\n- Added back button and fixed details tint behavior\n- Added favorite button for people details\n- Added favorite/watched indicators in details and library\n- Updated libraries UI\n- Updated collections to display contents in release order\n- Updated Moonfin plugin logo\n\n## Bug Fixes\n\n- Fixed details tint behavior that was causing the original jellyfin ui's backdrop image to look black\n- Fixed header bar glitch that was causing the library title to scroll with users in the library\n- Fixed plugin and UI not applying correctly (#60, #66, #76)\n- Fixed removed media bar items that did not have a backdrop and removed items that users did not have access to.\n- Fixed HDR badge truthy logic and expanded HDR range handling\n- Fixed trailer button forwards to home page\n- Fixed special features not showing with new details page\n- Fixed Seerr invalid CSRF token (#53, #63)\n- Fixed Seerr icon not showing on toolbar\n- Fixed Seerr integration slowness\n- Fixed /Moonfin/Settings returns 404 via reverse proxy",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.0/Moonfin.Server-1.8.0.0.zip",
-        "checksum": "BF2DA2868F49C577F14F2D61354F6281",
-        "timestamp": "2026-04-01T16:05:10",
-        "dependencies": []
-      },
-      {
-        "version": "1.7.1.0",
-        "changelog": "New Features:\n- Media Bar Genre Exclusions - exclude specific genres from the media bar so items from those genres won't appear, configurable per-user and as admin defaults\n- GET /Moonfin/Genres endpoint - returns all genre IDs and localized names for the genre picker\n\nBug Fixes:\n- Fixed Jellyseerr CSRF token errors causing failed authentication and proxy requests\n- Fixed Jellyseerr button not appearing when navbar/sidebar initializes after config is dispatched\n- Fixed media bar showing loading state indefinitely when no items are returned\n- Fixed media bar active class being added when there are no items to display\n- Fixed unnecessary Content-Type header on GET requests\n- Fixed duplicate event listeners on collection/library picker re-renders\n\nImprovements:\n- CSRF tokens are now fetched and sent for all Jellyseerr write operations with a fallback for IP-based URLs\n- Media bar loading class is now removed in error and empty states",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.1/Moonfin.Server-1.7.1.0.zip",
-        "checksum": "ECD1DE99E2A7CC34A4A7BD856848E073",
-        "timestamp": "2026-03-16T18:02:45",
-        "dependencies": []
-      },
-      {
-        "version": "1.7.0.0",
-        "changelog": "New Features:\n- Home Screen Row Ordering - drag and drop to reorder or hide home screen sections like Continue Watching, Next Up, and Latest Media\n- Media Bar Collections - choose specific collections or playlists to show in the media bar instead of pulling from all libraries\n- MDBList rating source labels can now be shown or hidden\n- Automatic settings change when switching between users on the same device\n\nNew Endpoint:\n- GET /Moonfin/MediaBar - returns media bar items based on user settings\n\nBug Fixes:\n- Fixed playback not working from the details page\n- Fixed media bar showing on pages other than the home screen\n- Fixed Seerr/Jellyseerr button not appearing after settings sync\n- Fixed details page interfering with media selection dialogs\n- Fixed incorrect Letterboxd rating values\n\nImprovements:\n- Reusable drag-and-drop sortable list component",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.0/Moonfin.Server-1.7.0.0.zip",
-        "checksum": "B698F944D017AD4675C16C222F8BB25D",
-        "timestamp": "2026-03-15T03:21:44",
-        "dependencies": []
-      },
-      {
-        "version": "1.6.0.0",
-        "changelog": "Bug Fixes:\n- Fixed Seerr/Jellyseerr proxy navigation - search, sidebar links, and in-app navigation no longer load indefinitely\n- Fixed user settings not saving correctly - refactored settings mapping for consistency\n- Fixed navbar background to use a gradient\n- Fixed admin config page not appearing in Jellyfin admin sidebar\n\nImprovements:\n- Media version/quality information now displayed on details overlay\n- Authentication now requires only a username for passwordless Jellyfin users\n- MDBList batch task refactored for better memory management with stream-based JSON I/O",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.6.0/Moonfin.Server-1.6.0.0.zip",
-        "checksum": "1764D016C791637BA0182F5662456B54",
-        "timestamp": "2026-03-14T12:47:13",
-        "dependencies": []
-      },
-      {
-        "version": "1.5.1.0",
-        "changelog": "Bug Fixes:\n- Fixed MDBList and TMDB user API keys not being read from v2 settings profiles (only admin keys worked)\n- Fixed user-selected MDBList rating sources being ignored after v1-to-v2 settings migration (only default 4 sources were returned)",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.1/Moonfin.Server-1.5.1.0.zip",
-        "checksum": "14CAC55434728A5E92CD2481E85DE152",
-        "timestamp": "2026-02-23T04:33:48",
-        "dependencies": []
-      },
-      {
-        "version": "1.5.0.0",
-        "changelog": "Features:\n- Device-specific settings profiles (global, desktop, mobile, TV) with inheritance and sync\n- Admin-configurable default user settings with per-user overrides\n- Sync toggle for enabling/disabling server settings synchronization\n\nImprovements:\n- Season posters fall back to series poster when unavailable (#15)\n- Lazy trailer fetching per displayed item instead of bulk RemoteTrailers query\n\nBug Fixes:\n- Fixed media bar auto-advance and trailer playback continuing after navigating away from home\n- Fixed media bar not stopping on admin pages and video player",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.0/Moonfin.Server-1.5.0.0.zip",
-        "checksum": "43D12A1CC3EBF5CDED1BC974BC925492",
-        "timestamp": "2026-02-22T18:33:27",
-        "dependencies": []
-      },
-      {
-        "version": "1.4.0.0",
-        "changelog": "Features:\n- Media bar trailer previews using YouTube IFrame API with SponsorBlock integration\n- Media bar redesign with logos, rating badges, and genre pills\n\nImprovements:\n- Seerr v3 support with auto-detection and direct iframe URL option\n- Server-wide TMDB API key with user notifications\n- Dynamic icon swapping for Jellyseerr/Seerr\n- Sidebar: settings moved under libraries with separator\n- Admin panel no longer blocked by plugin (whitelist-based route detection)\n- Sensitive data masked in console logs",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.4.0/Moonfin.Server-1.4.0.0.zip",
-        "checksum": "9E826973350BC5B2B56957F45D19EC56",
-        "timestamp": "2026-02-19T05:32:55",
-        "dependencies": []
-      },
-      {
-        "version": "1.3.1.0",
-        "changelog": "- Seerr v3 support with auto-detection (version-based)\n- Direct iframe URL option for Seerr behind reverse proxies\n- Server-wide TMDB API key with user notifications\n- Removed Rotten Tomatoes rating from details page\n- Added dynamic icon swapping for Jellyseerr/Seerr\n- Updated README with Seerr v3 reverse proxy documentation",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.1/Moonfin.Server-1.3.1.0.zip",
-        "checksum": "CAEF64ED665CD3C324F83B3EA490D281",
-        "timestamp": "2026-02-15T12:50:46",
-        "dependencies": []
-      },
-      {
-        "version": "1.3.0.0",
-        "changelog": "- Left sidebar navigation (configurable via navbarPosition)\n- Three-way settings merge with snapshot-based conflict resolution\n- MDBList server-side caching and batch pre-fetching\n\nImprovements:\n- PNG to SVG migration for all rating icons\n- Updated README and admin config page\n\nBug Fixes:\n- Fixed Jellyseerr session persistence (JSON deserialization)\n- Fixed Jellyseerr sessions on local IP addresses\n- Fixed Jellyseerr cookie rotation causing unexpected logouts\n- Fixed mobile media bar overlapping first library row",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.0/Moonfin.Server-1.3.0.0.zip",
-        "checksum": "39CC6BA712E02E2E5552A792CC1BF280",
-        "timestamp": "2026-02-14T22:00:16",
-        "dependencies": []
-      },
-      {
-        "version": "1.2.0.0",
-        "changelog": "- TMDB episode ratings with server-side caching\n- Drag & drop sortable rating sources\n- Jellyseerr dual login (Jellyfin + local accounts)\n- Edit Metadata/Images/Subtitles/Identify open as native dialogs\n- Create New Playlist from details page\n- Fixed homescreen context menu interception\n- Fixed subtitle picker triggering details overlay during playback",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.2.0/Moonfin.Server-1.2.0.0.zip",
-        "checksum": "FEBE25F651728978B685E8734E8B4953",
-        "timestamp": "2026-02-12T22:27:49",
-        "dependencies": []
-      },
-      {
-        "version": "1.1.1.0",
-        "changelog": "- Fixed Jellyseerr 404 when clicking links in iframe\n- Plugin now auto-registers file transformations on load (no manual task needed after updates)",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.1/Moonfin.Server-1.1.1.0.zip",
-        "checksum": "6F034F273541D5103C59B85346B275D4",
-        "timestamp": "2026-02-11T08:02:04",
-        "dependencies": []
-      },
-      {
-        "version": "1.1.0.0",
-        "changelog": "- Integrated File Transformation plugin for automatic web UI injection\n- Fixed bug where media bar did not load right away\n- Added server-wide MDBList API key support\n- Updated user settings and UI",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.0/Moonfin.Server-1.1.0.0.zip",
-        "checksum": "E635BA9B123DD5C8EB9AA32140FBA43D",
-        "timestamp": "2026-02-09T22:58:42",
-        "dependencies": []
-      },
-      {
-        "version": "1.0.0.0",
-        "changelog": "Initial release with core features: navbar, media bar, custom details screens, IMDBList integration, Jellyseerr integration, and settings sync.\n Hope you like it!",
-        "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/Moonfin-Client/Plugin/releases/download/1.0.0/Moonfin.Server-1.0.0.0.zip",
-        "checksum": "D96BC4F769AC38BA298258C0EF21F300",
-        "timestamp": "2026-02-11T07:59:01",
-        "dependencies": []
-      }
-    ]
-  }
+    {
+        "guid":  "8c5d0e91-4f2a-4b6d-9e3f-1a7c8d9e0f2b",
+        "name":  "Moonbase",
+        "overview":  "Moonfin server plugin for Jellyfin with web app hosting, settings sync, theming, and Seerr integrations",
+        "description":  "Moonbase is the Moonfin server plugin for Jellyfin, powering settings sync, the Moonfin Web app at /Moonfin/Web/, a built-in theme editor with custom theme APIs, media bar and ratings integrations, and Seerr proxy/SSO with admin defaults and broadcasts across Moonfin clients.",
+        "owner":  "RadicalMuffinMan",
+        "category":  "General",
+        "imageUrl":  "https://raw.githubusercontent.com/Moonfin-Client/Plugin/master/backend/assets/logo.png",
+        "versions":  [
+                         {
+                             "version":  "2.0.0.0",
+                             "changelog":  "Features:\n\n- The web theme editor gained a random theme generator that builds a complete, coherent palette from a random base and accent hue, while keeping your theme id, name, and description. The theme id validation message was also clarified.\n\nBug Fixes:\n\n- Media Bar trailers on web were reworked so YouTube trailer playback and advancing to the next slide now work correctly.\n- Web playback sessions are now reported as stopped when you close or navigate away from the browser tab, using a page exit beacon, so they no longer linger as active on the server.\n- The sidebar now follows desktop behavior in desktop browsers, instead of using the mobile layout.\n- Preferences are now parsed and type coerced more robustly for web compatibility, fixing settings that could fail to load or save when stored as browser strings.\n- The refresh rate switching and audio output mode settings are now hidden on the web build, where they do not apply.\n- ASS and PGS subtitles now render correctly on web, with the necessary fonts bundled.",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.1/Moonfin.Server-2.0.0.0.zip",
+                             "checksum":  "0925200A45D9FD6892F3394FB9F5E5D5",
+                             "timestamp":  "2026-07-18T16:09:52",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.9.0.0",
+                             "changelog":  "## Features\n\n- Refreshed the Moonfin plugin, now called Moonbase, experience with the Moonfin Flutter web app, now served from `/Moonfin/Web/`.\n- Replaced the older JavaScript overlay frontend with a proper web client bundled from the Flutter web project at the Moonfin-Core repo and theme assets for a smoother setup.\n- Added a built-in theme editor at `/Moonfin/Web/theme/`, including admin-managed custom theme uploads and validation.\n- Added discovery endpoints for plugin web startup: `/Moonfin/Discovery` and `/Moonfin/Discovery/discover`.\n- Added custom theme APIs and services for listing, retrieving, uploading or replacing, deleting, and validating themes.\n- Improved settings sync and admin tools with better global/profile behavior and admin broadcast support.",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.9.0/Moonfin.Server-1.9.0.0.zip",
+                             "checksum":  "BCFEC3007BCCA81F535594FA8332FD3F",
+                             "timestamp":  "2026-06-01T02:47:41",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.8.2.0",
+                             "changelog":  "## Features\n\n- Added Media Bar Enhanced support in desktop media bar settings. (#98)\n- Clicking a row item now navigates to the correct library, and playback from the Continue Watching row works properly again. (#60)\n\n## Bug Fixes\n\n- Details page buttons were too large on some screens — they\u0027ve been resized to something more reasonable. (#100)\n- Clicking items from third-party home screen section plugins no longer incorrectly triggers Moonfin\u0027s custom detail page. (#96)\n- Admin default settings now correctly propagate to existing users when changed. (#101)\n- The Jellyseerr discover page was crashing to an error screen because the proxy was wrapping responses in an unexpected JSON envelope. That\u0027s fixed now. (#108)\n- The global profile now saves reliably, the media bar state persists correctly across Moonfin and Paradox themes, and users no longer see genres or library sections they don\u0027t have access to. (#87)",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.2/Moonfin.Server-1.8.2.0.zip",
+                             "checksum":  "C559FB46DFE70DD27F151FB928D2F604",
+                             "timestamp":  "2026-04-19T20:07:23",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.8.1.0",
+                             "changelog":  "## Bug Fixes\n\n- Fixed Moonfin UI not loading on Jellyfin instances deployed under a reverse proxy sub-path\n- Fixed Moonfin login detection using private Jellyfin API internals that could return falsy values depending on Jellyfin version, causing the plugin to never initialize\n- Fixed Jellyseerr proxy (cookies, HTML/CSS rewrites, injected script) using hardcoded root-relative paths that broke under reverse proxy sub-path deployments\n- Fixed Letterboxd ratings showing doubled values for entries cached prior to v1.7.0",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.1/Moonfin.Server-1.8.1.0.zip",
+                             "checksum":  "7B8C49B2D56C554818D402CD7D8DD583",
+                             "timestamp":  "2026-04-07T18:09:53",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.8.0.0",
+                             "changelog":  "## Features\n\n- Added compatibility with @IAmParadox27 \u0027s  [media bar](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/) and [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) rows\n- Added support for @ranaldsgift \u0027s  [KefinTweaks](https://github.com/ranaldsgift/KefinTweaks) rows\n\u003e [!NOTE]  \n\u003e The rows are not yet implemented in the other clients. This is a manual method that will take time but the framework for implementation is done. The media bar compatibility is for web UI only under the desktop profile\n\n- Media bar went full screen like other clients\n- Added sync mode clarity dialog box\n- Added trailer overlay in details screen\n- Added details blur/opacity controls and new endpoints so it syncs with clients\n- Added special features, chapters, and collections in details\n- Added back button and fixed details tint behavior\n- Added favorite button for people details\n- Added favorite/watched indicators in details and library\n- Updated libraries UI\n- Updated collections to display contents in release order\n- Updated Moonfin plugin logo\n\n## Bug Fixes\n\n- Fixed details tint behavior that was causing the original jellyfin ui\u0027s backdrop image to look black\n- Fixed header bar glitch that was causing the library title to scroll with users in the library\n- Fixed plugin and UI not applying correctly (#60, #66, #76)\n- Fixed removed media bar items that did not have a backdrop and removed items that users did not have access to.\n- Fixed HDR badge truthy logic and expanded HDR range handling\n- Fixed trailer button forwards to home page\n- Fixed special features not showing with new details page\n- Fixed Seerr invalid CSRF token (#53, #63)\n- Fixed Seerr icon not showing on toolbar\n- Fixed Seerr integration slowness\n- Fixed /Moonfin/Settings returns 404 via reverse proxy",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.8.0/Moonfin.Server-1.8.0.0.zip",
+                             "checksum":  "BF2DA2868F49C577F14F2D61354F6281",
+                             "timestamp":  "2026-04-01T16:05:10",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.7.1.0",
+                             "changelog":  "New Features:\n- Media Bar Genre Exclusions - exclude specific genres from the media bar so items from those genres won\u0027t appear, configurable per-user and as admin defaults\n- GET /Moonfin/Genres endpoint - returns all genre IDs and localized names for the genre picker\n\nBug Fixes:\n- Fixed Jellyseerr CSRF token errors causing failed authentication and proxy requests\n- Fixed Jellyseerr button not appearing when navbar/sidebar initializes after config is dispatched\n- Fixed media bar showing loading state indefinitely when no items are returned\n- Fixed media bar active class being added when there are no items to display\n- Fixed unnecessary Content-Type header on GET requests\n- Fixed duplicate event listeners on collection/library picker re-renders\n\nImprovements:\n- CSRF tokens are now fetched and sent for all Jellyseerr write operations with a fallback for IP-based URLs\n- Media bar loading class is now removed in error and empty states",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.1/Moonfin.Server-1.7.1.0.zip",
+                             "checksum":  "ECD1DE99E2A7CC34A4A7BD856848E073",
+                             "timestamp":  "2026-03-16T18:02:45",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.7.0.0",
+                             "changelog":  "New Features:\n- Home Screen Row Ordering - drag and drop to reorder or hide home screen sections like Continue Watching, Next Up, and Latest Media\n- Media Bar Collections - choose specific collections or playlists to show in the media bar instead of pulling from all libraries\n- MDBList rating source labels can now be shown or hidden\n- Automatic settings change when switching between users on the same device\n\nNew Endpoint:\n- GET /Moonfin/MediaBar - returns media bar items based on user settings\n\nBug Fixes:\n- Fixed playback not working from the details page\n- Fixed media bar showing on pages other than the home screen\n- Fixed Seerr/Jellyseerr button not appearing after settings sync\n- Fixed details page interfering with media selection dialogs\n- Fixed incorrect Letterboxd rating values\n\nImprovements:\n- Reusable drag-and-drop sortable list component",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.7.0/Moonfin.Server-1.7.0.0.zip",
+                             "checksum":  "B698F944D017AD4675C16C222F8BB25D",
+                             "timestamp":  "2026-03-15T03:21:44",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.6.0.0",
+                             "changelog":  "Bug Fixes:\n- Fixed Seerr/Jellyseerr proxy navigation - search, sidebar links, and in-app navigation no longer load indefinitely\n- Fixed user settings not saving correctly - refactored settings mapping for consistency\n- Fixed navbar background to use a gradient\n- Fixed admin config page not appearing in Jellyfin admin sidebar\n\nImprovements:\n- Media version/quality information now displayed on details overlay\n- Authentication now requires only a username for passwordless Jellyfin users\n- MDBList batch task refactored for better memory management with stream-based JSON I/O",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.6.0/Moonfin.Server-1.6.0.0.zip",
+                             "checksum":  "1764D016C791637BA0182F5662456B54",
+                             "timestamp":  "2026-03-14T12:47:13",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.5.1.0",
+                             "changelog":  "Bug Fixes:\n- Fixed MDBList and TMDB user API keys not being read from v2 settings profiles (only admin keys worked)\n- Fixed user-selected MDBList rating sources being ignored after v1-to-v2 settings migration (only default 4 sources were returned)",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.1/Moonfin.Server-1.5.1.0.zip",
+                             "checksum":  "14CAC55434728A5E92CD2481E85DE152",
+                             "timestamp":  "2026-02-23T04:33:48",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.5.0.0",
+                             "changelog":  "Features:\n- Device-specific settings profiles (global, desktop, mobile, TV) with inheritance and sync\n- Admin-configurable default user settings with per-user overrides\n- Sync toggle for enabling/disabling server settings synchronization\n\nImprovements:\n- Season posters fall back to series poster when unavailable (#15)\n- Lazy trailer fetching per displayed item instead of bulk RemoteTrailers query\n\nBug Fixes:\n- Fixed media bar auto-advance and trailer playback continuing after navigating away from home\n- Fixed media bar not stopping on admin pages and video player",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.5.0/Moonfin.Server-1.5.0.0.zip",
+                             "checksum":  "43D12A1CC3EBF5CDED1BC974BC925492",
+                             "timestamp":  "2026-02-22T18:33:27",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.4.0.0",
+                             "changelog":  "Features:\n- Media bar trailer previews using YouTube IFrame API with SponsorBlock integration\n- Media bar redesign with logos, rating badges, and genre pills\n\nImprovements:\n- Seerr v3 support with auto-detection and direct iframe URL option\n- Server-wide TMDB API key with user notifications\n- Dynamic icon swapping for Jellyseerr/Seerr\n- Sidebar: settings moved under libraries with separator\n- Admin panel no longer blocked by plugin (whitelist-based route detection)\n- Sensitive data masked in console logs",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.4.0/Moonfin.Server-1.4.0.0.zip",
+                             "checksum":  "9E826973350BC5B2B56957F45D19EC56",
+                             "timestamp":  "2026-02-19T05:32:55",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.3.1.0",
+                             "changelog":  "- Seerr v3 support with auto-detection (version-based)\n- Direct iframe URL option for Seerr behind reverse proxies\n- Server-wide TMDB API key with user notifications\n- Removed Rotten Tomatoes rating from details page\n- Added dynamic icon swapping for Jellyseerr/Seerr\n- Updated README with Seerr v3 reverse proxy documentation",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.1/Moonfin.Server-1.3.1.0.zip",
+                             "checksum":  "CAEF64ED665CD3C324F83B3EA490D281",
+                             "timestamp":  "2026-02-15T12:50:46",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.3.0.0",
+                             "changelog":  "- Left sidebar navigation (configurable via navbarPosition)\n- Three-way settings merge with snapshot-based conflict resolution\n- MDBList server-side caching and batch pre-fetching\n\nImprovements:\n- PNG to SVG migration for all rating icons\n- Updated README and admin config page\n\nBug Fixes:\n- Fixed Jellyseerr session persistence (JSON deserialization)\n- Fixed Jellyseerr sessions on local IP addresses\n- Fixed Jellyseerr cookie rotation causing unexpected logouts\n- Fixed mobile media bar overlapping first library row",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.3.0/Moonfin.Server-1.3.0.0.zip",
+                             "checksum":  "39CC6BA712E02E2E5552A792CC1BF280",
+                             "timestamp":  "2026-02-14T22:00:16",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.2.0.0",
+                             "changelog":  "- TMDB episode ratings with server-side caching\n- Drag \u0026 drop sortable rating sources\n- Jellyseerr dual login (Jellyfin + local accounts)\n- Edit Metadata/Images/Subtitles/Identify open as native dialogs\n- Create New Playlist from details page\n- Fixed homescreen context menu interception\n- Fixed subtitle picker triggering details overlay during playback",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.2.0/Moonfin.Server-1.2.0.0.zip",
+                             "checksum":  "FEBE25F651728978B685E8734E8B4953",
+                             "timestamp":  "2026-02-12T22:27:49",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.1.1.0",
+                             "changelog":  "- Fixed Jellyseerr 404 when clicking links in iframe\n- Plugin now auto-registers file transformations on load (no manual task needed after updates)",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.1/Moonfin.Server-1.1.1.0.zip",
+                             "checksum":  "6F034F273541D5103C59B85346B275D4",
+                             "timestamp":  "2026-02-11T08:02:04",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.1.0.0",
+                             "changelog":  "- Integrated File Transformation plugin for automatic web UI injection\n- Fixed bug where media bar did not load right away\n- Added server-wide MDBList API key support\n- Updated user settings and UI",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.1.0/Moonfin.Server-1.1.0.0.zip",
+                             "checksum":  "E635BA9B123DD5C8EB9AA32140FBA43D",
+                             "timestamp":  "2026-02-09T22:58:42",
+                             "dependencies":  [
+
+                                              ]
+                         },
+                         {
+                             "version":  "1.0.0.0",
+                             "changelog":  "Initial release with core features: navbar, media bar, custom details screens, IMDBList integration, Jellyseerr integration, and settings sync.\n Hope you like it!",
+                             "targetAbi":  "10.10.0.0",
+                             "sourceUrl":  "https://github.com/Moonfin-Client/Plugin/releases/download/1.0.0/Moonfin.Server-1.0.0.0.zip",
+                             "checksum":  "D96BC4F769AC38BA298258C0EF21F300",
+                             "timestamp":  "2026-02-11T07:59:01",
+                             "dependencies":  [
+
+                                              ]
+                         }
+                     ]
+    }
 ]


### PR DESCRIPTION
Remove HttpStatusCode.Forbidden from the session eviction check in both Jellyfin and Emby SeerrSessionService. This allows the server plugin to pass 403 responses through to the client instead of inadvertently evicting the user's session.

# Pull Request

## Summary
Prevent Seerr HTTP 403 Forbidden responses from evicting server plugin user sessions.

## Related Issues
Link related issues or tickets separated by commas.

Discord reported feedback

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/844

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [X] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Removed HttpStatusCode.Forbidden from the session validation/eviction check in both Jellyfin and Emby SeerrSessionService implementations.
- Allows 403 status codes to pass through to the client naturally so they can be handled gracefully as permission/quota/blocklist constraints instead of forcing a full session logout (which converted to 401 SESSION_EXPIRED).

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/844
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Request a movie/show that the current user doesn't have cancel permission for in Seerr.
2. Cancel it and observe a 403 response on the server.
3. Verify that the session is not evicted and the user is not logged out on the client.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [ ] Any new setting keys match the client-side keys exactly
