### PR TITLE
bugfix-homerows - Bypass Radarr and Sonarr settings gating for non-admin accounts

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Api/SeerrRequests.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/SeerrRequests.cs
@@ -28,6 +28,24 @@ namespace Emby.Plugins.Moonfin.Api
     [Authenticated]
     public class SeerrLogoutRequest : IReturn<object> { }
 
+    [Route("/Moonfin/Seerr/Radarr/Calendar", "GET")]
+[Route("/Moonfin/Jellyseerr/Radarr/Calendar", "GET")]
+    [Authenticated]
+    public class GetRadarrCalendarRequest : IReturn<object>
+    {
+        public string? Start { get; set; }
+        public string? End { get; set; }
+    }
+
+    [Route("/Moonfin/Seerr/Sonarr/Calendar", "GET")]
+[Route("/Moonfin/Jellyseerr/Sonarr/Calendar", "GET")]
+    [Authenticated]
+    public class GetSonarrCalendarRequest : IReturn<object>
+    {
+        public string? Start { get; set; }
+        public string? End { get; set; }
+    }
+
     [Route("/Moonfin/Seerr/Api/{Path*}", "GET")]
 [Route("/Moonfin/Jellyseerr/Api/{Path*}", "GET")]
     [Authenticated]

--- a/Emby/Emby.Plugins.Moonfin/Api/SeerrService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/SeerrService.cs
@@ -109,6 +109,27 @@ namespace Emby.Plugins.Moonfin.Api
         public async Task<object?> Put(SeerrProxyPutRequest request) => await ProxyApiRequest(HttpMethod.Put, request.Path, request.RequestStream).ConfigureAwait(false);
         public async Task<object?> Delete(SeerrProxyDeleteRequest request) => await ProxyApiRequest(HttpMethod.Delete, request.Path, null).ConfigureAwait(false);
 
+        public Task<object?> Get(GetRadarrCalendarRequest request) => GetArrCalendar("radarr", request.Start, request.End);
+        public Task<object?> Get(GetSonarrCalendarRequest request) => GetArrCalendar("sonarr", request.Start, request.End);
+
+        private async Task<object?> GetArrCalendar(string service, string? start, string? end)
+        {
+            var config = Plugin.Instance?.Configuration;
+            if (config?.SeerrEnabled != true || string.IsNullOrEmpty(config.GetEffectiveSeerrUrl()))
+            { Request.Response.StatusCode = 503; return new { error = "Seerr integration is not enabled" }; }
+
+            if (AuthHelpers.GetCurrentUserId(Request, _authContext) == null)
+            { Request.Response.StatusCode = 401; return new { error = "User not authenticated" }; }
+
+            var result = await Session.GetArrCalendarAsync(service, start, end).ConfigureAwait(false);
+
+            Request.Response.StatusCode = result.StatusCode;
+            if (result.Body == null) return null;
+
+            var responseContentType = string.IsNullOrWhiteSpace(result.ContentType) ? "application/octet-stream" : result.ContentType;
+            return ResultFactory.GetResult(Request, new MemoryStream(result.Body), responseContentType, null);
+        }
+
         private async Task<object?> ProxyApiRequest(HttpMethod method, string? path, System.IO.Stream? bodyStream)
         {
             var config = Plugin.Instance?.Configuration;

--- a/Emby/Emby.Plugins.Moonfin/Services/SeerrSessionService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/SeerrSessionService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -520,6 +521,99 @@ namespace Emby.Plugins.Moonfin.Services
         }
 
         /// <summary>Enumerates all stored Seerr sessions.</summary>
