### PR TITLE
feat-homerows - Add global sync for CW&NU hiding

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -568,49 +568,70 @@ namespace Emby.Plugins.Moonfin.Services
                 settings.Global = new MoonfinSettingsProfile();
             }
 
-            // Check Desktop
-            if (settings.Desktop != null)
+            // Content hiding is a global preference, so lift each device's hidden lists into the
+            // global profile. Union across devices so a file that hid items on more than one device
+            // keeps them all instead of the last device winning.
+            var devices = new[] { settings.Desktop, settings.Mobile, settings.Tv };
+
+            var hiddenContinueWatching = UnionHiddenEntries(devices, p => p.HiddenContinueWatchingItems);
+            if (hiddenContinueWatching != null)
             {
-                if (settings.Desktop.HiddenContinueWatchingItems != null)
+                settings.Global.HiddenContinueWatchingItems = hiddenContinueWatching;
+            }
+
+            var hiddenNextUp = UnionHiddenEntries(devices, p => p.HiddenNextUpSeries);
+            if (hiddenNextUp != null)
+            {
+                settings.Global.HiddenNextUpSeries = hiddenNextUp;
+            }
+
+            foreach (var device in devices)
+            {
+                if (device == null) continue;
+                device.HiddenContinueWatchingItems = null;
+                device.HiddenNextUpSeries = null;
+            }
+        }
+
+        private static string? UnionHiddenEntries(
+            MoonfinSettingsProfile?[] devices,
+            Func<MoonfinSettingsProfile, string?> selector)
+        {
+            Dictionary<string, string>? merged = null;
+            foreach (var device in devices)
+            {
+                if (device == null) continue;
+                var value = selector(device);
+                if (value == null) continue;
+
+                if (merged == null)
                 {
-                    settings.Global.HiddenContinueWatchingItems = settings.Desktop.HiddenContinueWatchingItems;
-                    settings.Desktop.HiddenContinueWatchingItems = null;
+                    merged = new Dictionary<string, string>();
                 }
-                if (settings.Desktop.HiddenNextUpSeries != null)
+                foreach (var pair in ParseHiddenEntries(value))
                 {
-                    settings.Global.HiddenNextUpSeries = settings.Desktop.HiddenNextUpSeries;
-                    settings.Desktop.HiddenNextUpSeries = null;
+                    merged[pair.Key] = pair.Value;
                 }
             }
 
-            // Check Mobile
-            if (settings.Mobile != null)
+            return merged == null ? null : JsonSerializer.Serialize(merged);
+        }
+
+        private static Dictionary<string, string> ParseHiddenEntries(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
             {
-                if (settings.Mobile.HiddenContinueWatchingItems != null)
-                {
-                    settings.Global.HiddenContinueWatchingItems = settings.Mobile.HiddenContinueWatchingItems;
-                    settings.Mobile.HiddenContinueWatchingItems = null;
-                }
-                if (settings.Mobile.HiddenNextUpSeries != null)
-                {
-                    settings.Global.HiddenNextUpSeries = settings.Mobile.HiddenNextUpSeries;
-                    settings.Mobile.HiddenNextUpSeries = null;
-                }
+                return new Dictionary<string, string>();
             }
 
-            // Check Tv
-            if (settings.Tv != null)
+            try
             {
-                if (settings.Tv.HiddenContinueWatchingItems != null)
-                {
-                    settings.Global.HiddenContinueWatchingItems = settings.Tv.HiddenContinueWatchingItems;
-                    settings.Tv.HiddenContinueWatchingItems = null;
-                }
-                if (settings.Tv.HiddenNextUpSeries != null)
-                {
-                    settings.Global.HiddenNextUpSeries = settings.Tv.HiddenNextUpSeries;
-                    settings.Tv.HiddenNextUpSeries = null;
-                }
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(value)
+                    ?? new Dictionary<string, string>();
+            }
+            catch (JsonException)
+            {
+                return new Dictionary<string, string>();
             }
         }
 

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -192,6 +192,8 @@ namespace Emby.Plugins.Moonfin.Services
                 finalSettings.LastUpdatedBy = clientId ?? "unknown";
                 finalSettings.SchemaVersion = 2;
 
