### PR TITLE
add missing syncable settings

### DIFF
--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -765,7 +765,7 @@ public class MoonfinSettingsProfile
     public bool? UpdateNotificationsEnabled { get; set; }
 
     [JsonPropertyName("mediaSegmentActions")]
-    public bool? MediaSegmentActions { get; set; }
+    public string? MediaSegmentActions { get; set; }
 
     [JsonPropertyName("showClock")]
     public bool? showClock { get; set; }

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -763,6 +763,12 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("updateNotificationsEnabled")]
     public bool? UpdateNotificationsEnabled { get; set; }
+
+    [JsonPropertyName("mediaSegmentActions")]
+    public bool? MediaSegmentActions { get; set; }
+
+    [JsonPropertyName("showClock")]
+    public bool? showClock { get; set; }
 }
 
 


### PR DESCRIPTION
# Pull Request

## Summary
add a couple missing syncable settings

they exist in core/smarttv so might as well sync

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [X] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

-
-
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: 
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [ ] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