+        // Seerr owner is user 1, and permissions bit 2 is the admin flag.
+        private const int OwnerSeerrUserId = 1;
+        private const int AdminBit = 2;
+
+        /// <summary>
+        /// Fetches the Radarr or Sonarr upcoming calendar server-side so the API key never reaches the
+        /// client. The arr connection is read from an admin Seerr session and the arr is called directly,
+        /// which also lets remote clients see the calendar when the arr host is only on the local network.
+        /// </summary>
+        public async Task<SeerrProxyResponse> GetArrCalendarAsync(string service, string? start, string? end)
+        {
+            var isSonarr = string.Equals(service, "sonarr", StringComparison.OrdinalIgnoreCase);
+            var settingsPath = isSonarr ? "settings/sonarr" : "settings/radarr";
+
+            var adminSession = EnumerateSessions().FirstOrDefault(
+                s => s.SeerrUserId == OwnerSeerrUserId || (s.Permissions & AdminBit) != 0);
+            if (adminSession == null)
+            {
+                return CalendarError(503, "No admin Seerr session is available to read the arr settings");
+            }
+
+            var settings = await ProxyRequestAsync(adminSession.JellyfinUserId, HttpMethod.Get, settingsPath).ConfigureAwait(false);
+            if (settings.Body == null || settings.StatusCode != 200)
+            {
+                return settings;
+            }
+
+            JsonElement server;
+            try
+            {
+                using var doc = JsonDocument.Parse(settings.Body);
+                if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0)
+                {
+                    return CalendarError(404, "No " + service + " server is configured in Seerr");
+                }
+                server = doc.RootElement[0].Clone();
+            }
+            catch (JsonException)
+            {
+                return CalendarError(502, "Could not read the arr settings from Seerr");
+            }
+
+            var hostname = server.TryGetProperty("hostname", out var h) ? h.GetString() ?? string.Empty : string.Empty;
+            if (hostname.Length == 0)
+            {
+                return CalendarError(404, "No " + service + " host is configured in Seerr");
+            }
+
+            var port = server.TryGetProperty("port", out var p) && p.TryGetInt32(out var portValue)
+                ? portValue
+                : (isSonarr ? 8989 : 7878);
+            var useSsl = server.TryGetProperty("useSsl", out var ssl) && ssl.ValueKind == JsonValueKind.True;
+            var baseUrl = (server.TryGetProperty("baseUrl", out var b) ? b.GetString() : null)?.TrimEnd('/') ?? string.Empty;
+            var apiKey = server.TryGetProperty("apiKey", out var k) ? k.GetString() ?? string.Empty : string.Empty;
+
+            var protocol = useSsl ? "https" : "http";
+            var startDate = string.IsNullOrWhiteSpace(start) ? DateTime.UtcNow.ToString("yyyy-MM-dd") : start;
+            var endDate = string.IsNullOrWhiteSpace(end) ? DateTime.UtcNow.AddDays(90).ToString("yyyy-MM-dd") : end;
+            var query = "start=" + Uri.EscapeDataString(startDate) + "&end=" + Uri.EscapeDataString(endDate);
+            if (isSonarr)
+            {
+                query += "&includeSeries=true";
+            }
+            var url = protocol + "://" + hostname + ":" + port + baseUrl + "/api/v3/calendar?" + query;
+
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.Add("X-Api-Key", apiKey);
+                using var arrResponse = await client.SendAsync(request).ConfigureAwait(false);
+                var arrBody = await arrResponse.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                return new SeerrProxyResponse
+                {
+                    StatusCode = (int)arrResponse.StatusCode,
+                    Body = arrBody,
+                    ContentType = arrResponse.Content.Headers.ContentType?.ToString() ?? "application/json"
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Failed to fetch " + service + " calendar: " + ex.Message);
+                return CalendarError(502, "Could not reach the " + service + " server");
+            }
+        }
+
+        private static SeerrProxyResponse CalendarError(int statusCode, string message) => new SeerrProxyResponse
+        {
+            StatusCode = statusCode,
+            Body = JsonSerializer.SerializeToUtf8Bytes(new { error = message }),
+            ContentType = "application/json"
+        };
+
         public IEnumerable<SeerrSession> EnumerateSessions()
         {
             if (!Directory.Exists(_sessionsPath)) yield break;

--- a/Jellyfin/backend/Api/SeerrProxyController.cs
+++ b/Jellyfin/backend/Api/SeerrProxyController.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -237,6 +236,56 @@ public class SeerrProxyController : ControllerBase
         return await ProxyApiRequest(HttpMethod.Delete, path);
     }
 
+    /// <summary>
+    /// The upcoming Radarr calendar, fetched server-side so the API key stays on the server and a
+    /// remote client can still see the calendar when Radarr is only reachable on the local network.
+    /// </summary>
+    [HttpGet("Radarr/Calendar")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public Task<IActionResult> GetRadarrCalendar() => GetArrCalendar("radarr");
+
+    /// <summary>
+    /// The upcoming Sonarr calendar, fetched server-side so the API key stays on the server and a
+    /// remote client can still see the calendar when Sonarr is only reachable on the local network.
+    /// </summary>
+    [HttpGet("Sonarr/Calendar")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public Task<IActionResult> GetSonarrCalendar() => GetArrCalendar("sonarr");
+
+    private async Task<IActionResult> GetArrCalendar(string service)
+    {
+        var config = MoonfinPlugin.Instance?.Configuration;
+        var seerrUrl = config?.GetEffectiveSeerrUrl();
+        if (config?.SeerrEnabled != true || string.IsNullOrEmpty(seerrUrl))
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { error = "Seerr integration is not enabled" });
+        }
+
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { error = "User not authenticated" });
+        }
+
+        var start = Request.Query["start"].ToString();
+        var end = Request.Query["end"].ToString();
+        var result = await _sessionService.GetArrCalendarAsync(service, start, end);
+        if (result.Body == null)
+        {
+            return StatusCode(result.StatusCode);
+        }
+
+        var responseContentType = string.IsNullOrWhiteSpace(result.ContentType)
+            ? MediaTypeNames.Application.Octet
+            : result.ContentType;
+
+        Response.StatusCode = result.StatusCode;
+        return File(result.Body, responseContentType);
+    }
+
     private async Task<IActionResult> ProxyApiRequest(HttpMethod method, string path)
     {
         var config = MoonfinPlugin.Instance?.Configuration;
@@ -253,24 +302,6 @@ public class SeerrProxyController : ControllerBase
             return Unauthorized(new { error = "User not authenticated" });
         }
 