+                MoveContentHidingToGlobal(finalSettings);
+
                 var json = JsonSerializer.Serialize(finalSettings, _jsonOptions);
                 await Task.Run(() => AtomicFile.WriteAllText(filePath, json)).ConfigureAwait(false);
             }
@@ -225,6 +227,8 @@ namespace Emby.Plugins.Moonfin.Services
                 settings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 settings.LastUpdatedBy = clientId ?? "unknown";
                 settings.SchemaVersion = 2;
+
+                MoveContentHidingToGlobal(settings);
 
                 var serialized = JsonSerializer.Serialize(settings, _jsonOptions);
                 await Task.Run(() => AtomicFile.WriteAllText(filePath, serialized)).ConfigureAwait(false);
@@ -555,6 +559,59 @@ namespace Emby.Plugins.Moonfin.Services
                 SyncEnabled = true,
                 Global = global
             };
+        }
+
+        private void MoveContentHidingToGlobal(MoonfinUserSettings settings)
+        {
+            if (settings.Global == null)
+            {
+                settings.Global = new MoonfinSettingsProfile();
+            }
+
+            // Check Desktop
+            if (settings.Desktop != null)
+            {
+                if (settings.Desktop.HiddenContinueWatchingItems != null)
+                {
+                    settings.Global.HiddenContinueWatchingItems = settings.Desktop.HiddenContinueWatchingItems;
+                    settings.Desktop.HiddenContinueWatchingItems = null;
+                }
+                if (settings.Desktop.HiddenNextUpSeries != null)
+                {
+                    settings.Global.HiddenNextUpSeries = settings.Desktop.HiddenNextUpSeries;
+                    settings.Desktop.HiddenNextUpSeries = null;
+                }
+            }
+
+            // Check Mobile
+            if (settings.Mobile != null)
+            {
+                if (settings.Mobile.HiddenContinueWatchingItems != null)
+                {
+                    settings.Global.HiddenContinueWatchingItems = settings.Mobile.HiddenContinueWatchingItems;
+                    settings.Mobile.HiddenContinueWatchingItems = null;
+                }
+                if (settings.Mobile.HiddenNextUpSeries != null)
+                {
+                    settings.Global.HiddenNextUpSeries = settings.Mobile.HiddenNextUpSeries;
+                    settings.Mobile.HiddenNextUpSeries = null;
+                }
+            }
+
+            // Check Tv
+            if (settings.Tv != null)
+            {
+                if (settings.Tv.HiddenContinueWatchingItems != null)
+                {
+                    settings.Global.HiddenContinueWatchingItems = settings.Tv.HiddenContinueWatchingItems;
+                    settings.Tv.HiddenContinueWatchingItems = null;
+                }
+                if (settings.Tv.HiddenNextUpSeries != null)
+                {
+                    settings.Global.HiddenNextUpSeries = settings.Tv.HiddenNextUpSeries;
+                    settings.Tv.HiddenNextUpSeries = null;
+                }
+            }
         }
 
         private static void MergeProfile(MoonfinSettingsProfile existing, MoonfinSettingsProfile incoming)

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -229,6 +229,8 @@ public class MoonfinSettingsService
             finalSettings.LastUpdatedBy = clientId ?? "unknown";
             finalSettings.SchemaVersion = 2;
 
+            MoveContentHidingToGlobal(finalSettings);
+
             var json = JsonSerializer.Serialize(finalSettings, _jsonOptions);
             AtomicFile.WriteAllText(filePath, json);
         }
@@ -277,6 +279,8 @@ public class MoonfinSettingsService
             settings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             settings.LastUpdatedBy = clientId ?? "unknown";
             settings.SchemaVersion = 2;
+
+            MoveContentHidingToGlobal(settings);
 
             var serialized = JsonSerializer.Serialize(settings, _jsonOptions);
             AtomicFile.WriteAllText(filePath, serialized);
