### PR TITLE
bugfix-homerows - Fix Since You Watched rows for non-admin accounts

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -134,6 +134,16 @@ namespace Emby.Plugins.Moonfin.Services
             resolved.HomeSections = homeLayout.HomeSections;
             resolved.HomeRowOrder = homeLayout.HomeRowOrder;
 
+            if (string.IsNullOrWhiteSpace(resolved.TmdbApiKey))
+            {
+                resolved.TmdbApiKey = Plugin.Instance?.Configuration?.TmdbApiKey;
+            }
+
+            if (string.IsNullOrWhiteSpace(resolved.MdblistApiKey))
+            {
+                resolved.MdblistApiKey = Plugin.Instance?.Configuration?.MdblistApiKey;
+            }
+
             return resolved;
         }
 
@@ -169,6 +179,43 @@ namespace Emby.Plugins.Moonfin.Services
             return homeRowOrder.Count > 0 ? homeRowOrder : null;
         }
 
+        private void StripServerWideKeys(MoonfinSettingsProfile? profile)
+        {
+            if (profile == null) return;
+            var config = Plugin.Instance?.Configuration;
+            if (config == null) return;
+
+            if (profile.TmdbApiKey == config.TmdbApiKey)
+            {
+                profile.TmdbApiKey = null;
+            }
+            if (profile.MdblistApiKey == config.MdblistApiKey)
+            {
+                profile.MdblistApiKey = null;
+            }
+        }
+
+        private void StripServerWideKeys(MoonfinUserSettings? settings)
+        {
+            if (settings == null) return;
+            var config = Plugin.Instance?.Configuration;
+            if (config == null) return;
+
+            if (settings.TmdbApiKey == config.TmdbApiKey)
+            {
+                settings.TmdbApiKey = null;
+            }
+            if (settings.MdblistApiKey == config.MdblistApiKey)
+            {
+                settings.MdblistApiKey = null;
+            }
+
+            StripServerWideKeys(settings.Global);
+            StripServerWideKeys(settings.Desktop);
+            StripServerWideKeys(settings.Mobile);
+            StripServerWideKeys(settings.Tv);
+        }
+
         public async Task SaveUserSettingsAsync(Guid userId, MoonfinUserSettings settings, string? clientId = null, string mergeMode = "merge")
         {
             var filePath = GetUserSettingsPath(userId);
@@ -188,6 +235,7 @@ namespace Emby.Plugins.Moonfin.Services
                     finalSettings = settings;
                 }
 
+                StripServerWideKeys(finalSettings);
                 finalSettings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 finalSettings.LastUpdatedBy = clientId ?? "unknown";
                 finalSettings.SchemaVersion = 2;
@@ -222,6 +270,7 @@ namespace Emby.Plugins.Moonfin.Services
                 else
                     settings.SetProfile(profileName, profile);
 
+                StripServerWideKeys(settings);
                 settings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 settings.LastUpdatedBy = clientId ?? "unknown";
                 settings.SchemaVersion = 2;

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -148,6 +148,16 @@ public class MoonfinSettingsService
             }
         }
 
+        if (string.IsNullOrWhiteSpace(resolved.TmdbApiKey))
+        {
+            resolved.TmdbApiKey = MoonfinPlugin.Instance?.Configuration?.TmdbApiKey;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolved.MdblistApiKey))
+        {
+            resolved.MdblistApiKey = MoonfinPlugin.Instance?.Configuration?.MdblistApiKey;
+        }
+
         return resolved;
     }
 
@@ -225,6 +235,7 @@ public class MoonfinSettingsService
             }
 
             // Update metadata
+            StripServerWideKeys(finalSettings);
             finalSettings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             finalSettings.LastUpdatedBy = clientId ?? "unknown";
             finalSettings.SchemaVersion = 2;
@@ -274,6 +285,7 @@ public class MoonfinSettingsService
             }
 
             // Update metadata
+            StripServerWideKeys(settings);
             settings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             settings.LastUpdatedBy = clientId ?? "unknown";
             settings.SchemaVersion = 2;
@@ -808,5 +820,42 @@ public class MoonfinSettingsService
         // Settings that only survive as a backup still count as existing.
         var path = GetUserSettingsPath(userId);
         return File.Exists(path) || File.Exists(AtomicFile.BackupPath(path));
+    }
+
+    private void StripServerWideKeys(MoonfinSettingsProfile? profile)
+    {
+        if (profile == null) return;
+        var config = MoonfinPlugin.Instance?.Configuration;
+        if (config == null) return;
+
+        if (profile.TmdbApiKey == config.TmdbApiKey)
+        {
+            profile.TmdbApiKey = null;
+        }
+        if (profile.MdblistApiKey == config.MdblistApiKey)
+        {
+            profile.MdblistApiKey = null;
+        }
+    }
+
+    private void StripServerWideKeys(MoonfinUserSettings? settings)
+    {
+        if (settings == null) return;
+        var config = MoonfinPlugin.Instance?.Configuration;
+        if (config == null) return;
+
+        if (settings.TmdbApiKey == config.TmdbApiKey)
+        {
+            settings.TmdbApiKey = null;
+        }
+        if (settings.MdblistApiKey == config.MdblistApiKey)
+        {
+            settings.MdblistApiKey = null;
+        }
+
+        StripServerWideKeys(settings.Global);
+        StripServerWideKeys(settings.Desktop);
+        StripServerWideKeys(settings.Mobile);
+        StripServerWideKeys(settings.Tv);
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary
Add fallback to server-wide TMDb and MDBList API keys for non-admin accounts during profile resolution, and strip them before saving settings to prevent user files from storing copies of the server-wide keys.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [X] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added TMDb and MDBList API keys fallback to server-wide values in `ResolveProfile` inside **MoonfinSettingsService.cs**.
- Added helper methods `StripServerWideKeys` to strip keys matching the server-wide configuration from the user profiles and settings before serialization in `SaveUserSettingsAsync` and `SaveProfileAsync`.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built the plugin using the build script and deployed it to the NAS.
2. Verified that a non-admin account requesting their resolved settings profile gets the server-wide TMDb/MDBList keys.
3. Verified that saving profile/user settings strips these keys, so they are not persisted in individual user files.
4. Executed `synced_fields_test.dart` suite successfully.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