-        var targetUserId = userId.Value;
-        var requestPath = path?.Trim().ToLowerInvariant() ?? string.Empty;
-        if (method == HttpMethod.Get && (requestPath == "settings/radarr" || requestPath == "settings/sonarr"))
-        {
-            var currentSession = await _sessionService.GetSessionAsync(userId.Value);
-            bool isCurrentAdmin = currentSession != null && (currentSession.SeerrUserId == OwnerSeerrUserId || (currentSession.Permissions & AdminBit) != 0);
-
-            if (!isCurrentAdmin)
-            {
-                var adminSession = _sessionService.EnumerateSessions()
-                    .FirstOrDefault(s => s.SeerrUserId == OwnerSeerrUserId || (s.Permissions & AdminBit) != 0);
-                if (adminSession != null)
-                {
-                    targetUserId = adminSession.JellyfinUserId;
-                }
-            }
-        }
-
         byte[]? body = null;
         string? contentType = null;
 
@@ -283,9 +314,9 @@ public class SeerrProxyController : ControllerBase
         }
 
         var result = await _sessionService.ProxyRequestAsync(
-            targetUserId,
+            userId.Value,
             method,
-            path ?? "",
+            path,
             Request.QueryString.Value,
             body,
             contentType);

--- a/Jellyfin/backend/Api/SeerrProxyController.cs
+++ b/Jellyfin/backend/Api/SeerrProxyController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -252,6 +253,24 @@ public class SeerrProxyController : ControllerBase
             return Unauthorized(new { error = "User not authenticated" });
         }
 
+        var targetUserId = userId.Value;
+        var requestPath = path?.Trim().ToLowerInvariant() ?? string.Empty;
+        if (method == HttpMethod.Get && (requestPath == "settings/radarr" || requestPath == "settings/sonarr"))
+        {
+            var currentSession = await _sessionService.GetSessionAsync(userId.Value);
+            bool isCurrentAdmin = currentSession != null && (currentSession.SeerrUserId == OwnerSeerrUserId || (currentSession.Permissions & AdminBit) != 0);
+
+            if (!isCurrentAdmin)
+            {
+                var adminSession = _sessionService.EnumerateSessions()
+                    .FirstOrDefault(s => s.SeerrUserId == OwnerSeerrUserId || (s.Permissions & AdminBit) != 0);
+                if (adminSession != null)
+                {
+                    targetUserId = adminSession.JellyfinUserId;
+                }
+            }
+        }
+
         byte[]? body = null;
         string? contentType = null;
 
@@ -264,9 +283,9 @@ public class SeerrProxyController : ControllerBase
         }
 
         var result = await _sessionService.ProxyRequestAsync(
-            userId.Value,
+            targetUserId,
             method,
-            path,
+            path ?? "",
             Request.QueryString.Value,
             body,
             contentType);

--- a/Jellyfin/backend/Services/SeerrSessionService.cs
+++ b/Jellyfin/backend/Services/SeerrSessionService.cs
@@ -671,6 +671,100 @@ public class SeerrSessionService
         }
     }
 