@@ -486,6 +490,59 @@ public class MoonfinSettingsService
         settings.ThemeMusicVolume = null;
         settings.BlockedRatings = null;
         settings.ClientSpecific = null;
+    }
+
+    private void MoveContentHidingToGlobal(MoonfinUserSettings settings)
+    {
+        if (settings.Global == null)
+        {
+            settings.Global = new MoonfinSettingsProfile();
+        }
+
+        // Check Desktop
+        if (settings.Desktop != null)
+        {
+            if (settings.Desktop.HiddenContinueWatchingItems != null)
+            {
+                settings.Global.HiddenContinueWatchingItems = settings.Desktop.HiddenContinueWatchingItems;
+                settings.Desktop.HiddenContinueWatchingItems = null;
+            }
+            if (settings.Desktop.HiddenNextUpSeries != null)
+            {
+                settings.Global.HiddenNextUpSeries = settings.Desktop.HiddenNextUpSeries;
+                settings.Desktop.HiddenNextUpSeries = null;
+            }
+        }
+
+        // Check Mobile
+        if (settings.Mobile != null)
+        {
+            if (settings.Mobile.HiddenContinueWatchingItems != null)
+            {
+                settings.Global.HiddenContinueWatchingItems = settings.Mobile.HiddenContinueWatchingItems;
+                settings.Mobile.HiddenContinueWatchingItems = null;
+            }
+            if (settings.Mobile.HiddenNextUpSeries != null)
+            {
+                settings.Global.HiddenNextUpSeries = settings.Mobile.HiddenNextUpSeries;
+                settings.Mobile.HiddenNextUpSeries = null;
+            }
+        }
+
+        // Check Tv
+        if (settings.Tv != null)
+        {
+            if (settings.Tv.HiddenContinueWatchingItems != null)
+            {
+                settings.Global.HiddenContinueWatchingItems = settings.Tv.HiddenContinueWatchingItems;
+                settings.Tv.HiddenContinueWatchingItems = null;
+            }
+            if (settings.Tv.HiddenNextUpSeries != null)
+            {
+                settings.Global.HiddenNextUpSeries = settings.Tv.HiddenNextUpSeries;
+                settings.Tv.HiddenNextUpSeries = null;
+            }
+        }
     }
 
     private void MergeProfile(MoonfinSettingsProfile existing, MoonfinSettingsProfile incoming)

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -499,49 +499,70 @@ public class MoonfinSettingsService
             settings.Global = new MoonfinSettingsProfile();
         }
 
