### PR TITLE
feat-settings-sync - Allow for Custom Home Rows Sync across devices

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -751,13 +751,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         source.slice().sort(function (a, b) {
             return (a.order == null ? 0 : a.order) - (b.order == null ? 0 : b.order);
         }).forEach(function (section) {
-            if (!section || section.enabled === false) return;
+            if (!section) return;
             var normalized;
             if (section.kind === 'pluginDynamic') {
                 normalized = {
                     kind: 'pluginDynamic',
                     type: 'none',
-                    enabled: true,
+                    enabled: section.enabled !== false,
                     order: ordered.length,
                     serverId: section.serverId || '',
                     pluginSource: section.pluginSource || 'hss',
@@ -766,6 +766,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
                     pluginDisplayText: section.pluginDisplayText || section.pluginSection || 'Dynamic row'
                 };
             } else {
+                if (section.enabled === false) return;
                 var definition = homeSectionDefinition(section.type);
                 if (!definition) return;
                 normalized = {

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1154,15 +1154,21 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         if (state.sections.length === 0) return null;
         renumberHomeLayoutSections(state);
         return state.sections.map(function (section) {
+            var isDynamic = section.kind === 'pluginDynamic';
             var result = {
-                type: section.kind === 'pluginDynamic' ? 'none' : section.type,
-                enabled: true,
+                type: isDynamic ? 'none' : section.type,
+                // Dynamic rows stay in the editor when disabled, unlike builtins, so writing
+                // them all back as enabled would switch every custom row on.
+                enabled: isDynamic ? section.enabled !== false : true,
                 order: section.order
             };
-            if (section.kind === 'pluginDynamic') {
+            if (isDynamic) {
                 result.kind = 'pluginDynamic';
                 result.pluginSource = section.pluginSource || 'hss';
+                // Custom rows have no server of their own and the client keys them on this,
+                // so send the placeholder it uses rather than nothing.
                 if (section.serverId) result.serverId = section.serverId;
+                else if (result.pluginSource === 'custom') result.serverId = 'custom';
                 if (section.pluginSection) result.pluginSection = section.pluginSection;
                 if (section.pluginAdditionalData) result.pluginAdditionalData = section.pluginAdditionalData;
                 if (section.pluginDisplayText) result.pluginDisplayText = section.pluginDisplayText;

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -2378,15 +2378,21 @@
                 if (HOME_LAYOUT_STATE.sections.length === 0) return null;
                 renumberHomeLayoutSections();
                 return HOME_LAYOUT_STATE.sections.map(function(section) {
+                    var isDynamic = section.kind === 'pluginDynamic';
                     var result = {
-                        type: section.kind === 'pluginDynamic' ? 'none' : section.type,
-                        enabled: true,
+                        type: isDynamic ? 'none' : section.type,
+                        // Dynamic rows stay in the editor when disabled, unlike builtins, so
+                        // writing them all back as enabled would switch every custom row on.
+                        enabled: isDynamic ? section.enabled !== false : true,
                         order: section.order
                     };
-                    if (section.kind === 'pluginDynamic') {
+                    if (isDynamic) {
                         result.kind = 'pluginDynamic';
                         result.pluginSource = section.pluginSource;
+                        // Custom rows have no server of their own and the client keys them on
+                        // this, so send the placeholder it uses rather than nothing.
                         if (section.serverId) result.serverId = section.serverId;
+                        else if (result.pluginSource === 'custom') result.serverId = 'custom';
                         if (section.pluginSection) result.pluginSection = section.pluginSection;
                         if (section.pluginAdditionalData) result.pluginAdditionalData = section.pluginAdditionalData;
                         if (section.pluginDisplayText) result.pluginDisplayText = section.pluginDisplayText;

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1983,13 +1983,13 @@
                 source.slice().sort(function(a, b) {
                     return (a.order == null ? 0 : a.order) - (b.order == null ? 0 : b.order);
                 }).forEach(function(section) {
-                    if (!section || section.enabled === false) return;
+                    if (!section) return;
                     var normalized;
                     if (section.kind === 'pluginDynamic') {
                         normalized = {
                             kind: 'pluginDynamic',
                             type: 'none',
-                            enabled: true,
+                            enabled: section.enabled !== false,
                             order: ordered.length,
                             serverId: section.serverId || '',
                             pluginSource: section.pluginSource,
@@ -1998,6 +1998,7 @@
                             pluginDisplayText: section.pluginDisplayText || section.pluginSection || 'Dynamic row'
                         };
                     } else {
+                        if (section.enabled === false) return;
                         var definition = homeSectionDefinition(section.type);
                         if (!definition) return;
                         normalized = {

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -216,6 +216,7 @@ public class MoonfinSettingsService
         try
         {
             MoonfinUserSettings finalSettings;
+            var customSectionsBefore = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             if (mergeMode == "merge")
             {
@@ -227,6 +228,9 @@ public class MoonfinSettingsService
                     existingSettings = MigrateV1ToV2(existingSettings);
                 }
 
+                // MergeSettings writes into the stored object, so note which custom rows
+                // were on file first or there's nothing left to compare against.
+                customSectionsBefore = CustomHomeSectionIds(existingSettings);
                 finalSettings = MergeSettings(existingSettings, settings);
             }
             else
@@ -241,7 +245,11 @@ public class MoonfinSettingsService
             finalSettings.SchemaVersion = 2;
 
             MoveContentHidingToGlobal(finalSettings);
-            PropagateCustomHomeSectionsAcrossProfiles(finalSettings);
+            PropagateCustomHomeSectionsAcrossProfiles(
+                finalSettings,
+                removed: RemovedCustomHomeSections(
+                    customSectionsBefore,
+                    CustomHomeSectionIds(finalSettings)));
 
             var json = JsonSerializer.Serialize(finalSettings, _jsonOptions);
             AtomicFile.WriteAllText(filePath, json);
@@ -278,6 +286,13 @@ public class MoonfinSettingsService
                 ? settings.Global 
                 : settings.GetProfile(profileName);
 
+            // Note the custom rows this profile held before the merge overwrites them. Only a
+            // push carrying a layout can express a deletion, since a partial push leaves
+            // HomeSections null and mustn't read as the user clearing every custom row.
+            var customSectionsBefore = profile.HomeSections == null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : CustomHomeSectionIds(existingProfile);
+
             if (existingProfile != null)
             {
                 MergeProfile(existingProfile, profile);
@@ -287,6 +302,8 @@ public class MoonfinSettingsService
                 settings.SetProfile(profileName, profile);
             }
 
+            var savedProfile = existingProfile ?? profile;
+
             // Update metadata
             StripServerWideKeys(settings);
             settings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -294,7 +311,12 @@ public class MoonfinSettingsService
             settings.SchemaVersion = 2;
 
             MoveContentHidingToGlobal(settings);
-            PropagateCustomHomeSectionsAcrossProfiles(settings);
+            PropagateCustomHomeSectionsAcrossProfiles(
+                settings,
+                savedProfile,
+                RemovedCustomHomeSections(
+                    customSectionsBefore,
+                    CustomHomeSectionIds(savedProfile)));
 
             var serialized = JsonSerializer.Serialize(settings, _jsonOptions);
             AtomicFile.WriteAllText(filePath, serialized);
@@ -663,55 +685,125 @@ public class MoonfinSettingsService
             }
         }
 
-        PropagateCustomHomeSectionsAcrossProfiles(existing);
         return existing;
     }
 
-    private static void PropagateCustomHomeSectionsAcrossProfiles(MoonfinUserSettings settings)
+    private static bool IsCustomHomeSection(MoonfinHomeSectionConfig section) =>
+        string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(section.PluginSource, "custom", StringComparison.OrdinalIgnoreCase) &&
+        !string.IsNullOrWhiteSpace(section.PluginSection);
+
+    // Custom rows belong to no server, and the client keys them on this, so stand in for
+    // an empty value rather than letting the same row end up with two identities.
+    private static string CustomHomeSectionServerId(MoonfinHomeSectionConfig section) =>
+        string.IsNullOrWhiteSpace(section.ServerId) ? "custom" : section.ServerId!;
+
+    private static Dictionary<string, MoonfinHomeSectionConfig> CustomHomeSections(
+        MoonfinSettingsProfile? profile)
+    {
+        var sections = new Dictionary<string, MoonfinHomeSectionConfig>(StringComparer.OrdinalIgnoreCase);
+        if (profile?.HomeSections == null) return sections;
+
+        foreach (var section in profile.HomeSections)
+        {
+            if (IsCustomHomeSection(section)) sections.TryAdd(section.PluginSection!, section);
+        }
+
+        return sections;
+    }
+
+    private static HashSet<string> CustomHomeSectionIds(MoonfinSettingsProfile? profile) =>
+        new(CustomHomeSections(profile).Keys, StringComparer.OrdinalIgnoreCase);
+
+    private static HashSet<string> CustomHomeSectionIds(MoonfinUserSettings? settings)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (settings == null) return ids;
+
+        foreach (var profile in new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv })
+        {
+            ids.UnionWith(CustomHomeSectionIds(profile));
+        }
+
+        return ids;
+    }
+
+    private static HashSet<string> RemovedCustomHomeSections(HashSet<string> before, HashSet<string> after)
+    {
+        var removed = new HashSet<string>(before, StringComparer.OrdinalIgnoreCase);
+        removed.ExceptWith(after);
+        return removed;
+    }
+
+    /// <summary>
+    /// Mirrors custom rows onto the other device profiles so a row created on one device can
+    /// be switched on from another. Rows listed in <c>removed</c> are taken out everywhere,
+    /// because the copies sitting on the other profiles would otherwise put a row the user
+    /// just deleted straight back. The <c>authoritative</c> profile is the one that was just
+    /// written and its copy of a row wins, so editing a row on one device updates the copies
+    /// the other devices hold.
+    /// </summary>
+    private static void PropagateCustomHomeSectionsAcrossProfiles(
+        MoonfinUserSettings settings,
+        MoonfinSettingsProfile? authoritative = null,
+        HashSet<string>? removed = null)
     {
         var profiles = new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv };
-        var allCustomSections = new List<MoonfinHomeSectionConfig>();
 
-        foreach (var profile in profiles)
+        if (removed is { Count: > 0 })
         {
-            if (profile?.HomeSections == null) continue;
-            foreach (var section in profile.HomeSections)
+            foreach (var profile in profiles)
             {
-                if (string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(section.PluginSource, "custom", StringComparison.OrdinalIgnoreCase) &&
-                    !string.IsNullOrWhiteSpace(section.PluginSection))
-                {
-                    if (!allCustomSections.Any(s => string.Equals(s.PluginSection, section.PluginSection, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        allCustomSections.Add(section);
-                    }
-                }
+                profile?.HomeSections?.RemoveAll(
+                    section => IsCustomHomeSection(section) && removed.Contains(section.PluginSection!));
             }
         }
 
-        if (allCustomSections.Count == 0) return;
+        // The profile that was just written goes first so its copy of a row wins.
+        var known = new Dictionary<string, MoonfinHomeSectionConfig>(StringComparer.OrdinalIgnoreCase);
+        foreach (var profile in profiles.Prepend(authoritative))
+        {
+            foreach (var section in CustomHomeSections(profile))
+            {
+                known.TryAdd(section.Key, section.Value);
+            }
+        }
+
+        if (known.Count == 0) return;
 
         foreach (var profile in profiles)
         {
-            if (profile == null) continue;
-            profile.HomeSections ??= new List<MoonfinHomeSectionConfig>();
-            foreach (var custom in allCustomSections)
+            // A profile with no layout of its own falls back to the global or admin one, and
+            // a list holding nothing but custom rows would end that fallback and leave the
+            // device with no rows at all. Wait until it saves a layout of its own.
+            if (profile?.HomeSections == null) continue;
+
+            var present = CustomHomeSections(profile);
+
+            foreach (var custom in known.Values)
             {
-                if (!profile.HomeSections.Any(s => string.Equals(s.PluginSection, custom.PluginSection, StringComparison.OrdinalIgnoreCase)))
+                if (present.TryGetValue(custom.PluginSection!, out var match))
                 {
-                    profile.HomeSections.Add(new MoonfinHomeSectionConfig
-                    {
-                        Kind = "pluginDynamic",
-                        Type = "none",
-                        Enabled = false,
-                        Order = profile.HomeSections.Count,
-                        ServerId = string.IsNullOrWhiteSpace(custom.ServerId) ? "custom" : custom.ServerId,
-                        PluginSource = "custom",
-                        PluginSection = custom.PluginSection,
-                        PluginAdditionalData = custom.PluginAdditionalData,
-                        PluginDisplayText = custom.PluginDisplayText
-                    });
+                    // Take the newer definition but leave on/off state and position alone,
+                    // since those belong to the device.
+                    match.ServerId = CustomHomeSectionServerId(custom);
+                    match.PluginAdditionalData = custom.PluginAdditionalData;
+                    match.PluginDisplayText = custom.PluginDisplayText;
+                    continue;
                 }
+
+                profile.HomeSections.Add(new MoonfinHomeSectionConfig
+                {
+                    Kind = "pluginDynamic",
+                    Type = "none",
+                    Enabled = false,
+                    Order = profile.HomeSections.Count,
+                    ServerId = CustomHomeSectionServerId(custom),
+                    PluginSource = "custom",
+                    PluginSection = custom.PluginSection,
+                    PluginAdditionalData = custom.PluginAdditionalData,
+                    PluginDisplayText = custom.PluginDisplayText
+                });
             }
         }
     }

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -241,6 +241,7 @@ public class MoonfinSettingsService
             finalSettings.SchemaVersion = 2;
 
             MoveContentHidingToGlobal(finalSettings);
+            PropagateCustomHomeSectionsAcrossProfiles(finalSettings);
 
             var json = JsonSerializer.Serialize(finalSettings, _jsonOptions);
             AtomicFile.WriteAllText(filePath, json);
@@ -293,6 +294,7 @@ public class MoonfinSettingsService
             settings.SchemaVersion = 2;
 
             MoveContentHidingToGlobal(settings);
+            PropagateCustomHomeSectionsAcrossProfiles(settings);
 
             var serialized = JsonSerializer.Serialize(settings, _jsonOptions);
             AtomicFile.WriteAllText(filePath, serialized);
@@ -661,7 +663,57 @@ public class MoonfinSettingsService
             }
         }
 
+        PropagateCustomHomeSectionsAcrossProfiles(existing);
         return existing;
+    }
+
+    private static void PropagateCustomHomeSectionsAcrossProfiles(MoonfinUserSettings settings)
+    {
+        var profiles = new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv };
+        var allCustomSections = new List<MoonfinHomeSectionConfig>();
+
+        foreach (var profile in profiles)
+        {
+            if (profile?.HomeSections == null) continue;
+            foreach (var section in profile.HomeSections)
+            {
+                if (string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(section.PluginSource, "custom", StringComparison.OrdinalIgnoreCase) &&
+                    !string.IsNullOrWhiteSpace(section.PluginSection))
+                {
+                    if (!allCustomSections.Any(s => string.Equals(s.PluginSection, section.PluginSection, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        allCustomSections.Add(section);
+                    }
+                }
+            }
+        }
+
+        if (allCustomSections.Count == 0) return;
+
+        foreach (var profile in profiles)
+        {
+            if (profile == null) continue;
+            profile.HomeSections ??= new List<MoonfinHomeSectionConfig>();
+            foreach (var custom in allCustomSections)
+            {
+                if (!profile.HomeSections.Any(s => string.Equals(s.PluginSection, custom.PluginSection, StringComparison.OrdinalIgnoreCase)))
+                {
+                    profile.HomeSections.Add(new MoonfinHomeSectionConfig
+                    {
+                        Kind = "pluginDynamic",
+                        Type = "none",
+                        Enabled = false,
+                        Order = profile.HomeSections.Count,
+                        ServerId = string.IsNullOrWhiteSpace(custom.ServerId) ? "custom" : custom.ServerId,
+                        PluginSource = "custom",
+                        PluginSection = custom.PluginSection,
+                        PluginAdditionalData = custom.PluginAdditionalData,
+                        PluginDisplayText = custom.PluginDisplayText
+                    });
+                }
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# Pull Request

## Summary
Fixes server-side issues where custom home rows were either purged during web dashboard normalization or restricted to single device profiles instead of being accessible across all client devices.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/946

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [X] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `PropagateCustomHomeSectionsAcrossProfiles()` in `SaveUserSettingsAsync()` and `SaveProfileAsync()` in `MoonfinSettingsService.cs`.
- Automatically propagates custom sections created on one profile (e.g. `desktop`) into all other device profiles (`tv`, `mobile`, `global`) as `enabled: false`.
- Updated `normalizeHomeSections()` in `configPage.html` and `moonfin.js` to preserve disabled dynamic plugin sections (`section.enabled !== false`).

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/946
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Android TV and Windows Desktop
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Deployed compiled `Moonfin.Server.dll` to Synology NAS plugin directory and restarted Jellyfin.
2. Created custom home row on Windows Desktop client.
3. Verified `SaveProfileAsync` ran and populated `tv` profile with custom section (`enabled: false`).
4. Connected Nvidia Shield Android TV client and verified custom section appeared in Custom Home Rows Wizard and toggled ON cleanly.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

Screenshots are client-side so in PR 946

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
