### PR TITLE
MoonSync - New Settings (Playback Bar Customization and Others)

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -273,6 +273,16 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("showSeerrButton")] public bool? ShowSeerrButton { get; set; }
         [JsonPropertyName("diagnosticLoggingEnabled")] public bool? DiagnosticLoggingEnabled { get; set; }
         [JsonPropertyName("updateNotificationsEnabled")] public bool? UpdateNotificationsEnabled { get; set; }
+        [JsonPropertyName("musicPlaybackTimeDisplay")] public string? MusicPlaybackTimeDisplay { get; set; }
+        [JsonPropertyName("playbackTimeAboveLeft")] public string? PlaybackTimeAboveLeft { get; set; }
+        [JsonPropertyName("playbackTimeAboveCenter")] public string? PlaybackTimeAboveCenter { get; set; }
+        [JsonPropertyName("playbackTimeAboveRight")] public string? PlaybackTimeAboveRight { get; set; }
+        [JsonPropertyName("playbackTimeBelowLeft")] public string? PlaybackTimeBelowLeft { get; set; }
+        [JsonPropertyName("playbackTimeBelowCenter")] public string? PlaybackTimeBelowCenter { get; set; }
+        [JsonPropertyName("playbackTimeBelowRight")] public string? PlaybackTimeBelowRight { get; set; }
+        [JsonPropertyName("collectionsRowShowEpisodes")] public bool? CollectionsRowShowEpisodes { get; set; }
+        [JsonPropertyName("mergeRecentRowsByType")] public bool? MergeRecentRowsByType { get; set; }
+        [JsonPropertyName("playlistsRowShowEpisodes")] public bool? PlaylistsRowShowEpisodes { get; set; }
     }
 
     /// <summary>

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -763,6 +763,36 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("updateNotificationsEnabled")]
     public bool? UpdateNotificationsEnabled { get; set; }
+
+    [JsonPropertyName("musicPlaybackTimeDisplay")]
+    public string? MusicPlaybackTimeDisplay { get; set; }
+
+    [JsonPropertyName("playbackTimeAboveLeft")]
+    public string? PlaybackTimeAboveLeft { get; set; }
+
+    [JsonPropertyName("playbackTimeAboveCenter")]
+    public string? PlaybackTimeAboveCenter { get; set; }
+
+    [JsonPropertyName("playbackTimeAboveRight")]
+    public string? PlaybackTimeAboveRight { get; set; }
+
+    [JsonPropertyName("playbackTimeBelowLeft")]
+    public string? PlaybackTimeBelowLeft { get; set; }
+
+    [JsonPropertyName("playbackTimeBelowCenter")]
+    public string? PlaybackTimeBelowCenter { get; set; }
+
+    [JsonPropertyName("playbackTimeBelowRight")]
+    public string? PlaybackTimeBelowRight { get; set; }
+
+    [JsonPropertyName("collectionsRowShowEpisodes")]
+    public bool? CollectionsRowShowEpisodes { get; set; }
+
+    [JsonPropertyName("mergeRecentRowsByType")]
+    public bool? MergeRecentRowsByType { get; set; }
+
+    [JsonPropertyName("playlistsRowShowEpisodes")]
+    public bool? PlaylistsRowShowEpisodes { get; set; }
 }
 
 


### PR DESCRIPTION
# Pull Request

## Summary
Add server settings profile DTO properties to Moonbase matching newly introduced Moonfin-Core preferences for progress bar time slot displays and row visibility options.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1039
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1033
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1029

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `musicPlaybackTimeDisplay` string property to **MoonfinSettingsProfile.cs**
- Added 6 `playbackTimeAbove*` and `playbackTimeBelow*` slot string properties to **MoonfinSettingsProfile.cs**
- Added `collectionsRowShowEpisodes`, `mergeRecentRowsByType`, and `playlistsRowShowEpisodes` bool properties to **MoonfinSettingsProfile.cs**
- Updated both Jellyfin and Emby backend profile models for full cross-platform parity

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `musicPlaybackTimeDisplay`
  - `playbackTimeAboveLeft`
  - `playbackTimeAboveCenter`
  - `playbackTimeAboveRight`
  - `playbackTimeBelowLeft`
  - `playbackTimeBelowCenter`
  - `playbackTimeBelowRight`
  - `collectionsRowShowEpisodes`
  - `mergeRecentRowsByType`
  - `playlistsRowShowEpisodes`

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Validated DTO serialization and property naming against Moonfin-Core preference definitions.
2. Verified key matching and status tracking via MoonSync scanner diff.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