-        // Check Desktop
-        if (settings.Desktop != null)
+        // Content hiding is a global preference, so lift each device's hidden lists into the
+        // global profile. Union across devices so a file that hid items on more than one device
+        // keeps them all instead of the last device winning.
+        var devices = new[] { settings.Desktop, settings.Mobile, settings.Tv };
+
+        var hiddenContinueWatching = UnionHiddenEntries(devices, p => p.HiddenContinueWatchingItems);
+        if (hiddenContinueWatching != null)
         {
-            if (settings.Desktop.HiddenContinueWatchingItems != null)
+            settings.Global.HiddenContinueWatchingItems = hiddenContinueWatching;
+        }
+
+        var hiddenNextUp = UnionHiddenEntries(devices, p => p.HiddenNextUpSeries);
+        if (hiddenNextUp != null)
+        {
+            settings.Global.HiddenNextUpSeries = hiddenNextUp;
+        }
+
+        foreach (var device in devices)
+        {
+            if (device == null) continue;
+            device.HiddenContinueWatchingItems = null;
+            device.HiddenNextUpSeries = null;
+        }
+    }
+
+    private static string? UnionHiddenEntries(
+        MoonfinSettingsProfile?[] devices,
+        Func<MoonfinSettingsProfile, string?> selector)
+    {
+        Dictionary<string, string>? merged = null;
+        foreach (var device in devices)
+        {
+            if (device == null) continue;
+            var value = selector(device);
+            if (value == null) continue;
+
+            if (merged == null)
             {
-                settings.Global.HiddenContinueWatchingItems = settings.Desktop.HiddenContinueWatchingItems;
-                settings.Desktop.HiddenContinueWatchingItems = null;
+                merged = new Dictionary<string, string>();
             }
-            if (settings.Desktop.HiddenNextUpSeries != null)
+            foreach (var pair in ParseHiddenEntries(value))
             {
-                settings.Global.HiddenNextUpSeries = settings.Desktop.HiddenNextUpSeries;
-                settings.Desktop.HiddenNextUpSeries = null;
+                merged[pair.Key] = pair.Value;
             }
         }
 
-        // Check Mobile
-        if (settings.Mobile != null)
+        return merged == null ? null : JsonSerializer.Serialize(merged);
+    }
+
+    private static Dictionary<string, string> ParseHiddenEntries(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
         {
-            if (settings.Mobile.HiddenContinueWatchingItems != null)
-            {
-                settings.Global.HiddenContinueWatchingItems = settings.Mobile.HiddenContinueWatchingItems;
-                settings.Mobile.HiddenContinueWatchingItems = null;
-            }
-            if (settings.Mobile.HiddenNextUpSeries != null)
-            {
-                settings.Global.HiddenNextUpSeries = settings.Mobile.HiddenNextUpSeries;
-                settings.Mobile.HiddenNextUpSeries = null;
-            }
+            return new Dictionary<string, string>();
         }
 
-        // Check Tv
-        if (settings.Tv != null)
+        try
         {
-            if (settings.Tv.HiddenContinueWatchingItems != null)
-            {
-                settings.Global.HiddenContinueWatchingItems = settings.Tv.HiddenContinueWatchingItems;
-                settings.Tv.HiddenContinueWatchingItems = null;
-            }
-            if (settings.Tv.HiddenNextUpSeries != null)
-            {
-                settings.Global.HiddenNextUpSeries = settings.Tv.HiddenNextUpSeries;
-                settings.Tv.HiddenNextUpSeries = null;
-            }
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(value)
+                ?? new Dictionary<string, string>();
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, string>();
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Summary
Sync items/series hidden from "Next Up" or "Continue Watching" globally across all devices/profiles by intercepting `HiddenContinueWatchingItems` and `HiddenNextUpSeries` on the server and storing them under the `Global` profile instead of the device-specific profile. Since all profiles fall back to the `Global` profile during resolution, this ensures that content hidden on one device (e.g. Shield TV) is also hidden on other device types (e.g. mobile, desktop).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix (expected behaviour, although wasn't previously incorporated)
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Created `MoveContentHidingToGlobal` helper in Jellyfin's **MoonfinSettingsService.cs**.
- Invoked `MoveContentHidingToGlobal` inside `SaveUserSettingsAsync` and `SaveProfileAsync` in Jellyfin's **MoonfinSettingsService.cs** before JSON serialization.
- Implemented and invoked the same `MoveContentHidingToGlobal` helper inside Emby's **MoonfinSettingsService.cs**.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Hide a series from Continue Watching on desktop.
2. Verify that it gets pushed to the server and saved in the global profile.
3. Verify that on Android TV, the series is also correctly hidden from Continue Watching.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

### Content visible on Windows Desktop and Android TV:
<img width="2558" height="1542" alt="2026-07-19_13-17-22_moonfin" src="https://github.com/user-attachments/assets/ab512af3-c49f-47d6-9693-ed2be3e2c8ba" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_13-17-51" src="https://github.com/user-attachments/assets/5b19301d-0d06-4dab-bc32-f5669ee969cf" />

## Content manually hidden on Windows Desktop:
<img width="2558" height="1542" alt="2026-07-19_13-18-22_moonfin" src="https://github.com/user-attachments/assets/0d6624cd-6002-41c6-b0e3-40e120a93e9c" />

## Content hidden via sync on Android TV:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_13-18-30" src="https://github.com/user-attachments/assets/3a9bc853-b5c1-4b6a-a8c2-31c9a0da5d1c" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