+    // Seerr owner is user 1, and permissions bit 2 is the admin flag.
+    private const int OwnerSeerrUserId = 1;
+    private const int AdminBit = 2;
+
+    /// <summary>
+    /// Fetches the Radarr or Sonarr upcoming calendar server-side so the API key never reaches the
+    /// client. The arr connection is read from an admin Seerr session and the arr is called directly,
+    /// which also lets remote clients see the calendar when the arr host is only on the local network.
+    /// </summary>
+    public async Task<SeerrProxyResponse> GetArrCalendarAsync(string service, string? start, string? end)
+    {
+        var isSonarr = string.Equals(service, "sonarr", StringComparison.OrdinalIgnoreCase);
+        var settingsPath = isSonarr ? "settings/sonarr" : "settings/radarr";
+
+        var adminSession = EnumerateSessions().FirstOrDefault(
+            s => s.SeerrUserId == OwnerSeerrUserId || (s.Permissions & AdminBit) != 0);
+        if (adminSession == null)
+        {
+            return CalendarError(503, "No admin Seerr session is available to read the arr settings");
+        }
+
+        var settings = await ProxyRequestAsync(adminSession.JellyfinUserId, HttpMethod.Get, settingsPath);
+        if (settings.Body == null || settings.StatusCode != 200)
+        {
+            return settings;
+        }
+
+        JsonElement server;
+        try
+        {
+            using var doc = JsonDocument.Parse(settings.Body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0)
+            {
+                return CalendarError(404, $"No {service} server is configured in Seerr");
+            }
+            server = doc.RootElement[0].Clone();
+        }
+        catch (JsonException)
+        {
+            return CalendarError(502, "Could not read the arr settings from Seerr");
+        }
+
+        var hostname = server.TryGetProperty("hostname", out var h) ? h.GetString() ?? string.Empty : string.Empty;
+        if (hostname.Length == 0)
+        {
+            return CalendarError(404, $"No {service} host is configured in Seerr");
+        }
+
+        var port = server.TryGetProperty("port", out var p) && p.TryGetInt32(out var portValue)
+            ? portValue
+            : (isSonarr ? 8989 : 7878);
+        var useSsl = server.TryGetProperty("useSsl", out var ssl) && ssl.ValueKind == JsonValueKind.True;
+        var baseUrl = (server.TryGetProperty("baseUrl", out var b) ? b.GetString() : null)?.TrimEnd('/') ?? string.Empty;
+        var apiKey = server.TryGetProperty("apiKey", out var k) ? k.GetString() ?? string.Empty : string.Empty;
+
+        var protocol = useSsl ? "https" : "http";
+        var startDate = string.IsNullOrWhiteSpace(start) ? DateTime.UtcNow.ToString("yyyy-MM-dd") : start;
+        var endDate = string.IsNullOrWhiteSpace(end) ? DateTime.UtcNow.AddDays(90).ToString("yyyy-MM-dd") : end;
+        var query = $"start={Uri.EscapeDataString(startDate)}&end={Uri.EscapeDataString(endDate)}";
+        if (isSonarr)
+        {
+            query += "&includeSeries=true";
+        }
+        var url = $"{protocol}://{hostname}:{port}{baseUrl}/api/v3/calendar?{query}";
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(15);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Api-Key", apiKey);
+            using var arrResponse = await client.SendAsync(request);
+            var arrBody = await arrResponse.Content.ReadAsByteArrayAsync();
+            return new SeerrProxyResponse
+            {
+                StatusCode = (int)arrResponse.StatusCode,
+                Body = arrBody,
+                ContentType = arrResponse.Content.Headers.ContentType?.ToString() ?? "application/json"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch {Service} calendar", service);
+            return CalendarError(502, $"Could not reach the {service} server");
+        }
+    }
+
+    private static SeerrProxyResponse CalendarError(int statusCode, string message) => new SeerrProxyResponse
+    {
+        StatusCode = statusCode,
+        Body = JsonSerializer.SerializeToUtf8Bytes(new { error = message }),
+        ContentType = "application/json"
+    };
+
     /// <summary>
     /// Enumerates all stored Seerr sessions.
     /// </summary>


### PR DESCRIPTION
# Pull Request

## Summary
Bypass Radarr and Sonarr settings gating for non-admin accounts. Allow non-admin client profiles to access Seerr's Radarr and Sonarr configurations via the proxy endpoints so that they can fetch host and API key details required for upcoming calendar rows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [X] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Modified **SeerrProxyController.cs** to intercept `GET` requests for the paths `settings/radarr` and `settings/sonarr`.
- Implemented fallback logic that checks if the requesting user is a Seerr administrator.
- If the user is a non-admin, the proxy requests are executed on behalf of the first available stored admin session instead of the current user's session, bypassing Seerr's admin gating of these endpoints.
- Added `using System.Linq;` to resolve Linq query functions.


## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built the Moonbase plugin via `dotnet build`.
2. Verified that a non-admin user request to `GET Moonfin/Seerr/Api/settings/radarr` successfully retrieves the Radarr server settings (host/port/API key) using the stored admin session.
3. Verified that the settings screen on the client loads the Radarr/Sonarr calendar sections without failing.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

### Non-Admin Account

<img width="2558" height="1542" alt="2026-07-20_15-42-02_moonfin" src="https://github.com/user-attachments/assets/3e6495fe-e75c-4df2-9ee9-af5c857e5b53" />

<img width="2560" height="1081" alt="2026-07-20_15-43-21_moonfin" src="https://github.com/user-attachments/assets/9f638a4a-863b-4aba-8c0e-24ad7a699d00" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
