### PR TITLE
bugfix-ratings - Fix Rotten Tomatoes critics rating mismatch from MDBList

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Api/RatingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/RatingsService.cs
@@ -120,9 +120,16 @@ namespace Emby.Plugins.Moonfin.Api
             {
                 // rtAudience (legacy web) and tomatoes_audience (client) both come from MDBList's
                 // "popcorn" source. Look it up there but return it under the key the caller asked for.
-                var lookupSource = (string.Equals(src, "rtAudience", StringComparison.OrdinalIgnoreCase) ||
-                                    string.Equals(src, "tomatoes_audience", StringComparison.OrdinalIgnoreCase))
-                    ? "popcorn" : src;
+                var lookupSource = src;
+                if (string.Equals(src, "rtAudience", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(src, "tomatoes_audience", StringComparison.OrdinalIgnoreCase))
+                {
+                    lookupSource = "popcorn";
+                }
+                else if (string.Equals(src, "tomatoes", StringComparison.OrdinalIgnoreCase))
+                {
+                    lookupSource = "tomato";
+                }
 
                 if (bySource.TryGetValue(lookupSource, out var r))
                 {

--- a/Jellyfin/backend/Api/MdbListController.cs
+++ b/Jellyfin/backend/Api/MdbListController.cs
@@ -246,6 +246,10 @@ public class MdbListController : ControllerBase
             {
                 lookupSource = "popcorn";
             }
+            else if (string.Equals(source, "tomatoes", StringComparison.OrdinalIgnoreCase))
+            {
+                lookupSource = "tomato";
+            }
 
             if (ratingsBySource.TryGetValue(lookupSource, out var rating))
             {


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the Rotten Tomatoes critics score mismatch from MDBList by translating `"tomatoes"` back to the MDBList cache key `"tomato"` in the server plugin.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [x] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- **MdbListController.cs**: Updated `FilterAndOrderRatings` to look up the `"tomato"` cache key when `"tomatoes"` is requested from the Jellyfin server backend.
- **RatingsService.cs**: Updated lookup logic to map `"tomatoes"` to `"tomato"` when querying from the Emby server backend cache.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [x] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/881
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [x] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [x] Built the plugin and deployed to a Jellyfin server
- [x] Verified against a live client (which one: Windows Client)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Rebuild the Moonbase plugin and deploy it to Jellyfin.
2. Query server ratings for an item with Rotten Tomatoes ratings and confirm `"tomato"` is returned correctly when client requests `"tomatoes"`.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
- [x] Any new setting keys match the client-side keys exactly
