### PR TITLE
MoonSync: The Revamp

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -43,7 +43,6 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("mergeContinueWatchingNextUp")] public bool? MergeContinueWatchingNextUp { get; set; }
         [JsonPropertyName("nextUpMaxDays")] public int? NextUpMaxDays { get; set; }
         [JsonPropertyName("enableMultiServerLibraries")] public bool? EnableMultiServerLibraries { get; set; }
-        [JsonPropertyName("mergeRecentRowsByType")] public bool? MergeRecentRowsByType { get; set; }
         [JsonPropertyName("enableFolderView")] public bool? EnableFolderView { get; set; }
         [JsonPropertyName("useDetailedSubHeadings")] public bool? UseDetailedSubHeadings { get; set; }
         [JsonPropertyName("confirmExit")] public bool? ConfirmExit { get; set; }
@@ -94,10 +93,6 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("mediaBarTrailerCaptions")] public bool? MediaBarTrailerCaptions { get; set; }
         [JsonPropertyName("detailScreenStyle")] public string? DetailScreenStyle { get; set; }
         [JsonPropertyName("detailExpandedTabs")] public bool? DetailExpandedTabs { get; set; }
-        [JsonPropertyName("detailButtonOrder")] public List<string>? DetailButtonOrder { get; set; }
-        [JsonPropertyName("hiddenDetailButtons")] public List<string>? HiddenDetailButtons { get; set; }
-        [JsonPropertyName("seerrRowOrder")] public List<string>? SeerrRowOrder { get; set; }
-        [JsonPropertyName("hiddenSeerrRows")] public List<string>? HiddenSeerrRows { get; set; }
         [JsonPropertyName("themeMusicLoop")] public bool? ThemeMusicLoop { get; set; }
         [JsonPropertyName("displaySinceYouWatchedRows")] public bool? DisplaySinceYouWatchedRows { get; set; }
         [JsonPropertyName("sinceYouWatchedSource")] public string? SinceYouWatchedSource { get; set; }

--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -42,6 +42,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("mergeContinueWatchingNextUp")] public bool? MergeContinueWatchingNextUp { get; set; }
         [JsonPropertyName("nextUpMaxDays")] public int? NextUpMaxDays { get; set; }
         [JsonPropertyName("enableMultiServerLibraries")] public bool? EnableMultiServerLibraries { get; set; }
+        [JsonPropertyName("mergeRecentRowsByType")] public bool? MergeRecentRowsByType { get; set; }
         [JsonPropertyName("enableFolderView")] public bool? EnableFolderView { get; set; }
         [JsonPropertyName("useDetailedSubHeadings")] public bool? UseDetailedSubHeadings { get; set; }
         [JsonPropertyName("confirmExit")] public bool? ConfirmExit { get; set; }
@@ -89,8 +90,13 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("genresRowSortBy")] public string? GenresRowSortBy { get; set; }
         [JsonPropertyName("genresRowItemFilter")] public string? GenresRowItemFilter { get; set; }
         [JsonPropertyName("navbarAlwaysExpanded")] public bool? NavbarAlwaysExpanded { get; set; }
+        [JsonPropertyName("mediaBarTrailerCaptions")] public bool? MediaBarTrailerCaptions { get; set; }
         [JsonPropertyName("detailScreenStyle")] public string? DetailScreenStyle { get; set; }
         [JsonPropertyName("detailExpandedTabs")] public bool? DetailExpandedTabs { get; set; }
+        [JsonPropertyName("detailButtonOrder")] public List<string>? DetailButtonOrder { get; set; }
+        [JsonPropertyName("hiddenDetailButtons")] public List<string>? HiddenDetailButtons { get; set; }
+        [JsonPropertyName("seerrRowOrder")] public List<string>? SeerrRowOrder { get; set; }
+        [JsonPropertyName("hiddenSeerrRows")] public List<string>? HiddenSeerrRows { get; set; }
         [JsonPropertyName("themeMusicLoop")] public bool? ThemeMusicLoop { get; set; }
         [JsonPropertyName("displaySinceYouWatchedRows")] public bool? DisplaySinceYouWatchedRows { get; set; }
         [JsonPropertyName("sinceYouWatchedSource")] public string? SinceYouWatchedSource { get; set; }

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1299,6 +1299,16 @@
                                     <option value="extraLarge">Extra Large</option>
                                 </select>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageTypeContinueWatching">Continue Watching Image Type</label>
+                                <select id="DefaultHomeImageTypeContinueWatching" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="Primary">Poster</option>
+                                    <option value="Backdrop">Backdrop</option>
+                                    <option value="Thumb">Thumbnail</option>
+                                    <option value="Banner">Banner</option>
+                                </select>
+                            </div>
                         </div>
 
                         <!-- 5. Home Sections -->
@@ -1492,6 +1502,11 @@
                                     <option value="true">Yes</option>
                                     <option value="false">No</option>
                                 </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Excluded Genres</label>
+                                <div id="DefaultGenrePicker" style="max-height:260px;overflow-y:auto;border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:6px;margin-top:6px;"></div>
+                                <div class="fieldDescription">Titles in these genres never appear in the media bar.</div>
                             </div>
 
                             <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Seasonal Effects</h4>

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1053,7 +1053,7 @@
                                 <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
                             </div>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Details Background Opacity</label>
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Details Screen Blur</label>
                                 <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
                                     <select id="DefaultDetailsScreenBlur_Set" is="emby-select" style="width: auto; min-width: 195px;">
                                         <option value="unset">Not set (user decides)</option>

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -528,6 +528,49 @@
             color: inherit;
         }
 
+        #MoonfinConfigPage .defaultsSubnavBar {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-top: 1em;
+            margin-bottom: 1.5em;
+            border-bottom: 1px solid rgba(128, 128, 128, 0.28);
+            padding-bottom: 12px;
+        }
+
+        #MoonfinConfigPage .defaultsSubtabBtn {
+            background: rgba(128, 128, 128, 0.08);
+            border: 1px solid rgba(128, 128, 128, 0.28);
+            color: rgba(255, 255, 255, 0.75);
+            border-radius: 20px;
+            padding: 6px 16px;
+            font-size: 0.9em;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        #MoonfinConfigPage .defaultsSubtabBtn:hover {
+            background: rgba(128, 128, 128, 0.16);
+            color: #fff;
+        }
+
+        #MoonfinConfigPage .defaultsSubtabBtn.active {
+            background: #00a4dc;
+            border-color: #00a4dc;
+            color: #fff;
+            font-weight: 600;
+            box-shadow: 0 2px 8px rgba(0, 164, 220, 0.4);
+        }
+
+        #MoonfinConfigPage .defaultsSubtabPanel {
+            display: none;
+        }
+
+        #MoonfinConfigPage .defaultsSubtabPanel.active {
+            display: block;
+        }
+
         #MoonfinConfigPage .homeLayoutEmpty {
             padding: 12px 8px;
             color: rgba(128, 128, 128, 0.8);
@@ -860,316 +903,408 @@
                             <strong>Not set</strong> means "do not force this value" so users keep their own choice.
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Appearance</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultVisualTheme">App Theme</label>
-                            <select id="DefaultVisualTheme" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="moonfin">Moonfin</option>
-                                <option value="neonPulse">Neon Pulse</option>
-                                <option value="glass">Glass</option>
-                                <option value="eightbitHero">8-bit Hero</option>
-                            </select>
-                            <div class="fieldDescription">Default overall app style. Keep Not set to let users choose.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDetailScreenStyle">Detail Screen Style</label>
-                            <select id="DefaultDetailScreenStyle" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="classic">Classic</option>
-                                <option value="modern">Modern</option>
-                            </select>
-                            <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDetailExpandedTabs">Detail Screen Expanded Tabs</label>
-                            <select id="DefaultDetailExpandedTabs" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                            <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals their content without pressing select. When off, tabs start collapsed and open on press. Keep Not set to let users choose.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultFocusColor">Focus Highlight Color</label>
-                            <select id="DefaultFocusColor" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="white">White</option>
-                                <option value="black">Black</option>
-                                <option value="gray">Gray</option>
-                                <option value="darkBlue">Dark Blue</option>
-                                <option value="purple">Purple</option>
-                                <option value="teal">Teal</option>
-                                <option value="navy">Navy</option>
-                                <option value="charcoal">Charcoal</option>
-                                <option value="brown">Brown</option>
-                                <option value="darkRed">Dark Red</option>
-                                <option value="darkGreen">Dark Green</option>
-                                <option value="slate">Slate</option>
-                                <option value="indigo">Indigo</option>
-                                <option value="moonfinCyan">Moonfin Cyan</option>
-                                <option value="neonPulseMagenta">Neon Pulse Magenta</option>
-                                <option value="eightBitGold">8-bit Gold</option>
-                            </select>
-                            <div class="fieldDescription">Color used for focused cards and controls.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultWatchedIndicator">Watched Indicator</label>
-                            <select id="DefaultWatchedIndicator" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="always">Always</option>
-                                <option value="hideUnwatched">Hide Unwatched</option>
-                                <option value="episodesOnly">Episodes Only</option>
-                                <option value="never">Never</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultCardFocusExpansion">Scale Focused Cards</label>
-                            <select id="DefaultCardFocusExpansion" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultScreensaverMode">Screensaver Mode</label>
-                            <select id="DefaultScreensaverMode" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="off">Off</option>
-                                <option value="logo">Logo</option>
-                                <option value="library">Library</option>
-                            </select>
-                        </div>
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Navigation</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarPosition">Default Navbar Position</label>
-                            <select id="DefaultNavbarPosition" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="top">Top</option>
-                                <option value="left">Left (Sidebar)</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarColor">Navigation Bar Accent Color</label>
-                            <select id="DefaultNavbarColor" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="white">White</option>
-                                <option value="black">Black</option>
-                                <option value="gray">Gray</option>
-                                <option value="darkBlue">Dark Blue</option>
-                                <option value="purple">Purple</option>
-                                <option value="teal">Teal</option>
-                                <option value="navy">Navy</option>
-                                <option value="charcoal">Charcoal</option>
-                                <option value="brown">Brown</option>
-                                <option value="darkRed">Dark Red</option>
-                                <option value="darkGreen">Dark Green</option>
-                                <option value="slate">Slate</option>
-                                <option value="indigo">Indigo</option>
-                                <option value="moonfinCyan">Moonfin Cyan</option>
-                                <option value="neonPulseMagenta">Neon Pulse Magenta</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarOpacity">Navigation Bar Opacity (0-100)</label>
-                            <input type="number" id="DefaultNavbarOpacity" is="emby-input" min="0" max="100" step="1" placeholder="Not set" />
+                        <div class="defaultsSubnavBar">
+                            <button type="button" class="defaultsSubtabBtn active" data-subtab="general-style">General Style</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="details-screen">Details Screen</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="navigation">Navigation</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="home-screen">Home Screen</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="home-sections">Home Sections</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="libraries">Libraries</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="extras">Extras</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="integrations">Integrations</button>
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Media Bar</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarSourceType">Media Bar Content Source</label>
-                            <select id="DefaultMediaBarSourceType" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="library">Library (Random)</option>
-                                <option value="collection">Collections / Playlists</option>
-                            </select>
-                            <div class="fieldDescription">Default content source for the media bar. Users can override this.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarMode">Media Bar Style</label>
-                            <select id="DefaultMediaBarMode" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="moonfin">Moonfin</option>
-                                <option value="makd">MA KD</option>
-                                <option value="off">Off</option>
-                            </select>
-                            <div class="fieldDescription">Visual style/mode for the media bar.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerAudio">Trailer Audio In Media Bar</label>
-                            <select id="DefaultMediaBarTrailerAudio" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div id="DefaultCollectionPickerSection" style="display:none;">
+                        <!-- 1. General Style -->
+                        <div class="defaultsSubtabPanel active" data-subtab="general-style">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Theme</h4>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused">Default Collections / Playlists</label>
-                                <div class="fieldDescription" style="margin-bottom:0.5em;">Select which collections or playlists to show in the media bar by default. Users can override this in their own settings. Note: users who don't have access to a selected collection will simply not see those items.</div>
-                                <div id="DefaultCollectionPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:4px;"></div>
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultInterfaceStyle">Interface Style</label>
+                                <select id="DefaultInterfaceStyle" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="automatic">Automatic</option>
+                                    <option value="apple">Apple</option>
+                                    <option value="material">Material</option>
+                                </select>
+                                <div class="fieldDescription">Automatic adapts to your device. Choose Apple or Material to lock the look.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultVisualTheme">App Theme</label>
+                                <select id="DefaultVisualTheme" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="moonfin">Moonfin</option>
+                                    <option value="neonPulse">Neon Pulse</option>
+                                    <option value="glass">Glass</option>
+                                    <option value="eightbitHero">8-bit Hero</option>
+                                </select>
+                                <div class="fieldDescription">Default overall app style. Keep Not set to let users choose.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFocusColor">Focus Border Color</label>
+                                <select id="DefaultFocusColor" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="white">White</option>
+                                    <option value="black">Black</option>
+                                    <option value="gray">Gray</option>
+                                    <option value="darkBlue">Dark Blue</option>
+                                    <option value="purple">Purple</option>
+                                    <option value="teal">Teal</option>
+                                    <option value="navy">Navy</option>
+                                    <option value="charcoal">Charcoal</option>
+                                    <option value="brown">Brown</option>
+                                    <option value="darkRed">Dark Red</option>
+                                    <option value="darkGreen">Dark Green</option>
+                                    <option value="slate">Slate</option>
+                                    <option value="indigo">Indigo</option>
+                                    <option value="moonfinCyan">Moonfin Cyan</option>
+                                    <option value="neonPulseMagenta">Neon Pulse Magenta</option>
+                                    <option value="eightBitGold">8-bit Gold</option>
+                                </select>
+                                <div class="fieldDescription">Color used for focused cards and controls.</div>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Clock</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultClockBehavior">Clock Display</label>
+                                <select id="DefaultClockBehavior" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="always">Always</option>
+                                    <option value="inMenus">In menus</option>
+                                    <option value="never">Never</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultUse24HourClock">24-Hour Clock</label>
+                                <select id="DefaultUse24HourClock" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Display</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultCardFocusExpansion">Focus Expansion Animation</label>
+                                <select id="DefaultCardFocusExpansion" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDesktopUiScale">UI Scaling</label>
+                                <select id="DefaultDesktopUiScale" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="small">Small</option>
+                                    <option value="medium">Medium</option>
+                                    <option value="large">Large</option>
+                                    <option value="extraLarge">Extra Large</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultBackdropEnabled">Background Backdrops</label>
+                                <select id="DefaultBackdropEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultBrowsingBlur">Browsing Background Blur</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultBrowsingBlur_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultBrowsingBlur" min="0" max="25" step="1" value="0" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultBrowsingBlur_Val" style="font-weight: 600; min-width: 32px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultWatchedIndicator">Watched Indicators</label>
+                                <select id="DefaultWatchedIndicator" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="always">Always</option>
+                                    <option value="hideUnwatched">Hide Unwatched</option>
+                                    <option value="episodesOnly">Episodes Only</option>
+                                    <option value="never">Never</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultScreensaverMode">Screensaver Mode (TV clients only)</label>
+                                <select id="DefaultScreensaverMode" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="off">Off</option>
+                                    <option value="logo">Logo</option>
+                                    <option value="library">Library</option>
+                                </select>
                             </div>
                         </div>
-                        <div id="DefaultLibraryPickerSection" style="display:none;">
+
+                        <!-- 2. Details Screen -->
+                        <div class="defaultsSubtabPanel" data-subtab="details-screen">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Details Screen</h4>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused">Default Libraries</label>
-                                <div class="fieldDescription" style="margin-bottom:0.5em;">Optionally select specific libraries for the media bar. Leave all unchecked to use all libraries. Users can override this.</div>
-                                <div id="DefaultLibraryPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:4px;"></div>
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailScreenStyle">Detail screen style</label>
+                                <select id="DefaultDetailScreenStyle" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="classic">Classic</option>
+                                    <option value="modern">Modern</option>
+                                </select>
+                                <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Details Background Opacity</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultDetailsScreenBlur_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultDetailsScreenBlur" min="0" max="25" step="1" value="0" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultDetailsScreenBlur_Val" style="font-weight: 600; min-width: 32px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailExpandedTabs">Expanded Tabs</label>
+                                <select id="DefaultDetailExpandedTabs" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals content without pressing select.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailShowTechnicalDetails">Show Technical Details?</label>
+                                <select id="DefaultDetailShowTechnicalDetails" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRecommendationSystemSource">Recommendation System</label>
+                                <select id="DefaultRecommendationSystemSource" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="local">Moonfin</option>
+                                    <option value="online">TMDB</option>
+                                </select>
+                                <div class="fieldDescription">Source used for recommended and similar media on detail pages.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRecommendationsApplyParentalRatingCap">Apply Parental Rating Cap?</label>
+                                <select id="DefaultRecommendationsApplyParentalRatingCap" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Filter recommendations to not exceed the current item's age rating.</div>
+                            </div>
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Action Buttons</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Default Action Buttons &amp; Order</label>
+                                <div class="fieldDescription">Check which action buttons to show on detail pages and use the arrows to set their order.</div>
+                                <div id="DefaultDetailButtonsList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
                             </div>
                         </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused">Default Excluded Genres</label>
-                            <div class="fieldDescription" style="margin-bottom:0.5em;">Select genres to exclude from the media bar by default. Items with any of these genres will not appear. Users can override this.</div>
-                            <div id="DefaultGenrePicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:4px;"></div>
+
+                        <!-- 3. Navigation -->
+                        <div class="defaultsSubtabPanel" data-subtab="navigation">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Appearance</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarPosition">Navigation Style</label>
+                                <select id="DefaultNavbarPosition" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="top">Top</option>
+                                    <option value="left">Left (Sidebar)</option>
+                                    <option value="bottom">Bottom</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarColor">Navbar Color</label>
+                                <select id="DefaultNavbarColor" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="white">White</option>
+                                    <option value="black">Black</option>
+                                    <option value="gray">Gray</option>
+                                    <option value="darkBlue">Dark Blue</option>
+                                    <option value="purple">Purple</option>
+                                    <option value="teal">Teal</option>
+                                    <option value="navy">Navy</option>
+                                    <option value="charcoal">Charcoal</option>
+                                    <option value="brown">Brown</option>
+                                    <option value="darkRed">Dark Red</option>
+                                    <option value="darkGreen">Dark Green</option>
+                                    <option value="slate">Slate</option>
+                                    <option value="indigo">Indigo</option>
+                                    <option value="moonfinCyan">Moonfin Cyan</option>
+                                    <option value="neonPulseMagenta">Neon Pulse Magenta</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarOpacity">Navbar Opacity</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultNavbarOpacity_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultNavbarOpacity" min="0" max="100" step="5" value="100" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultNavbarOpacity_Val" style="font-weight: 600; min-width: 40px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Nav Buttons</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowShuffleButton">Show Shuffle Button</label>
+                                <select id="DefaultShowShuffleButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowGenresButton">Show Genres Button</label>
+                                <select id="DefaultShowGenresButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowFavoritesButton">Show Favorites Button</label>
+                                <select id="DefaultShowFavoritesButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowLibrariesInToolbar">Show Libraries in Toolbar</label>
+                                <select id="DefaultShowLibrariesInToolbar" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarAlwaysExpanded">Always Expand Navbar Labels</label>
+                                <select id="DefaultNavbarAlwaysExpanded" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultEnableFolderView">Enable Folder View</label>
+                                <select id="DefaultEnableFolderView" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowSeerrButton">Show Seerr Button</label>
+                                <select id="DefaultShowSeerrButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Screen</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultHomeRowsStyle">Home Rows Style</label>
-                            <select id="DefaultHomeRowsStyle" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="v1">Classic</option>
-                                <option value="v2">Modern</option>
-                            </select>
+
+                        <!-- 4. Home Screen -->
+                        <div class="defaultsSubtabPanel" data-subtab="home-screen">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Display</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeRowsStyle">Row Type</label>
+                                <select id="DefaultHomeRowsStyle" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="v1">Classic</option>
+                                    <option value="v2">Modern</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMergeContinueWatchingNextUp">Merge Continue Watching and Next Up</label>
+                                <select id="DefaultMergeContinueWatchingNextUp" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Combine Continue Watching and Next Up into a single home row by default.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNextUpMaxDays">Max days in Next Up</label>
+                                <select id="DefaultNextUpMaxDays" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="0">0 (No limit)</option>
+                                    <option value="30">30 Days</option>
+                                    <option value="90">90 Days</option>
+                                    <option value="180">180 Days</option>
+                                    <option value="365">365 Days (1 Year)</option>
+                                    <option value="730">730 Days (2 Years)</option>
+                                </select>
+                                <div class="fieldDescription">How long a show stays in Next Up after it was last watched.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageUseSeriesImage">Display Series Thumbnails</label>
+                                <select id="DefaultHomeImageUseSeriesImage" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFullScreenRows">Expanded Home Rows</label>
+                                <select id="DefaultFullScreenRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeRowInfoOverlay">Home Row Info Overlay</label>
+                                <select id="DefaultHomeRowInfoOverlay" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultClassicHomeRowsPadding">Home Row Padding (Classic)</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultClassicHomeRowsPadding_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultClassicHomeRowsPadding" min="10" max="130" step="5" value="10" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultClassicHomeRowsPadding_Val" style="font-weight: 600; min-width: 32px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultModernHomeRowsPadding">Home Row Padding (Modern)</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultModernHomeRowsPadding_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultModernHomeRowsPadding" min="360" max="560" step="10" value="360" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultModernHomeRowsPadding_Val" style="font-weight: 600; min-width: 32px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultPosterSize">Home Row Card Display Size</label>
+                                <select id="DefaultPosterSize" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="small">Small</option>
+                                    <option value="medium">Medium</option>
+                                    <option value="large">Large</option>
+                                    <option value="extraLarge">Extra Large</option>
+                                </select>
+                            </div>
                         </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultFullScreenRows">Expanded Rows</label>
-                            <select id="DefaultFullScreenRows" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultUseDetailedSubHeadings">Detailed Sub-Headings</label>
-                            <select id="DefaultUseDetailedSubHeadings" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageTypeContinueWatching">Continue Watching Image Type</label>
-                            <select id="DefaultHomeImageTypeContinueWatching" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="Primary">Poster</option>
-                                <option value="Backdrop">Backdrop</option>
-                                <option value="Thumb">Thumbnail</option>
-                                <option value="Banner">Banner</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultPosterSize">Card Size</label>
-                            <select id="DefaultPosterSize" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="small">Small</option>
-                                <option value="medium">Medium</option>
-                                <option value="large">Large</option>
-                                <option value="extraLarge">Extra Large</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayFavoritesRows">Show Favorites Rows</label>
-                            <select id="DefaultDisplayFavoritesRows" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayCollectionsRows">Show Collections Rows</label>
-                            <select id="DefaultDisplayCollectionsRows" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayGenresRows">Show Genres Rows</label>
-                            <select id="DefaultDisplayGenresRows" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayPlaylistsRows">Show Playlists Rows</label>
-                            <select id="DefaultDisplayPlaylistsRows" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayAudioRows">Show Audio Rows</label>
-                            <select id="DefaultDisplayAudioRows" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultFavoritesRowSortBy">Favorites Row Sort</label>
-                            <select id="DefaultFavoritesRowSortBy" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="name">Name</option>
-                                <option value="dateAdded">Date Added</option>
-                                <option value="premiereDate">Premiere Date</option>
-                                <option value="rating">Rating</option>
-                                <option value="runtime">Runtime</option>
-                                <option value="random">Random</option>
-                                <option value="criticRating">Critic Rating</option>
-                                <option value="communityRating">Community Rating</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultCollectionsRowSortBy">Collections Row Sort</label>
-                            <select id="DefaultCollectionsRowSortBy" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="name">Name</option>
-                                <option value="dateAdded">Date Added</option>
-                                <option value="premiereDate">Premiere Date</option>
-                                <option value="rating">Rating</option>
-                                <option value="runtime">Runtime</option>
-                                <option value="random">Random</option>
-                                <option value="criticRating">Critic Rating</option>
-                                <option value="communityRating">Community Rating</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultGenresRowSortBy">Genres Row Sort</label>
-                            <select id="DefaultGenresRowSortBy" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="name">Name</option>
-                                <option value="dateAdded">Date Added</option>
-                                <option value="premiereDate">Premiere Date</option>
-                                <option value="rating">Rating</option>
-                                <option value="runtime">Runtime</option>
-                                <option value="random">Random</option>
-                                <option value="criticRating">Critic Rating</option>
-                                <option value="communityRating">Community Rating</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultGenresRowItemFilter">Genres Row Item Filter</label>
-                            <select id="DefaultGenresRowItemFilter" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="movies">Movies</option>
-                                <option value="series">Series</option>
-                                <option value="both">Both</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageUseSeriesImage">Series Thumbnails</label>
-                            <select id="DefaultHomeImageUseSeriesImage" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                            <div class="fieldDescription">Use series thumbnails on home rows by default.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused">Default Home Layout</label>
-                            <div class="fieldDescription" style="margin-bottom:0.75em;">Choose active default home sections and their order. This builder only changes the layout; row visibility and sorting stay in the settings above.</div>
+
+                        <!-- 5. Home Sections -->
+                        <div class="defaultsSubtabPanel" data-subtab="home-sections">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Default Home Layout</h4>
+                            <div class="fieldDescription" style="margin-bottom:0.75em;">Choose active default home sections and their order. This builder configures layout and custom dynamic rows.</div>
                             <div class="homeLayoutBuilder">
                                 <div class="homeLayoutPanel">
                                     <h5 class="homeLayoutPanelTitle">Current Layout</h5>
@@ -1183,121 +1318,289 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultMergeContinueWatchingNextUp" is="emby-checkbox" />
-                                <span>Merge Continue Watching &amp; Next Up</span>
-                            </label>
-                            <div class="fieldDescription">Combine Continue Watching and Next Up into a single home row by default.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNextUpMaxDays">Max Days In Next Up</label>
-                            <input type="number" id="DefaultNextUpMaxDays" is="emby-input" min="0" max="3650" step="1" placeholder="Not set" />
-                            <div class="fieldDescription">How long a show stays in Next Up after it was last watched. Use 0 for no limit. Leaving this empty lets the client decide.</div>
+
+                        <!-- 6. Libraries -->
+                        <div class="defaultsSubtabPanel" data-subtab="libraries">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">General</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultEnableMultiServerLibraries">Enable Multi-Server Libraries</label>
+                                <select id="DefaultEnableMultiServerLibraries" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMergeRecentRowsByType">Merge Recent Rows by Type</label>
+                                <select id="DefaultMergeRecentRowsByType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Combines recently added media from different libraries of the same type into unified rows.</div>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Library View</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultGroupItemsIntoCollections">Group Items into Collections</label>
+                                <select id="DefaultGroupItemsIntoCollections" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowMediaDetailsOnLibraryPage">Show Media Details</label>
+                                <select id="DefaultShowMediaDetailsOnLibraryPage" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultUseDetailedSubHeadings">Use Detailed Subheadings</label>
+                                <select id="DefaultUseDetailedSubHeadings" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHideBackdropsInLibraries">Hide Backdrops in Libraries</label>
+                                <select id="DefaultHideBackdropsInLibraries" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Toolbar Buttons</h4>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowShuffleButton" is="emby-checkbox" />
-                                <span>Shuffle Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowGenresButton" is="emby-checkbox" />
-                                <span>Genres Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowFavoritesButton" is="emby-checkbox" />
-                                <span>Favorites Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowCastButton" is="emby-checkbox" />
-                                <span>Cast Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowSyncPlayButton" is="emby-checkbox" />
-                                <span>SyncPlay Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowLibrariesInToolbar" is="emby-checkbox" />
-                                <span>Library Shortcuts</span>
-                            </label>
+                        <!-- 7. Extras -->
+                        <div class="defaultsSubtabPanel" data-subtab="extras">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Media Bar</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarMode">Media Bar Style</label>
+                                <select id="DefaultMediaBarMode" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="moonfin">Moonfin</option>
+                                    <option value="makd">MakD</option>
+                                    <option value="bookshelf">Bookshelf</option>
+                                    <option value="gallery">Gallery</option>
+                                    <option value="banner">Banner</option>
+                                    <option value="off">Off</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarContentType">Content Type</label>
+                                <select id="DefaultMediaBarContentType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="both">Movies and TV Shows</option>
+                                    <option value="movies">Movies Only</option>
+                                    <option value="tvshows">TV Shows Only</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarItemCount">Item Count</label>
+                                <select id="DefaultMediaBarItemCount" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="5">5</option>
+                                    <option value="10">10</option>
+                                    <option value="15">15</option>
+                                    <option value="20">20</option>
+                                    <option value="25">25</option>
+                                    <option value="30">30</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarSourceType">Media Bar Source</label>
+                                <select id="DefaultMediaBarSourceType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="library">Library (Random)</option>
+                                    <option value="collection">Collections / Playlists</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarAutoAdvance">Auto Advance</label>
+                                <select id="DefaultMediaBarAutoAdvance" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarIntervalMs">Auto Advance Interval</label>
+                                <select id="DefaultMediaBarIntervalMs" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="5000">5 Seconds</option>
+                                    <option value="10000">10 Seconds</option>
+                                    <option value="15000">15 Seconds</option>
+                                    <option value="30000">30 Seconds</option>
+                                </select>
+                            </div>
+                            <div id="DefaultCollectionPickerSection" style="display:none;">
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused">Default Collections / Playlists</label>
+                                    <div id="DefaultCollectionPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
+                                </div>
+                            </div>
+                            <div id="DefaultLibraryPickerSection" style="display:none;">
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused">Default Libraries</label>
+                                    <div id="DefaultLibraryPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
+                                </div>
+                            </div>
+
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Local Previews</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerPreview">Trailer Preview</label>
+                                <select id="DefaultMediaBarTrailerPreview" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerAudio">Trailer Audio</label>
+                                <select id="DefaultMediaBarTrailerAudio" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerCaptions">Trailer Captions</label>
+                                <select id="DefaultMediaBarTrailerCaptions" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Show closed captions on YouTube trailers when available.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultEpisodePreviewEnabled">Media Preview</label>
+                                <select id="DefaultEpisodePreviewEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultPreviewAudioEnabled">Preview Audio</label>
+                                <select id="DefaultPreviewAudioEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Seasonal Effects</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultSeasonalSurprise">Seasonal Effects</label>
+                                <select id="DefaultSeasonalSurprise" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="none">None</option>
+                                    <option value="snow">Snow</option>
+                                    <option value="fireworks">Fireworks</option>
+                                    <option value="confetti">Confetti</option>
+                                    <option value="leaves">Falling Leaves</option>
+                                </select>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Theme Music</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicEnabled">Theme Music</label>
+                                <select id="DefaultThemeMusicEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicVolume">Theme Music Volume</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultThemeMusicVolume_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultThemeMusicVolume" min="0" max="100" step="5" value="100" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultThemeMusicVolume_Val" style="font-weight: 600; min-width: 40px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicOnHomeRows">Play Theme Music on Home Rows</label>
+                                <select id="DefaultThemeMusicOnHomeRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicLoop">Loop Theme Music</label>
+                                <select id="DefaultThemeMusicLoop" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Previews</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerPreview">Trailer Preview in Media Bar</label>
-                            <select id="DefaultMediaBarTrailerPreview" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultEpisodePreviewEnabled">Episode Previews On Hover</label>
-                            <select id="DefaultEpisodePreviewEnabled" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultPreviewAudioEnabled">Preview Audio</label>
-                            <select id="DefaultPreviewAudioEnabled" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
+                        <!-- 8. Integrations -->
+                        <div class="defaultsSubtabPanel" data-subtab="integrations">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Metadata &amp; Ratings</h4>
+                            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 1em;">
+                                <label class="emby-checkbox-label">
+                                    <input type="checkbox" id="DefaultMdblistEnabled" is="emby-checkbox" />
+                                    <span>MDBList Ratings</span>
+                                </label>
+                                <div class="fieldDescription">Enable MDBList ratings by default (requires server-wide or user API key).</div>
+                            </div>
+                            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 1.2em;">
+                                <label class="emby-checkbox-label">
+                                    <input type="checkbox" id="DefaultTmdbEpisodeRatingsEnabled" is="emby-checkbox" />
+                                    <span>TMDB Episode Ratings</span>
+                                </label>
+                                <div class="fieldDescription">Enable TMDB episode ratings by default (requires server-wide or user API key).</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingBadges">Show MDBList Rating Badges</label>
+                                <select id="DefaultMdblistShowRatingBadges" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingNames">Show Rating Labels</label>
+                                <select id="DefaultMdblistShowRatingNames" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Default Rating Sources &amp; Order</label>
+                                <div class="fieldDescription">Check which ratings to display and drag or use the arrows to set their order.</div>
+                                <div id="DefaultMdblistRatingSourcesList" style="max-height:220px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;margin-top:6px;"></div>
+                            </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Integrations</h4>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultMdblistEnabled" is="emby-checkbox" />
-                                <span>MDBList Ratings</span>
-                            </label>
-                            <div class="fieldDescription">Enable MDBList ratings by default (requires server-wide or user API key).</div>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultTmdbEpisodeRatingsEnabled" is="emby-checkbox" />
-                                <span>TMDB Episode Ratings</span>
-                            </label>
-                            <div class="fieldDescription">Enable TMDB episode ratings by default (requires server-wide or user API key).</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingBadges">Show MDBList Rating Badges</label>
-                            <select id="DefaultMdblistShowRatingBadges" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused">Default Rating Sources &amp; Order</label>
-                            <div class="fieldDescription" style="margin-bottom:0.5em;">Check which ratings to display and drag or use the arrows to set their order. Leave all unchecked to use each user's own choice.</div>
-                            <div id="DefaultMdblistRatingSourcesList" style="border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:4px;"></div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultSeerrBlockNsfw">Block NSFW In Seerr</label>
-                            <select id="DefaultSeerrBlockNsfw" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Seerr</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultSeerrBlockNsfw">Seerr Block NSFW</label>
+                                <select id="DefaultSeerrBlockNsfw" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Seerr Discovery Rows &amp; Order</label>
+                                <div class="fieldDescription">Enable rows to see on Seerr mainpage and use the arrows to set their order.</div>
+                                <div id="DefaultSeerrDiscoveryList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
+                            </div>
                         </div>
                     </div>
-
+                    </div>
                     </section>
                     <section class="moonfinTabPanel" data-tab="themes">
                     <div class="verticalSection">

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -3,6 +3,10 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     var PluginUniqueId = '9a1b2c3d-4e5f-6789-abcd-ef0123456789';
 
+    function esc(str) {
+        return String(str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
     var RATING_SOURCES = [
         { id: 'tomatoes', label: 'Rotten Tomatoes' },
         { id: 'tomatoes_audience', label: 'RT Audience Score' },
@@ -160,6 +164,65 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         if (raw === '') return null;
         var parsed = parseInt(raw, 10);
         return isNaN(parsed) ? null : parsed;
+    }
+
+    function setNullableRangeInput(view, selectorId, value, unit) {
+        var select = view.querySelector(selectorId + '_Set');
+        var range = view.querySelector(selectorId);
+        var display = view.querySelector(selectorId + '_Val');
+        if (!range) return;
+
+        unit = unit || '';
+
+        if (value == null || value === '') {
+            if (select) select.value = 'unset';
+            range.disabled = true;
+            if (display) display.textContent = '--';
+        } else {
+            if (select) select.value = 'set';
+            range.disabled = false;
+            range.value = String(value);
+            if (display) display.textContent = String(value) + unit;
+        }
+    }
+
+    function getNullableRangeInput(view, selectorId) {
+        var select = view.querySelector(selectorId + '_Set');
+        var range = view.querySelector(selectorId);
+        if (!range) return null;
+        if (select && select.value === 'unset') return null;
+        if (range.disabled) return null;
+        var parsed = parseInt(range.value, 10);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function bindNullableRangeInput(view, selectorId, unit) {
+        var select = view.querySelector(selectorId + '_Set');
+        var range = view.querySelector(selectorId);
+        var display = view.querySelector(selectorId + '_Val');
+        if (!range || !select) return;
+
+        unit = unit || '';
+
+        if (!select.dataset.rangeBound) {
+            select.dataset.rangeBound = 'true';
+            select.addEventListener('change', function() {
+                if (select.value === 'unset') {
+                    range.disabled = true;
+                    if (display) display.textContent = '--';
+                } else {
+                    range.disabled = false;
+                    if (display) display.textContent = range.value + unit;
+                }
+            });
+        }
+
+        if (!range.dataset.rangeBound) {
+            range.dataset.rangeBound = 'true';
+            range.addEventListener('input', function() {
+                if (display) display.textContent = range.value + unit;
+            });
+        }
     }
 
     // ── Tabbed navigation ───────────────────────────────────────────────────
@@ -494,35 +557,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         });
     }
 
-    function loadAdminGenrePicker(view, selectedIds) {
-        var picker = view.querySelector('#DefaultGenrePicker');
-        if (!picker) return;
-        picker.innerHTML = '<div style="padding:8px;color:rgba(128,128,128,0.5);font-size:0.9em;">Loading...</div>';
-        var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
-        fetch(serverUrl + '/Moonfin/Genres', { method: 'GET', headers: moonfinAuthHeaders() })
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                var genres = data.Items || data.items || [];
-                if (genres.length === 0) {
-                    picker.innerHTML = '<div style="padding:8px;color:rgba(128,128,128,0.5);font-size:0.9em;">No genres found.</div>';
-                    return;
-                }
-                var html = '';
-                for (var i = 0; i < genres.length; i++) {
-                    var g = genres[i];
-                    var gId = g.id || g.Id;
-                    var gName = g.name || g.Name;
-                    var isChecked = selectedIds.indexOf(gId) !== -1;
-                    html += '<label style="display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:4px;cursor:pointer;' + (isChecked ? 'background:rgba(0,164,220,0.1);' : '') + '">' +
-                        '<input type="checkbox" class="adminGenreCb" data-id="' + esc(gId) + '"' + (isChecked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;">' +
-                        '<div style="flex:1;min-width:0;"><div style="font-size:0.9em;color:rgba(128,128,128,0.9);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + esc(gName) + '</div></div></label>';
-                }
-                picker.innerHTML = html;
-            })
-            .catch(function () {
-                picker.innerHTML = '<div style="padding:8px;color:rgba(128,128,128,0.5);font-size:0.9em;">Failed to load genres.</div>';
-            });
-    }
+
 
     function loadRatingSourcesPicker(view, selectedIds) {
         var container = view.querySelector('#DefaultMdblistRatingSourcesList');
@@ -576,6 +611,190 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             if (cb && cb.checked) result.push(item.dataset.id);
         });
         return result.length > 0 ? result : null;
+    }
+
+    var DETAIL_BUTTONS = [
+        { id: 'shuffle', label: 'Shuffle' },
+        { id: 'restart', label: 'Restart' },
+        { id: 'playOffline', label: 'Play Offline' },
+        { id: 'audio', label: 'Audio' },
+        { id: 'subtitles', label: 'Subtitles' },
+        { id: 'version', label: 'Version' },
+        { id: 'cast', label: 'Cast' },
+        { id: 'trailer', label: 'Trailer' },
+        { id: 'watchWithGroup', label: 'Watch with group' },
+        { id: 'watched', label: 'Watched' },
+        { id: 'favorite', label: 'Favorite' },
+        { id: 'playlist', label: 'Playlist' },
+        { id: 'download', label: 'Download' },
+        { id: 'deleteFiles', label: 'Delete files' },
+        { id: 'goToSeries', label: 'Go to series' },
+        { id: 'admin', label: 'Admin' }
+    ];
+
+    function loadDetailButtonsPicker(view, order, hidden) {
+        var container = view.querySelector('#DefaultDetailButtonsList');
+        if (!container) return;
+        var hiddenSet = {};
+        if (hidden && Array.isArray(hidden)) {
+            hidden.forEach(function (id) { hiddenSet[id] = true; });
+        }
+
+        var ordered = [];
+        var addedSet = {};
+
+        if (order && Array.isArray(order) && order.length > 0) {
+            order.forEach(function (id) {
+                var btn = DETAIL_BUTTONS.find(function (b) { return b.id === id; });
+                if (btn) {
+                    ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                    addedSet[btn.id] = true;
+                }
+            });
+        }
+
+        DETAIL_BUTTONS.forEach(function (btn) {
+            if (!addedSet[btn.id]) {
+                ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+            }
+        });
+
+        container.innerHTML = '';
+        ordered.forEach(function (item) {
+            var row = document.createElement('div');
+            row.className = 'detailButtonItem';
+            row.dataset.id = item.id;
+            row.style.cssText = 'display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:4px;margin-bottom:2px;background:rgba(128,128,128,0.03);';
+            row.innerHTML =
+                '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">' +
+                '<span style="flex:1;font-size:0.9em;color:rgba(128,128,128,0.9);">' + esc(item.label) + '</span>' +
+                '<button type="button" class="detailButtonMoveBtn" data-dir="up" style="background:none;border:1px solid rgba(128,128,128,0.2);border-radius:3px;color:rgba(128,128,128,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2191;</button>' +
+                '<button type="button" class="detailButtonMoveBtn" data-dir="down" style="background:none;border:1px solid rgba(128,128,128,0.2);border-radius:3px;color:rgba(128,128,128,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2193;</button>';
+            container.appendChild(row);
+        });
+
+        if (!container.dataset.hasListener) {
+            container.dataset.hasListener = 'true';
+            container.addEventListener('click', function (e) {
+                var btn = e.target.closest('.detailButtonMoveBtn');
+                if (!btn) return;
+                var row = btn.closest('.detailButtonItem');
+                if (!row) return;
+                if (btn.dataset.dir === 'up' && row.previousElementSibling) {
+                    container.insertBefore(row, row.previousElementSibling);
+                } else if (btn.dataset.dir === 'down' && row.nextElementSibling) {
+                    container.insertBefore(row.nextElementSibling, row);
+                }
+            });
+        }
+    }
+
+    function getDetailButtonsValue(view) {
+        var items = view.querySelectorAll('#DefaultDetailButtonsList .detailButtonItem');
+        var order = [];
+        var hidden = [];
+        items.forEach(function (item) {
+            var cb = item.querySelector('input[type=checkbox]');
+            var id = item.dataset.id;
+            order.push(id);
+            if (cb && !cb.checked) {
+                hidden.push(id);
+            }
+        });
+        return {
+            order: order.length > 0 ? order : null,
+            hidden: hidden.length > 0 ? hidden : null
+        };
+    }
+
+    var SEERR_DISCOVERY_ROWS = [
+        { id: 'recent_requests', label: 'Recent Requests' },
+        { id: 'watchlist', label: 'Your Watchlist' },
+        { id: 'recently_added', label: 'Recently Added' },
+        { id: 'trending', label: 'Trending' },
+        { id: 'popular_movies', label: 'Popular Movies' },
+        { id: 'movie_genres', label: 'Movie Genres' },
+        { id: 'upcoming_movies', label: 'Upcoming Movies' },
+        { id: 'studios', label: 'Studios' },
+        { id: 'popular_series', label: 'Popular Series' },
+        { id: 'series_genres', label: 'Series Genres' },
+        { id: 'upcoming_series', label: 'Upcoming Series' },
+        { id: 'networks', label: 'Networks' }
+    ];
+
+    function loadSeerrDiscoveryPicker(view, order, hidden) {
+        var container = view.querySelector('#DefaultSeerrDiscoveryList');
+        if (!container) return;
+        var hiddenSet = {};
+        if (hidden && Array.isArray(hidden)) {
+            hidden.forEach(function (id) { hiddenSet[id] = true; });
+        }
+
+        var ordered = [];
+        var addedSet = {};
+
+        if (order && Array.isArray(order) && order.length > 0) {
+            order.forEach(function (id) {
+                var row = SEERR_DISCOVERY_ROWS.find(function (r) { return r.id === id; });
+                if (row) {
+                    ordered.push({ id: row.id, label: row.label, checked: !hiddenSet[row.id] });
+                    addedSet[row.id] = true;
+                }
+            });
+        }
+
+        SEERR_DISCOVERY_ROWS.forEach(function (row) {
+            if (!addedSet[row.id]) {
+                ordered.push({ id: row.id, label: row.label, checked: !hiddenSet[row.id] });
+            }
+        });
+
+        container.innerHTML = '';
+        ordered.forEach(function (item) {
+            var row = document.createElement('div');
+            row.className = 'seerrDiscoveryItem';
+            row.dataset.id = item.id;
+            row.style.cssText = 'display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:4px;margin-bottom:2px;background:rgba(128,128,128,0.03);';
+            row.innerHTML =
+                '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">' +
+                '<span style="flex:1;font-size:0.9em;color:rgba(128,128,128,0.9);">' + esc(item.label) + '</span>' +
+                '<button type="button" class="seerrMoveBtn" data-dir="up" style="background:none;border:1px solid rgba(128,128,128,0.2);border-radius:3px;color:rgba(128,128,128,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2191;</button>' +
+                '<button type="button" class="seerrMoveBtn" data-dir="down" style="background:none;border:1px solid rgba(128,128,128,0.2);border-radius:3px;color:rgba(128,128,128,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2193;</button>';
+            container.appendChild(row);
+        });
+
+        if (!container.dataset.hasListener) {
+            container.dataset.hasListener = 'true';
+            container.addEventListener('click', function (e) {
+                var btn = e.target.closest('.seerrMoveBtn');
+                if (!btn) return;
+                var row = btn.closest('.seerrDiscoveryItem');
+                if (!row) return;
+                if (btn.dataset.dir === 'up' && row.previousElementSibling) {
+                    container.insertBefore(row, row.previousElementSibling);
+                } else if (btn.dataset.dir === 'down' && row.nextElementSibling) {
+                    container.insertBefore(row.nextElementSibling, row);
+                }
+            });
+        }
+    }
+
+    function getSeerrDiscoveryValue(view) {
+        var items = view.querySelectorAll('#DefaultSeerrDiscoveryList .seerrDiscoveryItem');
+        var order = [];
+        var hidden = [];
+        items.forEach(function (item) {
+            var cb = item.querySelector('input[type=checkbox]');
+            var id = item.dataset.id;
+            order.push(id);
+            if (cb && !cb.checked) {
+                hidden.push(id);
+            }
+        });
+        return {
+            order: order.length > 0 ? order : null,
+            hidden: hidden.length > 0 ? hidden : null
+        };
     }
 
     // ── Home layout builder ─────────────────────────────────────────────────
@@ -1417,26 +1636,60 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             initGameCores(view, view.__moonfinState);
 
             var defaults = camelKeysDeep(config.DefaultUserSettings) || {};
+            setSelectValue(view, '#DefaultInterfaceStyle', defaults.interfaceStyle, 'Configured style');
             setSelectValue(view, '#DefaultVisualTheme', defaults.visualTheme, 'Configured theme');
             setSelectValue(view, '#DefaultDetailScreenStyle', defaults.detailScreenStyle, 'Configured style');
             setNullableBoolSelect(view, '#DefaultDetailExpandedTabs', defaults.detailExpandedTabs);
+            setNullableBoolSelect(view, '#DefaultDetailShowTechnicalDetails', defaults.detailShowTechnicalDetails);
+            setSelectValue(view, '#DefaultRecommendationSystemSource', defaults.recommendationSystemSource, 'Configured source');
+            setNullableBoolSelect(view, '#DefaultRecommendationsApplyParentalRatingCap', defaults.recommendationsApplyParentalRatingCap);
+            loadDetailButtonsPicker(view, defaults.detailButtonOrder || null, defaults.hiddenDetailButtons || null);
             setSelectValue(view, '#DefaultFocusColor', defaults.focusColor, 'Configured color');
+            setSelectValue(view, '#DefaultClockBehavior', defaults.clockBehavior, 'Configured clock');
+            setNullableBoolSelect(view, '#DefaultUse24HourClock', defaults.use24HourClock);
+            setSelectValue(view, '#DefaultDesktopUiScale', defaults.desktopUiScale, 'Configured scale');
+            setNullableBoolSelect(view, '#DefaultBackdropEnabled', defaults.backdropEnabled);
+            bindNullableRangeInput(view, '#DefaultBrowsingBlur');
+            setNullableRangeInput(view, '#DefaultBrowsingBlur', defaults.browsingBlur);
+            bindNullableRangeInput(view, '#DefaultDetailsScreenBlur');
+            setNullableRangeInput(view, '#DefaultDetailsScreenBlur', defaults.detailsScreenBlur);
+            setNullableBoolSelect(view, '#DefaultThemeMusicEnabled', defaults.themeMusicEnabled);
+            setNullableBoolSelect(view, '#DefaultThemeMusicOnHomeRows', defaults.themeMusicOnHomeRows);
+            setNullableBoolSelect(view, '#DefaultThemeMusicLoop', defaults.themeMusicLoop);
+            bindNullableRangeInput(view, '#DefaultThemeMusicVolume', '%');
+            setNullableRangeInput(view, '#DefaultThemeMusicVolume', defaults.themeMusicVolume, '%');
             setSelectValue(view, '#DefaultWatchedIndicator', defaults.watchedIndicator, 'Configured mode');
             setNullableBoolSelect(view, '#DefaultCardFocusExpansion', defaults.cardFocusExpansion);
             setSelectValue(view, '#DefaultScreensaverMode', defaults.screensaverMode, 'Configured mode');
 
             setSelectValue(view, '#DefaultNavbarPosition', defaults.navbarPosition, 'Configured position');
             setSelectValue(view, '#DefaultNavbarColor', defaults.navbarColor, 'Configured color');
-            setNullableIntInput(view, '#DefaultNavbarOpacity', defaults.navbarOpacity);
+            bindNullableRangeInput(view, '#DefaultNavbarOpacity', '%');
+            setNullableRangeInput(view, '#DefaultNavbarOpacity', defaults.navbarOpacity, '%');
+            setNullableBoolSelect(view, '#DefaultNavbarAlwaysExpanded', defaults.navbarAlwaysExpanded);
+            setNullableBoolSelect(view, '#DefaultEnableFolderView', defaults.enableFolderView);
+            setNullableBoolSelect(view, '#DefaultShowSeerrButton', defaults.showSeerrButton);
 
             setSelectValue(view, '#DefaultMediaBarSourceType', defaults.mediaBarSourceType, 'Configured source');
             setSelectValue(view, '#DefaultMediaBarMode', defaults.mediaBarMode, 'Configured mode');
+            setSelectValue(view, '#DefaultMediaBarContentType', defaults.mediaBarContentType, 'Configured content type');
+            setSelectValue(view, '#DefaultMediaBarItemCount', defaults.mediaBarItemCount, 'Configured item count');
+            setNullableBoolSelect(view, '#DefaultMediaBarAutoAdvance', defaults.mediaBarAutoAdvance);
+            setSelectValue(view, '#DefaultMediaBarIntervalMs', defaults.mediaBarIntervalMs, 'Configured interval');
+            setNullableBoolSelect(view, '#DefaultMediaBarTrailerPreview', defaults.mediaBarTrailerPreview);
             setNullableBoolSelect(view, '#DefaultMediaBarTrailerAudio', defaults.mediaBarTrailerAudio);
+            setNullableBoolSelect(view, '#DefaultMediaBarTrailerCaptions', defaults.mediaBarTrailerCaptions);
+            setNullableBoolSelect(view, '#DefaultEpisodePreviewEnabled', defaults.episodePreviewEnabled);
+            setNullableBoolSelect(view, '#DefaultPreviewAudioEnabled', defaults.previewAudioEnabled);
+            setSelectValue(view, '#DefaultSeasonalSurprise', defaults.seasonalSurprise, 'Configured surprise');
 
             setSelectValue(view, '#DefaultHomeRowsStyle', defaults.homeRowsStyle, 'Configured style');
             setNullableBoolSelect(view, '#DefaultFullScreenRows', defaults.fullScreenRows);
-            setNullableBoolSelect(view, '#DefaultUseDetailedSubHeadings', defaults.useDetailedSubHeadings);
-            setSelectValue(view, '#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
+            setNullableBoolSelect(view, '#DefaultHomeRowInfoOverlay', defaults.homeRowInfoOverlay);
+            bindNullableRangeInput(view, '#DefaultClassicHomeRowsPadding', 'px');
+            setNullableRangeInput(view, '#DefaultClassicHomeRowsPadding', defaults.classicHomeRowsPadding, 'px');
+            bindNullableRangeInput(view, '#DefaultModernHomeRowsPadding', 'px');
+            setNullableRangeInput(view, '#DefaultModernHomeRowsPadding', defaults.modernHomeRowsPadding, 'px');
             setSelectValue(view, '#DefaultPosterSize', defaults.posterSize, 'Configured size');
             setNullableBoolSelect(view, '#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
             setNullableBoolSelect(view, '#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
@@ -1449,25 +1702,29 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setSelectValue(view, '#DefaultGenresRowItemFilter', defaults.genresRowItemFilter, 'Configured filter');
             setNullableBoolSelect(view, '#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
             loadHomeSectionsEditor(view, defaults.homeSections || null, defaults.homeRowOrder || null);
-            view.querySelector('#DefaultMergeContinueWatchingNextUp').checked = !!defaults.mergeContinueWatchingNextUp;
-            setNullableIntInput(view, '#DefaultNextUpMaxDays', defaults.nextUpMaxDays);
+            setNullableBoolSelect(view, '#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
+            setSelectValue(view, '#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');
 
-            view.querySelector('#DefaultShowShuffleButton').checked = !!defaults.showShuffleButton;
-            view.querySelector('#DefaultShowGenresButton').checked = !!defaults.showGenresButton;
-            view.querySelector('#DefaultShowFavoritesButton').checked = !!defaults.showFavoritesButton;
+            setNullableBoolSelect(view, '#DefaultEnableMultiServerLibraries', defaults.enableMultiServerLibraries);
+            setNullableBoolSelect(view, '#DefaultMergeRecentRowsByType', defaults.mergeRecentRowsByType);
+            setNullableBoolSelect(view, '#DefaultGroupItemsIntoCollections', defaults.groupItemsIntoCollections);
+            setNullableBoolSelect(view, '#DefaultShowMediaDetailsOnLibraryPage', defaults.showMediaDetailsOnLibraryPage);
+            setNullableBoolSelect(view, '#DefaultUseDetailedSubHeadings', defaults.useDetailedSubHeadings);
+            setNullableBoolSelect(view, '#DefaultHideBackdropsInLibraries', defaults.hideBackdropsInLibraries);
+
+            setNullableBoolSelect(view, '#DefaultShowShuffleButton', defaults.showShuffleButton);
+            setNullableBoolSelect(view, '#DefaultShowGenresButton', defaults.showGenresButton);
+            setNullableBoolSelect(view, '#DefaultShowFavoritesButton', defaults.showFavoritesButton);
             view.querySelector('#DefaultShowCastButton').checked = !!defaults.showCastButton;
             view.querySelector('#DefaultShowSyncPlayButton').checked = !!defaults.showSyncPlayButton;
-            view.querySelector('#DefaultShowLibrariesInToolbar').checked = !!defaults.showLibrariesInToolbar;
-
-            setNullableBoolSelect(view, '#DefaultMediaBarTrailerPreview', defaults.mediaBarTrailerPreview);
-            setNullableBoolSelect(view, '#DefaultEpisodePreviewEnabled', defaults.episodePreviewEnabled);
-            setNullableBoolSelect(view, '#DefaultPreviewAudioEnabled', defaults.previewAudioEnabled);
+            setNullableBoolSelect(view, '#DefaultShowLibrariesInToolbar', defaults.showLibrariesInToolbar);
 
             view.querySelector('#DefaultMdblistEnabled').checked = !!defaults.mdblistEnabled;
             view.querySelector('#DefaultTmdbEpisodeRatingsEnabled').checked = !!defaults.tmdbEpisodeRatingsEnabled;
             setNullableBoolSelect(view, '#DefaultMdblistShowRatingBadges', defaults.mdblistShowRatingBadges);
             loadRatingSourcesPicker(view, defaults.mdblistRatingSources || null);
             setNullableBoolSelect(view, '#DefaultSeerrBlockNsfw', defaults.seerrBlockNsfw);
+            loadSeerrDiscoveryPicker(view, defaults.seerrRowOrder || null, defaults.hiddenSeerrRows || null);
 
             var sourceSelect = view.querySelector('#DefaultMediaBarSourceType');
             var collectionPickerSection = view.querySelector('#DefaultCollectionPickerSection');
@@ -1485,7 +1742,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
                 sourceSelect.addEventListener('change', togglePickerVisibility);
             }
             togglePickerVisibility();
-            loadAdminGenrePicker(view, defaults.mediaBarExcludedGenres || []);
 
             loading.hide();
         }).catch(reportConfigError);
@@ -1516,33 +1772,61 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
                 .map(function (cb) { return cb.getAttribute('data-id'); });
 
             var d = camelKeysDeep(config.DefaultUserSettings) || {};
+            d.interfaceStyle = view.querySelector('#DefaultInterfaceStyle').value || null;
             d.visualTheme = view.querySelector('#DefaultVisualTheme').value || null;
             d.detailScreenStyle = view.querySelector('#DefaultDetailScreenStyle').value || null;
             d.detailExpandedTabs = getNullableBoolSelect(view, '#DefaultDetailExpandedTabs');
+            d.detailShowTechnicalDetails = getNullableBoolSelect(view, '#DefaultDetailShowTechnicalDetails');
+            d.recommendationSystemSource = view.querySelector('#DefaultRecommendationSystemSource').value || null;
+            d.recommendationsApplyParentalRatingCap = getNullableBoolSelect(view, '#DefaultRecommendationsApplyParentalRatingCap');
+            var btnVal = getDetailButtonsValue(view);
+            d.detailButtonOrder = btnVal.order;
+            d.hiddenDetailButtons = btnVal.hidden;
             d.focusColor = view.querySelector('#DefaultFocusColor').value || null;
+            d.clockBehavior = view.querySelector('#DefaultClockBehavior').value || null;
+            d.use24HourClock = getNullableBoolSelect(view, '#DefaultUse24HourClock');
+            d.desktopUiScale = view.querySelector('#DefaultDesktopUiScale').value || null;
+            d.backdropEnabled = getNullableBoolSelect(view, '#DefaultBackdropEnabled');
+            d.browsingBlur = getNullableRangeInput(view, '#DefaultBrowsingBlur');
+            d.detailsScreenBlur = getNullableRangeInput(view, '#DefaultDetailsScreenBlur');
+            d.themeMusicEnabled = getNullableBoolSelect(view, '#DefaultThemeMusicEnabled');
+            d.themeMusicOnHomeRows = getNullableBoolSelect(view, '#DefaultThemeMusicOnHomeRows');
+            d.themeMusicLoop = getNullableBoolSelect(view, '#DefaultThemeMusicLoop');
+            d.themeMusicVolume = getNullableRangeInput(view, '#DefaultThemeMusicVolume');
             d.watchedIndicator = view.querySelector('#DefaultWatchedIndicator').value || null;
             d.cardFocusExpansion = getNullableBoolSelect(view, '#DefaultCardFocusExpansion');
             d.screensaverMode = view.querySelector('#DefaultScreensaverMode').value || null;
 
             d.navbarPosition = view.querySelector('#DefaultNavbarPosition').value || null;
             d.navbarColor = view.querySelector('#DefaultNavbarColor').value || null;
-            d.navbarOpacity = getNullableIntInput(view, '#DefaultNavbarOpacity');
+            d.navbarOpacity = getNullableRangeInput(view, '#DefaultNavbarOpacity');
+            d.navbarAlwaysExpanded = getNullableBoolSelect(view, '#DefaultNavbarAlwaysExpanded');
+            d.enableFolderView = getNullableBoolSelect(view, '#DefaultEnableFolderView');
+            d.showSeerrButton = getNullableBoolSelect(view, '#DefaultShowSeerrButton');
 
             d.mediaBarSourceType = view.querySelector('#DefaultMediaBarSourceType').value || null;
             d.mediaBarMode = view.querySelector('#DefaultMediaBarMode').value || null;
+            d.mediaBarContentType = view.querySelector('#DefaultMediaBarContentType').value || null;
+            d.mediaBarItemCount = getNullableIntInput(view, '#DefaultMediaBarItemCount');
+            d.mediaBarAutoAdvance = getNullableBoolSelect(view, '#DefaultMediaBarAutoAdvance');
+            d.mediaBarIntervalMs = getNullableIntInput(view, '#DefaultMediaBarIntervalMs');
+            d.mediaBarTrailerPreview = getNullableBoolSelect(view, '#DefaultMediaBarTrailerPreview');
             d.mediaBarTrailerAudio = getNullableBoolSelect(view, '#DefaultMediaBarTrailerAudio');
+            d.mediaBarTrailerCaptions = getNullableBoolSelect(view, '#DefaultMediaBarTrailerCaptions');
+            d.episodePreviewEnabled = getNullableBoolSelect(view, '#DefaultEpisodePreviewEnabled');
+            d.previewAudioEnabled = getNullableBoolSelect(view, '#DefaultPreviewAudioEnabled');
+            d.seasonalSurprise = view.querySelector('#DefaultSeasonalSurprise').value || null;
 
             var collectionIds = Array.prototype.slice.call(view.querySelectorAll('.adminCollectionCb:checked')).map(function (cb) { return cb.dataset.id; });
             d.mediaBarCollectionIds = collectionIds.length > 0 ? collectionIds : null;
             var libraryIds = Array.prototype.slice.call(view.querySelectorAll('.adminLibraryCb:checked')).map(function (cb) { return cb.dataset.id; });
             d.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
-            var genreIds = Array.prototype.slice.call(view.querySelectorAll('.adminGenreCb:checked')).map(function (cb) { return cb.dataset.id; });
-            d.mediaBarExcludedGenres = genreIds.length > 0 ? genreIds : null;
 
             d.homeRowsStyle = view.querySelector('#DefaultHomeRowsStyle').value || null;
             d.fullScreenRows = getNullableBoolSelect(view, '#DefaultFullScreenRows');
-            d.useDetailedSubHeadings = getNullableBoolSelect(view, '#DefaultUseDetailedSubHeadings');
-            d.homeImageTypeContinueWatching = view.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
+            d.homeRowInfoOverlay = getNullableBoolSelect(view, '#DefaultHomeRowInfoOverlay');
+            d.classicHomeRowsPadding = getNullableIntInput(view, '#DefaultClassicHomeRowsPadding');
+            d.modernHomeRowsPadding = getNullableIntInput(view, '#DefaultModernHomeRowsPadding');
             d.posterSize = view.querySelector('#DefaultPosterSize').value || null;
             d.displayFavoritesRows = getNullableBoolSelect(view, '#DefaultDisplayFavoritesRows');
             d.displayCollectionsRows = getNullableBoolSelect(view, '#DefaultDisplayCollectionsRows');
@@ -1557,15 +1841,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             var homeSections = getHomeSectionsValue(view);
             d.homeSections = homeSections;
             d.homeRowOrder = getHomeRowOrderValue(view, homeSections);
-            d.mergeContinueWatchingNextUp = view.querySelector('#DefaultMergeContinueWatchingNextUp').checked;
+            d.mergeContinueWatchingNextUp = getNullableBoolSelect(view, '#DefaultMergeContinueWatchingNextUp');
             d.nextUpMaxDays = getNullableIntInput(view, '#DefaultNextUpMaxDays');
 
-            d.showShuffleButton = view.querySelector('#DefaultShowShuffleButton').checked;
-            d.showGenresButton = view.querySelector('#DefaultShowGenresButton').checked;
-            d.showFavoritesButton = view.querySelector('#DefaultShowFavoritesButton').checked;
+            d.enableMultiServerLibraries = getNullableBoolSelect(view, '#DefaultEnableMultiServerLibraries');
+            d.mergeRecentRowsByType = getNullableBoolSelect(view, '#DefaultMergeRecentRowsByType');
+            d.groupItemsIntoCollections = getNullableBoolSelect(view, '#DefaultGroupItemsIntoCollections');
+            d.showMediaDetailsOnLibraryPage = getNullableBoolSelect(view, '#DefaultShowMediaDetailsOnLibraryPage');
+            d.useDetailedSubHeadings = getNullableBoolSelect(view, '#DefaultUseDetailedSubHeadings');
+            d.hideBackdropsInLibraries = getNullableBoolSelect(view, '#DefaultHideBackdropsInLibraries');
+
+            d.showShuffleButton = getNullableBoolSelect(view, '#DefaultShowShuffleButton');
+            d.showGenresButton = getNullableBoolSelect(view, '#DefaultShowGenresButton');
+            d.showFavoritesButton = getNullableBoolSelect(view, '#DefaultShowFavoritesButton');
             d.showCastButton = view.querySelector('#DefaultShowCastButton').checked;
             d.showSyncPlayButton = view.querySelector('#DefaultShowSyncPlayButton').checked;
-            d.showLibrariesInToolbar = view.querySelector('#DefaultShowLibrariesInToolbar').checked;
+            d.showLibrariesInToolbar = getNullableBoolSelect(view, '#DefaultShowLibrariesInToolbar');
 
             d.mediaBarTrailerPreview = getNullableBoolSelect(view, '#DefaultMediaBarTrailerPreview');
             d.episodePreviewEnabled = getNullableBoolSelect(view, '#DefaultEpisodePreviewEnabled');
@@ -1576,6 +1867,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.mdblistShowRatingBadges = getNullableBoolSelect(view, '#DefaultMdblistShowRatingBadges');
             d.mdblistRatingSources = getRatingSourcesValue(view);
             d.seerrBlockNsfw = getNullableBoolSelect(view, '#DefaultSeerrBlockNsfw');
+            var seerrVal = getSeerrDiscoveryValue(view);
+            d.seerrRowOrder = seerrVal.order;
+            d.hiddenSeerrRows = seerrVal.hidden;
 
             config.DefaultUserSettings = d;
 
@@ -1679,12 +1973,39 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         });
     }
 
+    function initializeDefaultsSubtabs(view) {
+        var subnav = view.querySelector('.defaultsSubnavBar');
+        if (!subnav || subnav.dataset.bound) return;
+        subnav.dataset.bound = 'true';
+
+        subnav.addEventListener('click', function (e) {
+            var btn = e.target.closest('.defaultsSubtabBtn');
+            if (!btn) return;
+            var subtab = btn.dataset.subtab;
+            if (!subtab) return;
+
+            var buttons = subnav.querySelectorAll('.defaultsSubtabBtn');
+            buttons.forEach(function (b) { b.classList.remove('active'); });
+            btn.classList.add('active');
+
+            var panels = view.querySelectorAll('.defaultsSubtabPanel');
+            panels.forEach(function (p) {
+                if (p.dataset.subtab === subtab) {
+                    p.classList.add('active');
+                } else {
+                    p.classList.remove('active');
+                }
+            });
+        });
+    }
+
     function bindOnce(view) {
         if (view.__moonfinBound) return;
         view.__moonfinBound = true;
         view.__moonfinState = { timer: null };
 
         initializeAdminTabs(view);
+        initializeDefaultsSubtabs(view);
 
         var form = view.querySelector('#MoonfinConfigForm');
         if (form) {

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -559,6 +559,36 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
 
 
+    function loadAdminGenrePicker(view, selectedIds) {
+        var picker = view.querySelector('#DefaultGenrePicker');
+        if (!picker) return;
+        picker.innerHTML = '<div style="padding:8px;color:rgba(128,128,128,0.5);font-size:0.9em;">Loading...</div>';
+        var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+        fetch(serverUrl + '/Moonfin/Genres', { method: 'GET', headers: moonfinAuthHeaders() })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                var genres = data.Items || data.items || [];
+                if (genres.length === 0) {
+                    picker.innerHTML = '<div style="padding:8px;color:rgba(128,128,128,0.5);font-size:0.9em;">No genres found.</div>';
+                    return;
+                }
+                var html = '';
+                for (var i = 0; i < genres.length; i++) {
+                    var g = genres[i];
+                    var gId = g.id || g.Id;
+                    var gName = g.name || g.Name;
+                    var isChecked = selectedIds.indexOf(gId) !== -1;
+                    html += '<label style="display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:4px;cursor:pointer;' + (isChecked ? 'background:rgba(0,164,220,0.1);' : '') + '">' +
+                        '<input type="checkbox" class="adminGenreCb" data-id="' + esc(gId) + '"' + (isChecked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;">' +
+                        '<div style="flex:1;min-width:0;"><div style="font-size:0.9em;color:rgba(128,128,128,0.9);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + esc(gName) + '</div></div></label>';
+                }
+                picker.innerHTML = html;
+            })
+            .catch(function () {
+                picker.innerHTML = '<div style="padding:8px;color:rgba(128,128,128,0.5);font-size:0.9em;">Failed to load genres.</div>';
+            });
+    }
+
     function loadRatingSourcesPicker(view, selectedIds) {
         var container = view.querySelector('#DefaultMdblistRatingSourcesList');
         if (!container) return;
@@ -613,10 +643,14 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         return result.length > 0 ? result : null;
     }
 
+    // Same ids and declaration order as DetailButton in Core, so an untouched
+    // arrangement here matches what a fresh client shows.
     var DETAIL_BUTTONS = [
+        { id: 'seerrRequest', label: 'Request' },
+        { id: 'seerrRequest4k', label: 'Request 4K' },
         { id: 'shuffle', label: 'Shuffle' },
-        { id: 'restart', label: 'Restart' },
-        { id: 'playOffline', label: 'Play Offline' },
+        { id: 'restart', label: 'Restart', canHide: false },
+        { id: 'playOffline', label: 'Play Offline', canHide: false },
         { id: 'audio', label: 'Audio' },
         { id: 'subtitles', label: 'Subtitles' },
         { id: 'version', label: 'Version' },
@@ -629,6 +663,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { id: 'download', label: 'Download' },
         { id: 'deleteFiles', label: 'Delete files' },
         { id: 'goToSeries', label: 'Go to series' },
+        { id: 'seerrWatchlist', label: 'Watchlist' },
+        { id: 'seerrReportIssue', label: 'Report Issue' },
+        { id: 'seerrManage', label: 'Manage Requests' },
         { id: 'admin', label: 'Admin' }
     ];
 
@@ -643,11 +680,21 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         var ordered = [];
         var addedSet = {};
 
+        function entryFor(btn) {
+            var hideable = btn.canHide !== false;
+            return {
+                id: btn.id,
+                label: btn.label,
+                hideable: hideable,
+                checked: hideable ? !hiddenSet[btn.id] : true
+            };
+        }
+
         if (order && Array.isArray(order) && order.length > 0) {
             order.forEach(function (id) {
                 var btn = DETAIL_BUTTONS.find(function (b) { return b.id === id; });
                 if (btn) {
-                    ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                    ordered.push(entryFor(btn));
                     addedSet[btn.id] = true;
                 }
             });
@@ -655,7 +702,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
         DETAIL_BUTTONS.forEach(function (btn) {
             if (!addedSet[btn.id]) {
-                ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                ordered.push(entryFor(btn));
             }
         });
 
@@ -666,7 +713,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             row.dataset.id = item.id;
             row.style.cssText = 'display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:4px;margin-bottom:2px;background:rgba(128,128,128,0.03);';
             row.innerHTML =
-                '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">' +
+                (item.hideable
+                    ? '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">'
+                    : '<span title="Always shown" style="width:16px;height:16px;flex-shrink:0;text-align:center;color:rgba(128,128,128,0.35);">&#x2713;</span>') +
                 '<span style="flex:1;font-size:0.9em;color:rgba(128,128,128,0.9);">' + esc(item.label) + '</span>' +
                 '<button type="button" class="detailButtonMoveBtn" data-dir="up" style="background:none;border:1px solid rgba(128,128,128,0.2);border-radius:3px;color:rgba(128,128,128,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2191;</button>' +
                 '<button type="button" class="detailButtonMoveBtn" data-dir="down" style="background:none;border:1px solid rgba(128,128,128,0.2);border-radius:3px;color:rgba(128,128,128,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2193;</button>';
@@ -779,22 +828,30 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         }
     }
 
-    function getSeerrDiscoveryValue(view) {
+    // Clients carry Seerr rows as seerrRows.rowOrder, which lists the visible rows in
+    // order and treats every row it leaves out as switched off.
+    function getSeerrDiscoveryRowOrder(view) {
         var items = view.querySelectorAll('#DefaultSeerrDiscoveryList .seerrDiscoveryItem');
-        var order = [];
-        var hidden = [];
+        var rowOrder = [];
         items.forEach(function (item) {
             var cb = item.querySelector('input[type=checkbox]');
-            var id = item.dataset.id;
-            order.push(id);
-            if (cb && !cb.checked) {
-                hidden.push(id);
+            if (!cb || cb.checked) {
+                rowOrder.push(item.dataset.id);
             }
         });
-        return {
-            order: order.length > 0 ? order : null,
-            hidden: hidden.length > 0 ? hidden : null
-        };
+        return rowOrder.length > 0 ? rowOrder : null;
+    }
+
+    // Turns a stored rowOrder back into the picker's order plus hidden pair.
+    function seerrRowsToPicker(seerrRows) {
+        var rowOrder = seerrRows && Array.isArray(seerrRows.rowOrder) ? seerrRows.rowOrder : null;
+        if (!rowOrder || rowOrder.length === 0) return { order: null, hidden: null };
+        var visible = {};
+        rowOrder.forEach(function (id) { visible[id] = true; });
+        var hidden = SEERR_DISCOVERY_ROWS
+            .filter(function (row) { return !visible[row.id]; })
+            .map(function (row) { return row.id; });
+        return { order: rowOrder, hidden: hidden.length > 0 ? hidden : null };
     }
 
     // ── Home layout builder ─────────────────────────────────────────────────
@@ -1643,7 +1700,10 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setNullableBoolSelect(view, '#DefaultDetailShowTechnicalDetails', defaults.detailShowTechnicalDetails);
             setSelectValue(view, '#DefaultRecommendationSystemSource', defaults.recommendationSystemSource, 'Configured source');
             setNullableBoolSelect(view, '#DefaultRecommendationsApplyParentalRatingCap', defaults.recommendationsApplyParentalRatingCap);
-            loadDetailButtonsPicker(view, defaults.detailButtonOrder || null, defaults.hiddenDetailButtons || null);
+            // One picker stands in for all three form factors.
+            loadDetailButtonsPicker(view,
+                defaults.detailButtonOrderTv || defaults.detailButtonOrderMobile || defaults.detailButtonOrderDesktop || null,
+                defaults.hiddenDetailButtonsTv || defaults.hiddenDetailButtonsMobile || defaults.hiddenDetailButtonsDesktop || null);
             setSelectValue(view, '#DefaultFocusColor', defaults.focusColor, 'Configured color');
             setSelectValue(view, '#DefaultClockBehavior', defaults.clockBehavior, 'Configured clock');
             setNullableBoolSelect(view, '#DefaultUse24HourClock', defaults.use24HourClock);
@@ -1671,6 +1731,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setNullableBoolSelect(view, '#DefaultShowSeerrButton', defaults.showSeerrButton);
 
             setSelectValue(view, '#DefaultMediaBarSourceType', defaults.mediaBarSourceType, 'Configured source');
+            loadAdminGenrePicker(view, defaults.mediaBarExcludedGenres || []);
             setSelectValue(view, '#DefaultMediaBarMode', defaults.mediaBarMode, 'Configured mode');
             setSelectValue(view, '#DefaultMediaBarContentType', defaults.mediaBarContentType, 'Configured content type');
             setSelectValue(view, '#DefaultMediaBarItemCount', defaults.mediaBarItemCount, 'Configured item count');
@@ -1691,6 +1752,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             bindNullableRangeInput(view, '#DefaultModernHomeRowsPadding', 'px');
             setNullableRangeInput(view, '#DefaultModernHomeRowsPadding', defaults.modernHomeRowsPadding, 'px');
             setSelectValue(view, '#DefaultPosterSize', defaults.posterSize, 'Configured size');
+            setSelectValue(view, '#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
             setNullableBoolSelect(view, '#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
             setNullableBoolSelect(view, '#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
             setNullableBoolSelect(view, '#DefaultDisplayGenresRows', defaults.displayGenresRows);
@@ -1724,7 +1786,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setNullableBoolSelect(view, '#DefaultMdblistShowRatingBadges', defaults.mdblistShowRatingBadges);
             loadRatingSourcesPicker(view, defaults.mdblistRatingSources || null);
             setNullableBoolSelect(view, '#DefaultSeerrBlockNsfw', defaults.seerrBlockNsfw);
-            loadSeerrDiscoveryPicker(view, defaults.seerrRowOrder || null, defaults.hiddenSeerrRows || null);
+            var seerrPicker = seerrRowsToPicker(defaults.seerrRows);
+            loadSeerrDiscoveryPicker(view, seerrPicker.order, seerrPicker.hidden);
 
             var sourceSelect = view.querySelector('#DefaultMediaBarSourceType');
             var collectionPickerSection = view.querySelector('#DefaultCollectionPickerSection');
@@ -1780,8 +1843,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.recommendationSystemSource = view.querySelector('#DefaultRecommendationSystemSource').value || null;
             d.recommendationsApplyParentalRatingCap = getNullableBoolSelect(view, '#DefaultRecommendationsApplyParentalRatingCap');
             var btnVal = getDetailButtonsValue(view);
-            d.detailButtonOrder = btnVal.order;
-            d.hiddenDetailButtons = btnVal.hidden;
+            // Clients read a different key per form factor, so one arrangement covers all three.
+            d.detailButtonOrderTv = btnVal.order;
+            d.detailButtonOrderMobile = btnVal.order;
+            d.detailButtonOrderDesktop = btnVal.order;
+            d.hiddenDetailButtonsTv = btnVal.hidden;
+            d.hiddenDetailButtonsMobile = btnVal.hidden;
+            d.hiddenDetailButtonsDesktop = btnVal.hidden;
             d.focusColor = view.querySelector('#DefaultFocusColor').value || null;
             d.clockBehavior = view.querySelector('#DefaultClockBehavior').value || null;
             d.use24HourClock = getNullableBoolSelect(view, '#DefaultUse24HourClock');
@@ -1805,6 +1873,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.showSeerrButton = getNullableBoolSelect(view, '#DefaultShowSeerrButton');
 
             d.mediaBarSourceType = view.querySelector('#DefaultMediaBarSourceType').value || null;
+            var genreIds = Array.prototype.slice.call(view.querySelectorAll('.adminGenreCb:checked')).map(function (cb) { return cb.dataset.id; });
+            d.mediaBarExcludedGenres = genreIds.length > 0 ? genreIds : null;
             d.mediaBarMode = view.querySelector('#DefaultMediaBarMode').value || null;
             d.mediaBarContentType = view.querySelector('#DefaultMediaBarContentType').value || null;
             d.mediaBarItemCount = getNullableIntInput(view, '#DefaultMediaBarItemCount');
@@ -1828,6 +1898,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.classicHomeRowsPadding = getNullableIntInput(view, '#DefaultClassicHomeRowsPadding');
             d.modernHomeRowsPadding = getNullableIntInput(view, '#DefaultModernHomeRowsPadding');
             d.posterSize = view.querySelector('#DefaultPosterSize').value || null;
+            d.homeImageTypeContinueWatching = view.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
             d.displayFavoritesRows = getNullableBoolSelect(view, '#DefaultDisplayFavoritesRows');
             d.displayCollectionsRows = getNullableBoolSelect(view, '#DefaultDisplayCollectionsRows');
             d.displayGenresRows = getNullableBoolSelect(view, '#DefaultDisplayGenresRows');
@@ -1867,9 +1938,10 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.mdblistShowRatingBadges = getNullableBoolSelect(view, '#DefaultMdblistShowRatingBadges');
             d.mdblistRatingSources = getRatingSourcesValue(view);
             d.seerrBlockNsfw = getNullableBoolSelect(view, '#DefaultSeerrBlockNsfw');
-            var seerrVal = getSeerrDiscoveryValue(view);
-            d.seerrRowOrder = seerrVal.order;
-            d.hiddenSeerrRows = seerrVal.hidden;
+            // seerrRows carries more than the ordering, so merge rather than replace.
+            var seerrRows = Object.assign({}, d.seerrRows || {});
+            seerrRows.rowOrder = getSeerrDiscoveryRowOrder(view);
+            d.seerrRows = seerrRows;
 
             config.DefaultUserSettings = d;
 

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -77,6 +77,9 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("navbarAlwaysExpanded")]
     public bool? NavbarAlwaysExpanded { get; set; }
 
+    [JsonPropertyName("mediaBarTrailerCaptions")]
+    public bool? MediaBarTrailerCaptions { get; set; }
+
     [JsonPropertyName("focusColor")]
     public string? FocusColor { get; set; }
 
@@ -97,6 +100,18 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("cardFocusExpansion")]
     public bool? CardFocusExpansion { get; set; }
+
+    [JsonPropertyName("detailButtonOrder")]
+    public List<string>? DetailButtonOrder { get; set; }
+
+    [JsonPropertyName("hiddenDetailButtons")]
+    public List<string>? HiddenDetailButtons { get; set; }
+
+    [JsonPropertyName("seerrRowOrder")]
+    public List<string>? SeerrRowOrder { get; set; }
+
+    [JsonPropertyName("hiddenSeerrRows")]
+    public List<string>? HiddenSeerrRows { get; set; }
 
     [JsonPropertyName("showShuffleButton")]
     public bool? ShowShuffleButton { get; set; }
@@ -127,6 +142,9 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("enableMultiServerLibraries")]
     public bool? EnableMultiServerLibraries { get; set; }
+
+    [JsonPropertyName("mergeRecentRowsByType")]
+    public bool? MergeRecentRowsByType { get; set; }
 
     [JsonPropertyName("enableFolderView")]
     public bool? EnableFolderView { get; set; }

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -104,18 +104,6 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("cardFocusExpansion")]
     public bool? CardFocusExpansion { get; set; }
 
-    [JsonPropertyName("detailButtonOrder")]
-    public List<string>? DetailButtonOrder { get; set; }
-
-    [JsonPropertyName("hiddenDetailButtons")]
-    public List<string>? HiddenDetailButtons { get; set; }
-
-    [JsonPropertyName("seerrRowOrder")]
-    public List<string>? SeerrRowOrder { get; set; }
-
-    [JsonPropertyName("hiddenSeerrRows")]
-    public List<string>? HiddenSeerrRows { get; set; }
-
     [JsonPropertyName("showShuffleButton")]
     public bool? ShowShuffleButton { get; set; }
 
@@ -145,9 +133,6 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("enableMultiServerLibraries")]
     public bool? EnableMultiServerLibraries { get; set; }
-
-    [JsonPropertyName("mergeRecentRowsByType")]
-    public bool? MergeRecentRowsByType { get; set; }
 
     [JsonPropertyName("enableFolderView")]
     public bool? EnableFolderView { get; set; }

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -21,6 +21,49 @@
                 max-width: none;
             }
 
+            #MoonfinConfigPage .defaultsSubnavBar {
+                display: flex;
+                gap: 8px;
+                flex-wrap: wrap;
+                margin-top: 1em;
+                margin-bottom: 1.5em;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+                padding-bottom: 12px;
+            }
+
+            #MoonfinConfigPage .defaultsSubtabBtn {
+                background: rgba(255, 255, 255, 0.06);
+                border: 1px solid rgba(255, 255, 255, 0.12);
+                color: rgba(255, 255, 255, 0.75);
+                border-radius: 20px;
+                padding: 6px 16px;
+                font-size: 0.9em;
+                font-weight: 500;
+                cursor: pointer;
+                transition: all 0.2s ease;
+            }
+
+            #MoonfinConfigPage .defaultsSubtabBtn:hover {
+                background: rgba(255, 255, 255, 0.12);
+                color: #fff;
+            }
+
+            #MoonfinConfigPage .defaultsSubtabBtn.active {
+                background: #00a4dc;
+                border-color: #00a4dc;
+                color: #fff;
+                font-weight: 600;
+                box-shadow: 0 2px 8px rgba(0, 164, 220, 0.4);
+            }
+
+            #MoonfinConfigPage .defaultsSubtabPanel {
+                display: none;
+            }
+
+            #MoonfinConfigPage .defaultsSubtabPanel.active {
+                display: block;
+            }
+
             #MoonfinConfigPage .moonfinAdminShell {
                 display: flex;
                 gap: 18px;
@@ -667,479 +710,681 @@
                             <strong>Not set</strong> means "do not force this value" so users keep their own choice.
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Appearance</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultVisualTheme">App Theme</label>
-                            <select id="DefaultVisualTheme" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="moonfin">Moonfin</option>
-                                <option value="neonPulse">Neon Pulse</option>
-                                <option value="glass">Glass</option>
-                                <option value="eightbitHero">8-bit Hero</option>
-                            </select>
-                            <div class="fieldDescription">Default overall app style. Keep Not set to let users choose.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDetailScreenStyle">Detail Screen Style</label>
-                            <select id="DefaultDetailScreenStyle" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="classic">Classic</option>
-                                <option value="modern">Modern</option>
-                            </select>
-                            <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDetailExpandedTabs">Detail Screen Expanded Tabs</label>
-                            <select id="DefaultDetailExpandedTabs" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                            <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals their content without pressing select. When off, tabs start collapsed and open on press. Keep Not set to let users choose.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultFocusColor">Focus Highlight Color</label>
-                            <select id="DefaultFocusColor" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="white">White</option>
-                                <option value="black">Black</option>
-                                <option value="gray">Gray</option>
-                                <option value="darkBlue">Dark Blue</option>
-                                <option value="purple">Purple</option>
-                                <option value="teal">Teal</option>
-                                <option value="navy">Navy</option>
-                                <option value="charcoal">Charcoal</option>
-                                <option value="brown">Brown</option>
-                                <option value="darkRed">Dark Red</option>
-                                <option value="darkGreen">Dark Green</option>
-                                <option value="slate">Slate</option>
-                                <option value="indigo">Indigo</option>
-                                <option value="moonfinCyan">Moonfin Cyan</option>
-                                <option value="neonPulseMagenta">Neon Pulse Magenta</option>
-                                <option value="eightBitGold">8-bit Gold</option>
-                            </select>
-                            <div class="fieldDescription">Color used for focused cards and controls.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultBrowsingBlur">Browsing Blur</label>
-                            <input type="number" id="DefaultBrowsingBlur" is="emby-input" min="0" max="100" step="1" placeholder="Not set" />
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Detail Screen Blur</label>
-                            <input type="number" id="DefaultDetailsScreenBlur" is="emby-input" min="0" max="100" step="1" placeholder="Not set" />
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicEnabled">Enable Theme Music</label>
-                            <select id="DefaultThemeMusicEnabled" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultWatchedIndicator">Watched Indicator</label>
-                            <select id="DefaultWatchedIndicator" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="always">Always</option>
-                                <option value="hideUnwatched">Hide Unwatched</option>
-                                <option value="episodesOnly">Episodes Only</option>
-                                <option value="never">Never</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultCardFocusExpansion">Scale Focused Cards</label>
-                            <select id="DefaultCardFocusExpansion" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultScreensaverMode">Screensaver Mode</label>
-                            <select id="DefaultScreensaverMode" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="off">Off</option>
-                                <option value="logo">Logo</option>
-                                <option value="library">Library</option>
-                            </select>
-                        </div>
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Navigation</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarPosition">Default Navbar Position</label>
-                            <select id="DefaultNavbarPosition" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="top">Top</option>
-                                <option value="left">Left (Sidebar)</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarColor">Navigation Bar Accent Color</label>
-                            <select id="DefaultNavbarColor" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="white">White</option>
-                                <option value="black">Black</option>
-                                <option value="gray">Gray</option>
-                                <option value="darkBlue">Dark Blue</option>
-                                <option value="purple">Purple</option>
-                                <option value="teal">Teal</option>
-                                <option value="navy">Navy</option>
-                                <option value="charcoal">Charcoal</option>
-                                <option value="brown">Brown</option>
-                                <option value="darkRed">Dark Red</option>
-                                <option value="darkGreen">Dark Green</option>
-                                <option value="slate">Slate</option>
-                                <option value="indigo">Indigo</option>
-                                <option value="moonfinCyan">Moonfin Cyan</option>
-                                <option value="neonPulseMagenta">Neon Pulse Magenta</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarOpacity">Navigation Bar Opacity (0-100)</label>
-                            <input type="number" id="DefaultNavbarOpacity" is="emby-input" min="0" max="100" step="1" placeholder="Not set" />
+                        <div class="defaultsSubnavBar">
+                            <button type="button" class="defaultsSubtabBtn active" data-subtab="general-style">General Style</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="details-screen">Details Screen</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="navigation">Navigation</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="home-screen">Home Screen</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="home-sections">Home Sections</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="libraries">Libraries</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="extras">Extras</button>
+                            <button type="button" class="defaultsSubtabBtn" data-subtab="integrations">Integrations</button>
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Media Bar</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarSourceType">Media Bar Content Source</label>
-                            <select id="DefaultMediaBarSourceType" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="library">Library (Random)</option>
-                                <option value="collection">Collections / Playlists</option>
-                            </select>
-                            <div class="fieldDescription">Default content source for the media bar. Users can override this.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarMode">Media Bar Style</label>
-                            <select id="DefaultMediaBarMode" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="moonfin">Moonfin</option>
-                                <option value="makd">MA KD</option>
-                                <option value="bookshelf">Bookshelf</option>
-                                <option value="gallery">Gallery</option>
-                                <option value="banner">Banner</option>
-                                <option value="off">Off</option>
-                            </select>
-                            <div class="fieldDescription">Visual style/mode for the media bar.</div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerPreview">Trailer In Media Bar</label>
-                            <select id="DefaultMediaBarTrailerPreview" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerAudio">Trailer Audio In Media Bar</label>
-                            <select id="DefaultMediaBarTrailerAudio" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div id="DefaultCollectionPickerSection" style="display:none;">
+                        <!-- 1. General Style -->
+                        <div class="defaultsSubtabPanel active" data-subtab="general-style">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Theme</h4>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused">Default Collections / Playlists</label>
-                                <div class="fieldDescription" style="margin-bottom:0.5em;">Select which collections or playlists to show in the media bar by default. Users can override this in their own settings. Note: users who don't have access to a selected collection will simply not see those items.</div>
-                                <div id="DefaultCollectionPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultInterfaceStyle">Interface Style</label>
+                                <select id="DefaultInterfaceStyle" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="automatic">Automatic</option>
+                                    <option value="apple">Apple</option>
+                                    <option value="material">Material</option>
+                                </select>
+                                <div class="fieldDescription">Automatic adapts to your device. Choose Apple or Material to lock the look.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultVisualTheme">App Theme</label>
+                                <select id="DefaultVisualTheme" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="moonfin">Moonfin</option>
+                                    <option value="neonPulse">Neon Pulse</option>
+                                    <option value="glass">Glass</option>
+                                    <option value="eightbitHero">8-bit Hero</option>
+                                </select>
+                                <div class="fieldDescription">Default overall app style. Keep Not set to let users choose.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFocusColor">Focus Border Color</label>
+                                <select id="DefaultFocusColor" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="white">White</option>
+                                    <option value="black">Black</option>
+                                    <option value="gray">Gray</option>
+                                    <option value="darkBlue">Dark Blue</option>
+                                    <option value="purple">Purple</option>
+                                    <option value="teal">Teal</option>
+                                    <option value="navy">Navy</option>
+                                    <option value="charcoal">Charcoal</option>
+                                    <option value="brown">Brown</option>
+                                    <option value="darkRed">Dark Red</option>
+                                    <option value="darkGreen">Dark Green</option>
+                                    <option value="slate">Slate</option>
+                                    <option value="indigo">Indigo</option>
+                                    <option value="moonfinCyan">Moonfin Cyan</option>
+                                    <option value="neonPulseMagenta">Neon Pulse Magenta</option>
+                                    <option value="eightBitGold">8-bit Gold</option>
+                                </select>
+                                <div class="fieldDescription">Color used for focused cards and controls.</div>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Clock</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultClockBehavior">Clock Display</label>
+                                <select id="DefaultClockBehavior" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="always">Always</option>
+                                    <option value="inMenus">In menus</option>
+                                    <option value="never">Never</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultUse24HourClock">24-Hour Clock</label>
+                                <select id="DefaultUse24HourClock" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Display</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultCardFocusExpansion">Focus Expansion Animation</label>
+                                <select id="DefaultCardFocusExpansion" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDesktopUiScale">UI Scaling</label>
+                                <select id="DefaultDesktopUiScale" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="small">Small</option>
+                                    <option value="medium">Medium</option>
+                                    <option value="large">Large</option>
+                                    <option value="extraLarge">Extra Large</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultBackdropEnabled">Background Backdrops</label>
+                                <select id="DefaultBackdropEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultBrowsingBlur">Browsing Background Blur</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultBrowsingBlur_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultBrowsingBlur" min="0" max="25" step="1" value="0" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultBrowsingBlur_Val" style="font-weight: 600; min-width: 32px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultWatchedIndicator">Watched Indicators</label>
+                                <select id="DefaultWatchedIndicator" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="always">Always</option>
+                                    <option value="hideUnwatched">Hide Unwatched</option>
+                                    <option value="episodesOnly">Episodes Only</option>
+                                    <option value="never">Never</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultScreensaverMode">Screensaver Mode (TV clients only)</label>
+                                <select id="DefaultScreensaverMode" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="off">Off</option>
+                                    <option value="logo">Logo</option>
+                                    <option value="library">Library</option>
+                                </select>
                             </div>
                         </div>
-                        <div id="DefaultLibraryPickerSection" style="display:none;">
+
+                        <!-- 2. Details Screen -->
+                        <div class="defaultsSubtabPanel" data-subtab="details-screen">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Details Screen</h4>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused">Default Libraries</label>
-                                <div class="fieldDescription" style="margin-bottom:0.5em;">Optionally select specific libraries for the media bar. Leave all unchecked to use all libraries. Users can override this.</div>
-                                <div id="DefaultLibraryPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailScreenStyle">Detail screen style</label>
+                                <select id="DefaultDetailScreenStyle" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="classic">Classic</option>
+                                    <option value="modern">Modern</option>
+                                </select>
+                                <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Details Background Opacity</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultDetailsScreenBlur_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultDetailsScreenBlur" min="0" max="25" step="1" value="0" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultDetailsScreenBlur_Val" style="font-weight: 600; min-width: 32px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailExpandedTabs">Expanded Tabs</label>
+                                <select id="DefaultDetailExpandedTabs" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals content without pressing select.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailShowTechnicalDetails">Show Technical Details?</label>
+                                <select id="DefaultDetailShowTechnicalDetails" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRecommendationSystemSource">Recommendation System</label>
+                                <select id="DefaultRecommendationSystemSource" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="local">Moonfin</option>
+                                    <option value="online">TMDB</option>
+                                </select>
+                                <div class="fieldDescription">Source used for recommended and similar media on detail pages.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRecommendationsApplyParentalRatingCap">Apply Parental Rating Cap?</label>
+                                <select id="DefaultRecommendationsApplyParentalRatingCap" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Filter recommendations to not exceed the current item's age rating.</div>
+                            </div>
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Action Buttons</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Default Action Buttons &amp; Order</label>
+                                <div class="fieldDescription">Check which action buttons to show on detail pages and use the arrows to set their order.</div>
+                                <div id="DefaultDetailButtonsList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
                             </div>
                         </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused">Default Excluded Genres</label>
-                            <div class="fieldDescription" style="margin-bottom:0.5em;">Select genres to exclude from the media bar by default. Items with any of these genres will not appear. Users can override this.</div>
-                            <div id="DefaultGenrePicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
-                        </div>
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Settings</h4>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultHomeRowsStyle">Home Rows Style</label>
-                                    <select id="DefaultHomeRowsStyle" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="v1">Classic</option>
-                                        <option value="v2">Modern</option>
+
+                        <!-- 3. Navigation -->
+                        <div class="defaultsSubtabPanel" data-subtab="navigation">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Appearance</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarPosition">Navigation Style</label>
+                                <select id="DefaultNavbarPosition" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="top">Top</option>
+                                    <option value="left">Left (Sidebar)</option>
+                                    <option value="bottom">Bottom</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarColor">Navbar Color</label>
+                                <select id="DefaultNavbarColor" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="white">White</option>
+                                    <option value="black">Black</option>
+                                    <option value="gray">Gray</option>
+                                    <option value="darkBlue">Dark Blue</option>
+                                    <option value="purple">Purple</option>
+                                    <option value="teal">Teal</option>
+                                    <option value="navy">Navy</option>
+                                    <option value="charcoal">Charcoal</option>
+                                    <option value="brown">Brown</option>
+                                    <option value="darkRed">Dark Red</option>
+                                    <option value="darkGreen">Dark Green</option>
+                                    <option value="slate">Slate</option>
+                                    <option value="indigo">Indigo</option>
+                                    <option value="moonfinCyan">Moonfin Cyan</option>
+                                    <option value="neonPulseMagenta">Neon Pulse Magenta</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarOpacity">Navbar Opacity</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultNavbarOpacity_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
                                     </select>
+                                    <input type="range" id="DefaultNavbarOpacity" min="0" max="100" step="5" value="100" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultNavbarOpacity_Val" style="font-weight: 600; min-width: 40px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
                                 </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultFullScreenRows">Expanded Rows</label>
-                                    <select id="DefaultFullScreenRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageTypeContinueWatching">Continue Watching Image Type</label>
-                                    <select id="DefaultHomeImageTypeContinueWatching" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="Primary">Poster</option>
-                                        <option value="Backdrop">Backdrop</option>
-                                        <option value="Thumb">Thumbnail</option>
-                                        <option value="Banner">Banner</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultPosterSize">Card Size</label>
-                                    <select id="DefaultPosterSize" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="small">Small</option>
-                                        <option value="medium">Medium</option>
-                                        <option value="large">Large</option>
-                                        <option value="extraLarge">Extra Large</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicOnHomeRows">Play Theme Music on Home Rows</label>
-                                    <select id="DefaultThemeMusicOnHomeRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayFavoritesRows">Show Favorites Rows</label>
-                                    <select id="DefaultDisplayFavoritesRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayCollectionsRows">Show Collections Rows</label>
-                                    <select id="DefaultDisplayCollectionsRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayGenresRows">Show Genres Rows</label>
-                                    <select id="DefaultDisplayGenresRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayPlaylistsRows">Show Playlist Rows</label>
-                                    <select id="DefaultDisplayPlaylistsRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayAudioRows">Show Audio Rows</label>
-                                    <select id="DefaultDisplayAudioRows" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultFavoritesRowSortBy">Favorites Row Sort</label>
-                                    <select id="DefaultFavoritesRowSortBy" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="name">Name</option>
-                                        <option value="dateAdded">Date Added</option>
-                                        <option value="premiereDate">Premiere Date</option>
-                                        <option value="rating">Rating</option>
-                                        <option value="runtime">Runtime</option>
-                                        <option value="random">Random</option>
-                                        <option value="criticRating">Critic Rating</option>
-                                        <option value="communityRating">Community Rating</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultCollectionsRowSortBy">Collections Row Sort</label>
-                                    <select id="DefaultCollectionsRowSortBy" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="name">Name</option>
-                                        <option value="dateAdded">Date Added</option>
-                                        <option value="premiereDate">Premiere Date</option>
-                                        <option value="rating">Rating</option>
-                                        <option value="runtime">Runtime</option>
-                                        <option value="random">Random</option>
-                                        <option value="criticRating">Critic Rating</option>
-                                        <option value="communityRating">Community Rating</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultGenresRowSortBy">Genres Row Sort</label>
-                                    <select id="DefaultGenresRowSortBy" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="name">Name</option>
-                                        <option value="dateAdded">Date Added</option>
-                                        <option value="premiereDate">Premiere Date</option>
-                                        <option value="rating">Rating</option>
-                                        <option value="runtime">Runtime</option>
-                                        <option value="random">Random</option>
-                                        <option value="criticRating">Critic Rating</option>
-                                        <option value="communityRating">Community Rating</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultGenresRowItemFilter">Genres Row Item Filter</label>
-                                    <select id="DefaultGenresRowItemFilter" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="movies">Movies</option>
-                                        <option value="series">Series</option>
-                                        <option value="both">Both</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageUseSeriesImage">Series Thumbnails</label>
-                                    <select id="DefaultHomeImageUseSeriesImage" is="emby-select">
-                                        <option value="">Not set (user decides)</option>
-                                        <option value="true">Yes</option>
-                                        <option value="false">No</option>
-                                    </select>
-                                    <div class="fieldDescription">Use series thumbnails on home rows by default.</div>
-                                </div>
-                                <div class="checkboxContainer checkboxContainer-withDescription">
-                                    <label class="emby-checkbox-label">
-                                        <input type="checkbox" id="DefaultMergeContinueWatchingNextUp" is="emby-checkbox" />
-                                        <span>Merge Continue Watching &amp; Next Up</span>
-                                    </label>
-                                    <div class="fieldDescription">Combine Continue Watching and Next Up into a single home row by default.</div>
-                                </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="DefaultNextUpMaxDays">Max Days In Next Up</label>
-                                    <input type="number" id="DefaultNextUpMaxDays" is="emby-input" min="0" max="3650" step="1" placeholder="Not set" />
-                                    <div class="fieldDescription">How long a show stays in Next Up after it was last watched. Use 0 for no limit. Leaving this empty lets the client decide.</div>
-                                </div>
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Layout</h4>
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused">Default Home Layout</label>
-                                    <div class="fieldDescription" style="margin-bottom:0.75em;">Choose active default home sections and their order. This builder only changes the layout; row visibility and sorting stay in Home Row Settings.</div>
-                                    <div class="homeLayoutBuilder">
-                                        <div class="homeLayoutPanel">
-                                            <h5 class="homeLayoutPanelTitle">Current Layout</h5>
-                                            <div id="DefaultHomeRowOrder" class="homeLayoutList"></div>
-                                        </div>
-                                        <div class="homeLayoutPanel">
-                                            <h5 class="homeLayoutPanelTitle">Available Rows</h5>
-                                            <div id="DefaultHomeAvailableTabs" class="homeLayoutTabs"></div>
-                                            <input id="DefaultHomeAvailableSearch" class="homeLayoutSearch" type="search" placeholder="Search rows" />
-                                            <div id="DefaultHomeAvailableRows" class="homeLayoutList"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Toolbar Buttons</h4>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowShuffleButton" is="emby-checkbox" />
-                                <span>Shuffle Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowGenresButton" is="emby-checkbox" />
-                                <span>Genres Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowFavoritesButton" is="emby-checkbox" />
-                                <span>Favorites Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowCastButton" is="emby-checkbox" />
-                                <span>Cast Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowSyncPlayButton" is="emby-checkbox" />
-                                <span>SyncPlay Button</span>
-                            </label>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultShowLibrariesInToolbar" is="emby-checkbox" />
-                                <span>Library Shortcuts</span>
-                            </label>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Nav Buttons</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowShuffleButton">Show Shuffle Button</label>
+                                <select id="DefaultShowShuffleButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowGenresButton">Show Genres Button</label>
+                                <select id="DefaultShowGenresButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowFavoritesButton">Show Favorites Button</label>
+                                <select id="DefaultShowFavoritesButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowLibrariesInToolbar">Show Libraries in Toolbar</label>
+                                <select id="DefaultShowLibrariesInToolbar" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNavbarAlwaysExpanded">Always Expand Navbar Labels</label>
+                                <select id="DefaultNavbarAlwaysExpanded" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultEnableFolderView">Enable Folder View</label>
+                                <select id="DefaultEnableFolderView" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowSeerrButton">Show Seerr Button</label>
+                                <select id="DefaultShowSeerrButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Previews</h4>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerPreview">Trailer Preview in Media Bar</label>
-                            <select id="DefaultMediaBarTrailerPreview" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultEpisodePreviewEnabled">Episode Previews On Hover</label>
-                            <select id="DefaultEpisodePreviewEnabled" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultPreviewAudioEnabled">Preview Audio</label>
-                            <select id="DefaultPreviewAudioEnabled" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
+                        <!-- 4. Home Screen -->
+                        <div class="defaultsSubtabPanel" data-subtab="home-screen">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Display</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeRowsStyle">Row Type</label>
+                                <select id="DefaultHomeRowsStyle" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="v1">Classic</option>
+                                    <option value="v2">Modern</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMergeContinueWatchingNextUp">Merge Continue Watching and Next Up</label>
+                                <select id="DefaultMergeContinueWatchingNextUp" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Combine Continue Watching and Next Up into a single home row by default.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultNextUpMaxDays">Max days in Next Up</label>
+                                <select id="DefaultNextUpMaxDays" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="0">0 (No limit)</option>
+                                    <option value="30">30 Days</option>
+                                    <option value="90">90 Days</option>
+                                    <option value="180">180 Days</option>
+                                    <option value="365">365 Days (1 Year)</option>
+                                    <option value="730">730 Days (2 Years)</option>
+                                </select>
+                                <div class="fieldDescription">How long a show stays in Next Up after it was last watched.</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageUseSeriesImage">Display Series Thumbnails</label>
+                                <select id="DefaultHomeImageUseSeriesImage" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFullScreenRows">Expanded Home Rows</label>
+                                <select id="DefaultFullScreenRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeRowInfoOverlay">Home Row Info Overlay</label>
+                                <select id="DefaultHomeRowInfoOverlay" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultPosterSize">Home Row Card Display Size</label>
+                                <select id="DefaultPosterSize" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="small">Small</option>
+                                    <option value="medium">Medium</option>
+                                    <option value="large">Large</option>
+                                    <option value="extraLarge">Extra Large</option>
+                                </select>
+                            </div>
                         </div>
 
-                        <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Integrations</h4>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultMdblistEnabled" is="emby-checkbox" />
-                                <span>MDBList Ratings</span>
-                            </label>
-                            <div class="fieldDescription">Enable MDBList ratings by default (requires server-wide or user API key).</div>
+                        <!-- 5. Home Sections -->
+                        <div class="defaultsSubtabPanel" data-subtab="home-sections">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Default Home Layout</h4>
+                            <div class="fieldDescription" style="margin-bottom:0.75em;">Choose active default home sections and their order. This builder configures layout and custom dynamic rows.</div>
+                            <div class="homeLayoutBuilder">
+                                <div class="homeLayoutPanel">
+                                    <h5 class="homeLayoutPanelTitle">Current Layout</h5>
+                                    <div id="DefaultHomeRowOrder" class="homeLayoutList"></div>
+                                </div>
+                                <div class="homeLayoutPanel">
+                                    <h5 class="homeLayoutPanelTitle">Available Rows</h5>
+                                    <div id="DefaultHomeAvailableTabs" class="homeLayoutTabs"></div>
+                                    <input id="DefaultHomeAvailableSearch" class="homeLayoutSearch" type="search" placeholder="Search rows" />
+                                    <div id="DefaultHomeAvailableRows" class="homeLayoutList"></div>
+                                </div>
+                            </div>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="DefaultTmdbEpisodeRatingsEnabled" is="emby-checkbox" />
-                                <span>TMDB Episode Ratings</span>
-                            </label>
-                            <div class="fieldDescription">Enable TMDB episode ratings by default (requires server-wide or user API key).</div>
+
+                        <!-- 6. Libraries -->
+                        <div class="defaultsSubtabPanel" data-subtab="libraries">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">General</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultEnableMultiServerLibraries">Enable Multi-Server Libraries</label>
+                                <select id="DefaultEnableMultiServerLibraries" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMergeRecentRowsByType">Merge Recent Rows by Type</label>
+                                <select id="DefaultMergeRecentRowsByType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Combines recently added media from different libraries of the same type into unified rows.</div>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Library View</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultGroupItemsIntoCollections">Group Items into Collections</label>
+                                <select id="DefaultGroupItemsIntoCollections" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowMediaDetailsOnLibraryPage">Show Media Details</label>
+                                <select id="DefaultShowMediaDetailsOnLibraryPage" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultUseDetailedSubHeadings">Use Detailed Subheadings</label>
+                                <select id="DefaultUseDetailedSubHeadings" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHideBackdropsInLibraries">Hide Backdrops in Libraries</label>
+                                <select id="DefaultHideBackdropsInLibraries" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingBadges">Show MDBList Rating Badges</label>
-                            <select id="DefaultMdblistShowRatingBadges" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
+
+                        <!-- 7. Extras -->
+                        <div class="defaultsSubtabPanel" data-subtab="extras">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Media Bar</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarMode">Media Bar Style</label>
+                                <select id="DefaultMediaBarMode" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="moonfin">Moonfin</option>
+                                    <option value="makd">MakD</option>
+                                    <option value="bookshelf">Bookshelf</option>
+                                    <option value="gallery">Gallery</option>
+                                    <option value="banner">Banner</option>
+                                    <option value="off">Off</option>
+                                </select>
+                            </div>
+                             <div class="inputContainer">
+                                 <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarContentType">Content Type</label>
+                                 <select id="DefaultMediaBarContentType" is="emby-select">
+                                     <option value="">Not set (user decides)</option>
+                                     <option value="both">Movies and TV Shows</option>
+                                     <option value="movies">Movies Only</option>
+                                     <option value="tvshows">TV Shows Only</option>
+                                 </select>
+                             </div>
+                             <div class="inputContainer">
+                                 <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarItemCount">Item Count</label>
+                                 <select id="DefaultMediaBarItemCount" is="emby-select">
+                                     <option value="">Not set (user decides)</option>
+                                     <option value="5">5</option>
+                                     <option value="10">10</option>
+                                     <option value="15">15</option>
+                                     <option value="20">20</option>
+                                     <option value="25">25</option>
+                                     <option value="30">30</option>
+                                 </select>
+                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarSourceType">Media Bar Source</label>
+                                <select id="DefaultMediaBarSourceType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="library">Library (Random)</option>
+                                    <option value="collection">Collections / Playlists</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarAutoAdvance">Auto Advance</label>
+                                <select id="DefaultMediaBarAutoAdvance" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarIntervalMs">Auto Advance Interval</label>
+                                <select id="DefaultMediaBarIntervalMs" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="5000">5 Seconds</option>
+                                    <option value="10000">10 Seconds</option>
+                                    <option value="15000">15 Seconds</option>
+                                    <option value="30000">30 Seconds</option>
+                                </select>
+                            </div>
+                            <div id="DefaultCollectionPickerSection" style="display:none;">
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused">Default Collections / Playlists</label>
+                                    <div id="DefaultCollectionPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
+                                </div>
+                            </div>
+                            <div id="DefaultLibraryPickerSection" style="display:none;">
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused">Default Libraries</label>
+                                    <div id="DefaultLibraryPicker" style="max-height:200px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
+                                </div>
+                            </div>
+
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Local Previews</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerPreview">Trailer Preview</label>
+                                <select id="DefaultMediaBarTrailerPreview" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerAudio">Trailer Audio</label>
+                                <select id="DefaultMediaBarTrailerAudio" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                             <div class="inputContainer">
+                                 <label class="inputLabel inputLabelUnfocused" for="DefaultMediaBarTrailerCaptions">Trailer Captions</label>
+                                 <select id="DefaultMediaBarTrailerCaptions" is="emby-select">
+                                     <option value="">Not set (user decides)</option>
+                                     <option value="true">Yes</option>
+                                     <option value="false">No</option>
+                                 </select>
+                                 <div class="fieldDescription">Show closed captions on YouTube trailers when available.</div>
+                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultEpisodePreviewEnabled">Media Preview</label>
+                                <select id="DefaultEpisodePreviewEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultPreviewAudioEnabled">Preview Audio</label>
+                                <select id="DefaultPreviewAudioEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Seasonal Effects</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultSeasonalSurprise">Seasonal Effects</label>
+                                <select id="DefaultSeasonalSurprise" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="none">None</option>
+                                    <option value="snow">Snow</option>
+                                    <option value="fireworks">Fireworks</option>
+                                    <option value="confetti">Confetti</option>
+                                    <option value="leaves">Falling Leaves</option>
+                                </select>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Theme Music</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicEnabled">Theme Music</label>
+                                <select id="DefaultThemeMusicEnabled" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicVolume">Theme Music Volume</label>
+                                <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
+                                    <select id="DefaultThemeMusicVolume_Set" is="emby-select" style="width: auto; min-width: 195px;">
+                                        <option value="unset">Not set (user decides)</option>
+                                        <option value="set">Set default:</option>
+                                    </select>
+                                    <input type="range" id="DefaultThemeMusicVolume" min="0" max="100" step="5" value="100" disabled style="flex: 1; accent-color: #00a4dc;" />
+                                    <span id="DefaultThemeMusicVolume_Val" style="font-weight: 600; min-width: 40px; color: #00a4dc; text-align: right; font-size: 0.95em;">--</span>
+                                </div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicOnHomeRows">Play Theme Music on Home Rows</label>
+                                <select id="DefaultThemeMusicOnHomeRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultThemeMusicLoop">Loop Theme Music</label>
+                                <select id="DefaultThemeMusicLoop" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingNames">Show Rating Labels</label>
-                            <select id="DefaultMdblistShowRatingNames" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused">Default Rating Sources &amp; Order</label>
-                            <div class="fieldDescription" style="margin-bottom:0.5em;">Check which ratings to display and drag or use the arrows to set their order. Leave all unchecked to use each user's own choice.</div>
-                            <div id="DefaultMdblistRatingSourcesList" style="border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;"></div>
-                        </div>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="DefaultSeerrBlockNsfw">Block NSFW In Seerr</label>
-                            <select id="DefaultSeerrBlockNsfw" is="emby-select">
-                                <option value="">Not set (user decides)</option>
-                                <option value="true">Yes</option>
-                                <option value="false">No</option>
-                            </select>
+
+                        <!-- 8. Integrations -->
+                        <div class="defaultsSubtabPanel" data-subtab="integrations">
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Metadata &amp; Ratings</h4>
+                            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 1em;">
+                                <label class="emby-checkbox-label">
+                                    <input type="checkbox" id="DefaultMdblistEnabled" is="emby-checkbox" />
+                                    <span>MDBList Ratings</span>
+                                </label>
+                                <div class="fieldDescription">Enable MDBList ratings by default (requires server-wide or user API key).</div>
+                            </div>
+                            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 1.2em;">
+                                <label class="emby-checkbox-label">
+                                    <input type="checkbox" id="DefaultTmdbEpisodeRatingsEnabled" is="emby-checkbox" />
+                                    <span>TMDB Episode Ratings</span>
+                                </label>
+                                <div class="fieldDescription">Enable TMDB episode ratings by default (requires server-wide or user API key).</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingBadges">Show MDBList Rating Badges</label>
+                                <select id="DefaultMdblistShowRatingBadges" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultMdblistShowRatingNames">Show Rating Labels</label>
+                                <select id="DefaultMdblistShowRatingNames" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Default Rating Sources &amp; Order</label>
+                                <div class="fieldDescription">Check which ratings to display and drag or use the arrows to set their order.</div>
+                                <div id="DefaultMdblistRatingSourcesList" style="max-height:220px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:4px;margin-top:6px;"></div>
+                            </div>
+
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Seerr</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultSeerrBlockNsfw">Seerr Block NSFW</label>
+                                <select id="DefaultSeerrBlockNsfw" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Seerr Discovery Rows &amp; Order</label>
+                                <div class="fieldDescription">Enable rows to see on Seerr mainpage and use the arrows to set their order.</div>
+                                <div id="DefaultSeerrDiscoveryList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
+                            </div>
                         </div>
                     </div>
-
                     </section>
                     <section class="moonfinTabPanel" data-tab="themes">
                     <div class="verticalSection">
@@ -1525,73 +1770,25 @@
         <script type="text/javascript">
             function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
-            function buildDefaultSettingsSubTabs(section) {
-                if (!section || section.dataset.subTabsInit === 'true') {
-                    return;
-                }
+            function bindDefaultSettingsSubTabs(page) {
+                var root = page || document;
+                var buttons = Array.prototype.slice.call(root.querySelectorAll('.defaultsSubtabBtn'));
+                var panels = Array.prototype.slice.call(root.querySelectorAll('.defaultsSubtabPanel'));
+                if (!buttons.length || !panels.length) return;
 
-                var headings = Array.prototype.slice.call(section.querySelectorAll('h4'));
-                if (!headings.length) {
-                    return;
-                }
-
-                section.dataset.subTabsInit = 'true';
-
-                var tabBar = document.createElement('div');
-                tabBar.className = 'moonfinSubTabs';
-                tabBar.setAttribute('role', 'tablist');
-
-                var entries = [];
-
-                function selectSubTab(active) {
-                    entries.forEach(function(entry, i) {
-                        var on = i === active;
-                        entry.button.classList.toggle('is-active', on);
-                        entry.button.setAttribute('aria-selected', on ? 'true' : 'false');
-                        entry.panel.classList.toggle('is-active', on);
+                buttons.forEach(function(btn) {
+                    if (btn.dataset.bound === 'true') return;
+                    btn.dataset.bound = 'true';
+                    btn.addEventListener('click', function() {
+                        var target = btn.getAttribute('data-subtab');
+                        buttons.forEach(function(b) {
+                            b.classList.toggle('active', b.getAttribute('data-subtab') === target);
+                        });
+                        panels.forEach(function(p) {
+                            p.classList.toggle('active', p.getAttribute('data-subtab') === target);
+                        });
                     });
-                }
-
-                headings.forEach(function(heading, index) {
-                    if (!heading || !heading.parentNode) {
-                        return;
-                    }
-
-                    var title = (heading.textContent || '').trim();
-
-                    var panel = document.createElement('div');
-                    panel.className = 'moonfinSubPanel';
-                    panel.setAttribute('role', 'tabpanel');
-                    panel.setAttribute('data-subpanel', String(index));
-
-                    var node = heading.nextSibling;
-                    while (node && !(node.nodeType === 1 && node.tagName && node.tagName.toUpperCase() === 'H4')) {
-                        var nextNode = node.nextSibling;
-                        panel.appendChild(node);
-                        node = nextNode;
-                    }
-
-                    heading.parentNode.insertBefore(panel, heading);
-                    heading.remove();
-
-                    var button = document.createElement('button');
-                    button.type = 'button';
-                    button.className = 'moonfinSubTab';
-                    button.setAttribute('role', 'tab');
-                    button.setAttribute('data-subtab', String(index));
-                    button.textContent = title;
-                    button.addEventListener('click', function() {
-                        selectSubTab(index);
-                    });
-
-                    tabBar.appendChild(button);
-                    entries.push({ button: button, panel: panel });
                 });
-
-                if (entries.length) {
-                    section.insertBefore(tabBar, entries[0].panel);
-                    selectSubTab(0);
-                }
             }
 
             function initializeAdminTabs(root) {
@@ -1630,13 +1827,7 @@
                     });
                 });
 
-                var defaultsPanel = page.querySelector('.moonfinTabPanel[data-tab="defaults"]');
-                if (defaultsPanel) {
-                    var defaultsSection = defaultsPanel.querySelector('.verticalSection');
-                    if (defaultsSection) {
-                        buildDefaultSettingsSubTabs(defaultsSection);
-                    }
-                }
+                bindDefaultSettingsSubTabs(page);
 
                 var saved = null;
                 try { saved = window.localStorage.getItem('moonfinAdminActiveTab'); } catch (e) {}
@@ -1730,6 +1921,20 @@
                 select.value = '';
             }
 
+            function esc(str) {
+                return String(str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+            }
+
+            function setCheckbox(selector, val) {
+                var el = document.querySelector(selector);
+                if (el) el.checked = !!val;
+            }
+
+            function getCheckbox(selector) {
+                var el = document.querySelector(selector);
+                return el ? !!el.checked : false;
+            }
+
             function getNullableBoolSelect(selector) {
                 var select = document.querySelector(selector);
                 if (!select) return null;
@@ -1756,6 +1961,65 @@
 
                 var parsed = parseInt(raw, 10);
                 return Number.isNaN(parsed) ? null : parsed;
+            }
+
+            function setNullableRangeInput(selectorId, value, unit) {
+                var select = document.querySelector(selectorId + '_Set');
+                var range = document.querySelector(selectorId);
+                var display = document.querySelector(selectorId + '_Val');
+                if (!range) return;
+
+                unit = unit || '';
+
+                if (value == null || value === '') {
+                    if (select) select.value = 'unset';
+                    range.disabled = true;
+                    if (display) display.textContent = '--';
+                } else {
+                    if (select) select.value = 'set';
+                    range.disabled = false;
+                    range.value = String(value);
+                    if (display) display.textContent = String(value) + unit;
+                }
+            }
+
+            function getNullableRangeInput(selectorId) {
+                var select = document.querySelector(selectorId + '_Set');
+                var range = document.querySelector(selectorId);
+                if (!range) return null;
+                if (select && select.value === 'unset') return null;
+                if (range.disabled) return null;
+                var parsed = parseInt(range.value, 10);
+                return Number.isNaN(parsed) ? null : parsed;
+            }
+
+            function bindNullableRangeInput(selectorId, unit) {
+                var select = document.querySelector(selectorId + '_Set');
+                var range = document.querySelector(selectorId);
+                var display = document.querySelector(selectorId + '_Val');
+                if (!range || !select) return;
+
+                unit = unit || '';
+
+                if (!select.dataset.rangeBound) {
+                    select.dataset.rangeBound = 'true';
+                    select.addEventListener('change', function() {
+                        if (select.value === 'unset') {
+                            range.disabled = true;
+                            if (display) display.textContent = '--';
+                        } else {
+                            range.disabled = false;
+                            if (display) display.textContent = range.value + unit;
+                        }
+                    });
+                }
+
+                if (!range.dataset.rangeBound) {
+                    range.dataset.rangeBound = 'true';
+                    range.addEventListener('input', function() {
+                        if (display) display.textContent = range.value + unit;
+                    });
+                }
             }
 
             var RATING_SOURCES = [
@@ -1886,6 +2150,190 @@
                     if (cb && cb.checked) { result.push(item.dataset.id); }
                 });
                 return result.length > 0 ? result : null;
+            }
+
+            var DETAIL_BUTTONS = [
+                { id: 'shuffle', label: 'Shuffle' },
+                { id: 'restart', label: 'Restart' },
+                { id: 'playOffline', label: 'Play Offline' },
+                { id: 'audio', label: 'Audio' },
+                { id: 'subtitles', label: 'Subtitles' },
+                { id: 'version', label: 'Version' },
+                { id: 'cast', label: 'Cast' },
+                { id: 'trailer', label: 'Trailer' },
+                { id: 'watchWithGroup', label: 'Watch with group' },
+                { id: 'watched', label: 'Watched' },
+                { id: 'favorite', label: 'Favorite' },
+                { id: 'playlist', label: 'Playlist' },
+                { id: 'download', label: 'Download' },
+                { id: 'deleteFiles', label: 'Delete files' },
+                { id: 'goToSeries', label: 'Go to series' },
+                { id: 'admin', label: 'Admin' }
+            ];
+
+            function loadDetailButtonsPicker(order, hidden) {
+                var container = document.querySelector('#DefaultDetailButtonsList');
+                if (!container) return;
+                var hiddenSet = {};
+                if (hidden && Array.isArray(hidden)) {
+                    hidden.forEach(function(id) { hiddenSet[id] = true; });
+                }
+
+                var ordered = [];
+                var addedSet = {};
+
+                if (order && Array.isArray(order) && order.length > 0) {
+                    order.forEach(function(id) {
+                        var btn = DETAIL_BUTTONS.find(function(b) { return b.id === id; });
+                        if (btn) {
+                            ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                            addedSet[btn.id] = true;
+                        }
+                    });
+                }
+
+                DETAIL_BUTTONS.forEach(function(btn) {
+                    if (!addedSet[btn.id]) {
+                        ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                    }
+                });
+
+                container.innerHTML = '';
+                ordered.forEach(function(item) {
+                    var row = document.createElement('div');
+                    row.className = 'detailButtonItem';
+                    row.dataset.id = item.id;
+                    row.style.cssText = 'display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:4px;margin-bottom:2px;background:rgba(255,255,255,0.03);';
+                    row.innerHTML =
+                        '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">'
+                        + '<span style="flex:1;font-size:0.9em;color:rgba(255,255,255,0.9);">' + esc(item.label) + '</span>'
+                        + '<button type="button" class="detailButtonMoveBtn" data-dir="up" style="background:none;border:1px solid rgba(255,255,255,0.2);border-radius:3px;color:rgba(255,255,255,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2191;</button>'
+                        + '<button type="button" class="detailButtonMoveBtn" data-dir="down" style="background:none;border:1px solid rgba(255,255,255,0.2);border-radius:3px;color:rgba(255,255,255,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2193;</button>';
+                    container.appendChild(row);
+                });
+
+                if (!container.dataset.hasListener) {
+                    container.dataset.hasListener = 'true';
+                    container.addEventListener('click', function(e) {
+                        var btn = e.target.closest('.detailButtonMoveBtn');
+                        if (!btn) return;
+                        var row = btn.closest('.detailButtonItem');
+                        if (!row) return;
+                        if (btn.dataset.dir === 'up' && row.previousElementSibling) {
+                            container.insertBefore(row, row.previousElementSibling);
+                        } else if (btn.dataset.dir === 'down' && row.nextElementSibling) {
+                            container.insertBefore(row.nextElementSibling, row);
+                        }
+                    });
+                }
+            }
+
+            function getDetailButtonsValue() {
+                var items = document.querySelectorAll('#DefaultDetailButtonsList .detailButtonItem');
+                var order = [];
+                var hidden = [];
+                items.forEach(function(item) {
+                    var cb = item.querySelector('input[type=checkbox]');
+                    var id = item.dataset.id;
+                    order.push(id);
+                    if (cb && !cb.checked) {
+                        hidden.push(id);
+                    }
+                });
+                return {
+                    order: order.length > 0 ? order : null,
+                    hidden: hidden.length > 0 ? hidden : null
+                };
+            }
+
+            var SEERR_DISCOVERY_ROWS = [
+                { id: 'recent_requests', label: 'Recent Requests' },
+                { id: 'watchlist', label: 'Your Watchlist' },
+                { id: 'recently_added', label: 'Recently Added' },
+                { id: 'trending', label: 'Trending' },
+                { id: 'popular_movies', label: 'Popular Movies' },
+                { id: 'movie_genres', label: 'Movie Genres' },
+                { id: 'upcoming_movies', label: 'Upcoming Movies' },
+                { id: 'studios', label: 'Studios' },
+                { id: 'popular_series', label: 'Popular Series' },
+                { id: 'series_genres', label: 'Series Genres' },
+                { id: 'upcoming_series', label: 'Upcoming Series' },
+                { id: 'networks', label: 'Networks' }
+            ];
+
+            function loadSeerrDiscoveryPicker(order, hidden) {
+                var container = document.querySelector('#DefaultSeerrDiscoveryList');
+                if (!container) return;
+                var hiddenSet = {};
+                if (hidden && Array.isArray(hidden)) {
+                    hidden.forEach(function(id) { hiddenSet[id] = true; });
+                }
+
+                var ordered = [];
+                var addedSet = {};
+
+                if (order && Array.isArray(order) && order.length > 0) {
+                    order.forEach(function(id) {
+                        var row = SEERR_DISCOVERY_ROWS.find(function(r) { return r.id === id; });
+                        if (row) {
+                            ordered.push({ id: row.id, label: row.label, checked: !hiddenSet[row.id] });
+                            addedSet[row.id] = true;
+                        }
+                    });
+                }
+
+                SEERR_DISCOVERY_ROWS.forEach(function(row) {
+                    if (!addedSet[row.id]) {
+                        ordered.push({ id: row.id, label: row.label, checked: !hiddenSet[row.id] });
+                    }
+                });
+
+                container.innerHTML = '';
+                ordered.forEach(function(item) {
+                    var row = document.createElement('div');
+                    row.className = 'seerrDiscoveryItem';
+                    row.dataset.id = item.id;
+                    row.style.cssText = 'display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:4px;margin-bottom:2px;background:rgba(255,255,255,0.03);';
+                    row.innerHTML =
+                        '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">'
+                        + '<span style="flex:1;font-size:0.9em;color:rgba(255,255,255,0.9);">' + esc(item.label) + '</span>'
+                        + '<button type="button" class="seerrMoveBtn" data-dir="up" style="background:none;border:1px solid rgba(255,255,255,0.2);border-radius:3px;color:rgba(255,255,255,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2191;</button>'
+                        + '<button type="button" class="seerrMoveBtn" data-dir="down" style="background:none;border:1px solid rgba(255,255,255,0.2);border-radius:3px;color:rgba(255,255,255,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2193;</button>';
+                    container.appendChild(row);
+                });
+
+                if (!container.dataset.hasListener) {
+                    container.dataset.hasListener = 'true';
+                    container.addEventListener('click', function(e) {
+                        var btn = e.target.closest('.seerrMoveBtn');
+                        if (!btn) return;
+                        var row = btn.closest('.seerrDiscoveryItem');
+                        if (!row) return;
+                        if (btn.dataset.dir === 'up' && row.previousElementSibling) {
+                            container.insertBefore(row, row.previousElementSibling);
+                        } else if (btn.dataset.dir === 'down' && row.nextElementSibling) {
+                            container.insertBefore(row.nextElementSibling, row);
+                        }
+                    });
+                }
+            }
+
+            function getSeerrDiscoveryValue() {
+                var items = document.querySelectorAll('#DefaultSeerrDiscoveryList .seerrDiscoveryItem');
+                var order = [];
+                var hidden = [];
+                items.forEach(function(item) {
+                    var cb = item.querySelector('input[type=checkbox]');
+                    var id = item.dataset.id;
+                    order.push(id);
+                    if (cb && !cb.checked) {
+                        hidden.push(id);
+                    }
+                });
+                return {
+                    order: order.length > 0 ? order : null,
+                    hidden: hidden.length > 0 ? hidden : null
+                };
             }
 
             var HOME_LAYOUT_TABS = [
@@ -2758,11 +3206,37 @@
                 style.textContent = source.textContent;
             }
 
+            function initializeDefaultsSubtabs() {
+                var subnav = document.querySelector('#MoonfinConfigPage .defaultsSubnavBar');
+                if (!subnav || subnav.dataset.bound) return;
+                subnav.dataset.bound = 'true';
+
+                subnav.addEventListener('click', function(e) {
+                    var btn = e.target.closest('.defaultsSubtabBtn');
+                    if (!btn) return;
+                    var subtab = btn.getAttribute('data-subtab');
+                    var allBtns = subnav.querySelectorAll('.defaultsSubtabBtn');
+                    var allPanels = document.querySelectorAll('#MoonfinConfigPage .defaultsSubtabPanel');
+                    for (var i = 0; i < allBtns.length; i++) {
+                        allBtns[i].classList.remove('active');
+                    }
+                    for (var j = 0; j < allPanels.length; j++) {
+                        allPanels[j].classList.remove('active');
+                    }
+                    btn.classList.add('active');
+                    var targetPanel = document.querySelector('#MoonfinConfigPage .defaultsSubtabPanel[data-subtab="' + subtab + '"]');
+                    if (targetPanel) {
+                        targetPanel.classList.add('active');
+                    }
+                });
+            }
+
             document.addEventListener('pageshow', function(e) {
                 if (e.target.id !== 'MoonfinConfigPage') return;
 
                 ensureMoonfinAdminRuntimeStyles();
                 initializeAdminTabs();
+                initializeDefaultsSubtabs();
 
                 var themeFileInput = document.querySelector('#AdminThemeFileInput');
                 var themeChooseButton = document.querySelector('#AdminThemeChooseBtn');
@@ -2892,27 +3366,60 @@
                     initGameCores();
 
                     var defaults = config.DefaultUserSettings || {};
+                    setSelectValue('#DefaultInterfaceStyle', defaults.interfaceStyle, 'Configured style');
                     setSelectValue('#DefaultVisualTheme', defaults.visualTheme, 'Configured theme');
                     setSelectValue('#DefaultDetailScreenStyle', defaults.detailScreenStyle, 'Configured style');
                     setNullableBoolSelect('#DefaultDetailExpandedTabs', defaults.detailExpandedTabs);
+                    setNullableBoolSelect('#DefaultDetailShowTechnicalDetails', defaults.detailShowTechnicalDetails);
+                    setSelectValue('#DefaultRecommendationSystemSource', defaults.recommendationSystemSource, 'Configured source');
+                    setNullableBoolSelect('#DefaultRecommendationsApplyParentalRatingCap', defaults.recommendationsApplyParentalRatingCap);
+                    loadDetailButtonsPicker(defaults.detailButtonOrder || null, defaults.hiddenDetailButtons || null);
                     setSelectValue('#DefaultFocusColor', defaults.focusColor, 'Configured color');
-                    setNullableIntInput('#DefaultBrowsingBlur', defaults.browsingBlur);
-                    setNullableIntInput('#DefaultDetailsScreenBlur', defaults.detailsScreenBlur);
+                    setSelectValue('#DefaultClockBehavior', defaults.clockBehavior, 'Configured clock');
+                    setNullableBoolSelect('#DefaultUse24HourClock', defaults.use24HourClock);
+                    setSelectValue('#DefaultDesktopUiScale', defaults.desktopUiScale, 'Configured scale');
+                    setNullableBoolSelect('#DefaultBackdropEnabled', defaults.backdropEnabled);
+                    bindNullableRangeInput('#DefaultBrowsingBlur');
+                    setNullableRangeInput('#DefaultBrowsingBlur', defaults.browsingBlur);
+                    bindNullableRangeInput('#DefaultDetailsScreenBlur');
+                    setNullableRangeInput('#DefaultDetailsScreenBlur', defaults.detailsScreenBlur);
                     setNullableBoolSelect('#DefaultThemeMusicEnabled', defaults.themeMusicEnabled);
+                    setNullableBoolSelect('#DefaultThemeMusicOnHomeRows', defaults.themeMusicOnHomeRows);
+                    setNullableBoolSelect('#DefaultThemeMusicLoop', defaults.themeMusicLoop);
+                    bindNullableRangeInput('#DefaultThemeMusicVolume', '%');
+                    setNullableRangeInput('#DefaultThemeMusicVolume', defaults.themeMusicVolume, '%');
                     setSelectValue('#DefaultWatchedIndicator', defaults.watchedIndicator, 'Configured mode');
                     setNullableBoolSelect('#DefaultCardFocusExpansion', defaults.cardFocusExpansion);
                     setSelectValue('#DefaultScreensaverMode', defaults.screensaverMode, 'Configured mode');
 
                     setSelectValue('#DefaultNavbarPosition', defaults.navbarPosition, 'Configured position');
                     setSelectValue('#DefaultNavbarColor', defaults.navbarColor, 'Configured color');
-                    setNullableIntInput('#DefaultNavbarOpacity', defaults.navbarOpacity);
+                    bindNullableRangeInput('#DefaultNavbarOpacity', '%');
+                    setNullableRangeInput('#DefaultNavbarOpacity', defaults.navbarOpacity, '%');
+                    setNullableBoolSelect('#DefaultNavbarAlwaysExpanded', defaults.navbarAlwaysExpanded);
+                    setNullableBoolSelect('#DefaultEnableFolderView', defaults.enableFolderView);
+                    setNullableBoolSelect('#DefaultShowSeerrButton', defaults.showSeerrButton);
 
                     setSelectValue('#DefaultMediaBarSourceType', defaults.mediaBarSourceType, 'Configured source');
                     setSelectValue('#DefaultMediaBarMode', defaults.mediaBarMode, 'Configured mode');
+                    setSelectValue('#DefaultMediaBarContentType', defaults.mediaBarContentType, 'Configured content type');
+                    setSelectValue('#DefaultMediaBarItemCount', defaults.mediaBarItemCount, 'Configured item count');
+                    setNullableBoolSelect('#DefaultMediaBarAutoAdvance', defaults.mediaBarAutoAdvance);
+                    setSelectValue('#DefaultMediaBarIntervalMs', defaults.mediaBarIntervalMs, 'Configured interval');
+                    setNullableBoolSelect('#DefaultMediaBarTrailerPreview', defaults.mediaBarTrailerPreview);
                     setNullableBoolSelect('#DefaultMediaBarTrailerAudio', defaults.mediaBarTrailerAudio);
+                    setNullableBoolSelect('#DefaultMediaBarTrailerCaptions', defaults.mediaBarTrailerCaptions);
+                    setNullableBoolSelect('#DefaultEpisodePreviewEnabled', defaults.episodePreviewEnabled);
+                    setNullableBoolSelect('#DefaultPreviewAudioEnabled', defaults.previewAudioEnabled);
+                    setSelectValue('#DefaultSeasonalSurprise', defaults.seasonalSurprise, 'Configured surprise');
 
                     setSelectValue('#DefaultHomeRowsStyle', defaults.homeRowsStyle, 'Configured style');
                     setNullableBoolSelect('#DefaultFullScreenRows', defaults.fullScreenRows);
+                    setNullableBoolSelect('#DefaultHomeRowInfoOverlay', defaults.homeRowInfoOverlay);
+                    bindNullableRangeInput('#DefaultClassicHomeRowsPadding', 'px');
+                    setNullableRangeInput('#DefaultClassicHomeRowsPadding', defaults.classicHomeRowsPadding, 'px');
+                    bindNullableRangeInput('#DefaultModernHomeRowsPadding', 'px');
+                    setNullableRangeInput('#DefaultModernHomeRowsPadding', defaults.modernHomeRowsPadding, 'px');
                     setSelectValue('#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
                     setSelectValue('#DefaultPosterSize', defaults.posterSize, 'Configured size');
                     setNullableBoolSelect('#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
@@ -2926,26 +3433,34 @@
                     setSelectValue('#DefaultGenresRowItemFilter', defaults.genresRowItemFilter, 'Configured filter');
                     setNullableBoolSelect('#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
                     loadHomeSectionsEditor(defaults.homeSections || null, defaults.homeRowOrder || null);
-                    document.querySelector('#DefaultMergeContinueWatchingNextUp').checked = !!defaults.mergeContinueWatchingNextUp;
-                    setNullableIntInput('#DefaultNextUpMaxDays', defaults.nextUpMaxDays);
+                    setNullableBoolSelect('#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
+                    setSelectValue('#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');
 
-                    document.querySelector('#DefaultShowShuffleButton').checked = !!defaults.showShuffleButton;
-                    document.querySelector('#DefaultShowGenresButton').checked = !!defaults.showGenresButton;
-                    document.querySelector('#DefaultShowFavoritesButton').checked = !!defaults.showFavoritesButton;
-                    document.querySelector('#DefaultShowCastButton').checked = !!defaults.showCastButton;
-                    document.querySelector('#DefaultShowSyncPlayButton').checked = !!defaults.showSyncPlayButton;
-                    document.querySelector('#DefaultShowLibrariesInToolbar').checked = !!defaults.showLibrariesInToolbar;
+                    setNullableBoolSelect('#DefaultEnableMultiServerLibraries', defaults.enableMultiServerLibraries);
+                    setNullableBoolSelect('#DefaultMergeRecentRowsByType', defaults.mergeRecentRowsByType);
+                    setNullableBoolSelect('#DefaultGroupItemsIntoCollections', defaults.groupItemsIntoCollections);
+                    setNullableBoolSelect('#DefaultShowMediaDetailsOnLibraryPage', defaults.showMediaDetailsOnLibraryPage);
+                    setNullableBoolSelect('#DefaultUseDetailedSubHeadings', defaults.useDetailedSubHeadings);
+                    setNullableBoolSelect('#DefaultHideBackdropsInLibraries', defaults.hideBackdropsInLibraries);
+
+                    setNullableBoolSelect('#DefaultShowShuffleButton', defaults.showShuffleButton);
+                    setNullableBoolSelect('#DefaultShowGenresButton', defaults.showGenresButton);
+                    setNullableBoolSelect('#DefaultShowFavoritesButton', defaults.showFavoritesButton);
+                    setCheckbox('#DefaultShowCastButton', defaults.showCastButton);
+                    setCheckbox('#DefaultShowSyncPlayButton', defaults.showSyncPlayButton);
+                    setNullableBoolSelect('#DefaultShowLibrariesInToolbar', defaults.showLibrariesInToolbar);
 
                     setNullableBoolSelect('#DefaultMediaBarTrailerPreview', defaults.mediaBarTrailerPreview);
                     setNullableBoolSelect('#DefaultEpisodePreviewEnabled', defaults.episodePreviewEnabled);
                     setNullableBoolSelect('#DefaultPreviewAudioEnabled', defaults.previewAudioEnabled);
 
-                    document.querySelector('#DefaultMdblistEnabled').checked = !!defaults.mdblistEnabled;
-                    document.querySelector('#DefaultTmdbEpisodeRatingsEnabled').checked = !!defaults.tmdbEpisodeRatingsEnabled;
+                    setCheckbox('#DefaultMdblistEnabled', defaults.mdblistEnabled);
+                    setCheckbox('#DefaultTmdbEpisodeRatingsEnabled', defaults.tmdbEpisodeRatingsEnabled);
                     setNullableBoolSelect('#DefaultMdblistShowRatingBadges', defaults.mdblistShowRatingBadges);
                     setNullableBoolSelect('#DefaultMdblistShowRatingNames', defaults.mdblistShowRatingNames);
                     loadRatingSourcesPicker(defaults.mdblistRatingSources || null);
                     setNullableBoolSelect('#DefaultSeerrBlockNsfw', defaults.seerrBlockNsfw);
+                    loadSeerrDiscoveryPicker(defaults.seerrRowOrder || null, defaults.hiddenSeerrRows || null);
 
                     var sourceSelect = document.querySelector('#DefaultMediaBarSourceType');
                     var collectionPickerSection = document.querySelector('#DefaultCollectionPickerSection');
@@ -2964,7 +3479,6 @@
                     }
                     sourceSelect.addEventListener('change', togglePickerVisibility);
                     togglePickerVisibility();
-                    loadAdminGenrePicker(defaults.mediaBarExcludedGenres || []);
 
                     Dashboard.hideLoadingMsg();
                 });
@@ -3051,14 +3565,10 @@
                     var statusEl = document.querySelector('#GameCoresStatus');
                     if (!statusEl) return;
                     var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
-                    fetch(serverUrl + '/Moonfin/Games/Cores/Status', { headers: gameCoresHeaders() })
+                    fetch(serverUrl + '/Moonfin/Games/Cores/Status', { method: 'GET', headers: gameCoresHeaders() })
                         .then(function(r) { return r.json(); })
                         .then(function(s) {
-                            if (s.downloading) {
-                                statusEl.textContent = 'Downloading cores... (' + (s.filesInstalled || 0) + ' files so far)';
-                                if (!gameCoresPollTimer) gameCoresPollTimer = setInterval(refreshCoresStatus, 4000);
-                                return;
-                            }
+                            if (!s) return;
                             if (gameCoresPollTimer) { clearInterval(gameCoresPollTimer); gameCoresPollTimer = null; }
                             if (s.installed) {
                                 statusEl.textContent = 'Installed on server (offline ready).';
@@ -3123,40 +3633,7 @@
                     });
                 }
 
-                function loadAdminGenrePicker(selectedIds) {
-                    var picker = document.querySelector('#DefaultGenrePicker');
-                    if (!picker) return;
-                    picker.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.5);font-size:0.9em;">Loading...</div>';
 
-                    var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
-                    var token = ApiClient.accessToken ? ApiClient.accessToken() : '';
-                    var headers = token ? { 'Authorization': 'MediaBrowser Token="' + token + '"' } : {};
-
-                    fetch(serverUrl + '/Moonfin/Genres', { method: 'GET', headers: headers })
-                        .then(function(r) { return r.json(); })
-                        .then(function(data) {
-                            var genres = data.Items || data.items || [];
-                            if (genres.length === 0) {
-                                picker.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.5);font-size:0.9em;">No genres found.</div>';
-                                return;
-                            }
-                            var html = '';
-                            for (var i = 0; i < genres.length; i++) {
-                                var g = genres[i];
-                                var gId = g.id || g.Id;
-                                var gName = g.name || g.Name;
-                                var isChecked = selectedIds.indexOf(gId) !== -1;
-                                html += '<label style="display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:4px;cursor:pointer;' + (isChecked ? 'background:rgba(0,164,220,0.1);' : '') + '">' +
-                                    '<input type="checkbox" class="adminGenreCb" data-id="' + esc(gId) + '"' + (isChecked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;">' +
-                                    '<span style="font-size:14px;">&#x1F6AB;</span>' +
-                                    '<div style="flex:1;min-width:0;"><div style="font-size:0.9em;color:rgba(255,255,255,0.9);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + esc(gName) + '</div></div></label>';
-                            }
-                            picker.innerHTML = html;
-                        })
-                        .catch(function() {
-                            picker.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.5);font-size:0.9em;">Failed to load genres.</div>';
-                        });
-                }
 
                 function loadWebhookProvisioningStatus() {
                     var note = document.querySelector('#WebhookProvisioningStatus');
@@ -3239,13 +3716,26 @@
                         ).map(function (cb) { return cb.getAttribute('data-id'); });
 
                         config.DefaultUserSettings = config.DefaultUserSettings || {};
+                        config.DefaultUserSettings.interfaceStyle = document.querySelector('#DefaultInterfaceStyle').value || null;
                         config.DefaultUserSettings.visualTheme = document.querySelector('#DefaultVisualTheme').value || null;
                         config.DefaultUserSettings.detailScreenStyle = document.querySelector('#DefaultDetailScreenStyle').value || null;
                         config.DefaultUserSettings.detailExpandedTabs = getNullableBoolSelect('#DefaultDetailExpandedTabs');
+                        config.DefaultUserSettings.detailShowTechnicalDetails = getNullableBoolSelect('#DefaultDetailShowTechnicalDetails');
+                        config.DefaultUserSettings.recommendationSystemSource = document.querySelector('#DefaultRecommendationSystemSource').value || null;
+                        config.DefaultUserSettings.recommendationsApplyParentalRatingCap = getNullableBoolSelect('#DefaultRecommendationsApplyParentalRatingCap');
+                        var btnVal = getDetailButtonsValue();
+                        config.DefaultUserSettings.detailButtonOrder = btnVal.order;
+                        config.DefaultUserSettings.hiddenDetailButtons = btnVal.hidden;
                         config.DefaultUserSettings.focusColor = document.querySelector('#DefaultFocusColor').value || null;
+                        config.DefaultUserSettings.clockBehavior = document.querySelector('#DefaultClockBehavior').value || null;
+                        config.DefaultUserSettings.use24HourClock = getNullableBoolSelect('#DefaultUse24HourClock');
+                        config.DefaultUserSettings.desktopUiScale = document.querySelector('#DefaultDesktopUiScale').value || null;
+                        config.DefaultUserSettings.backdropEnabled = getNullableBoolSelect('#DefaultBackdropEnabled');
                         config.DefaultUserSettings.browsingBlur = getNullableIntInput('#DefaultBrowsingBlur');
                         config.DefaultUserSettings.detailsScreenBlur = getNullableIntInput('#DefaultDetailsScreenBlur');
                         config.DefaultUserSettings.themeMusicEnabled = getNullableBoolSelect('#DefaultThemeMusicEnabled');
+                        config.DefaultUserSettings.themeMusicOnHomeRows = getNullableBoolSelect('#DefaultThemeMusicOnHomeRows');
+                        config.DefaultUserSettings.themeMusicLoop = getNullableBoolSelect('#DefaultThemeMusicLoop');
                         config.DefaultUserSettings.watchedIndicator = document.querySelector('#DefaultWatchedIndicator').value || null;
                         config.DefaultUserSettings.cardFocusExpansion = getNullableBoolSelect('#DefaultCardFocusExpansion');
                         config.DefaultUserSettings.screensaverMode = document.querySelector('#DefaultScreensaverMode').value || null;
@@ -3253,10 +3743,21 @@
                         config.DefaultUserSettings.navbarPosition = document.querySelector('#DefaultNavbarPosition').value || null;
                         config.DefaultUserSettings.navbarColor = document.querySelector('#DefaultNavbarColor').value || null;
                         config.DefaultUserSettings.navbarOpacity = getNullableIntInput('#DefaultNavbarOpacity');
+                        config.DefaultUserSettings.navbarAlwaysExpanded = getNullableBoolSelect('#DefaultNavbarAlwaysExpanded');
+                        config.DefaultUserSettings.enableFolderView = getNullableBoolSelect('#DefaultEnableFolderView');
+                        config.DefaultUserSettings.showSeerrButton = getNullableBoolSelect('#DefaultShowSeerrButton');
 
                         config.DefaultUserSettings.mediaBarSourceType = document.querySelector('#DefaultMediaBarSourceType').value || null;
                         config.DefaultUserSettings.mediaBarMode = document.querySelector('#DefaultMediaBarMode').value || null;
+                        config.DefaultUserSettings.mediaBarContentType = document.querySelector('#DefaultMediaBarContentType').value || null;
+                        config.DefaultUserSettings.mediaBarItemCount = getNullableIntInput('#DefaultMediaBarItemCount');
+                        config.DefaultUserSettings.mediaBarAutoAdvance = getNullableBoolSelect('#DefaultMediaBarAutoAdvance');
+                        config.DefaultUserSettings.mediaBarTrailerPreview = getNullableBoolSelect('#DefaultMediaBarTrailerPreview');
                         config.DefaultUserSettings.mediaBarTrailerAudio = getNullableBoolSelect('#DefaultMediaBarTrailerAudio');
+                        config.DefaultUserSettings.mediaBarTrailerCaptions = getNullableBoolSelect('#DefaultMediaBarTrailerCaptions');
+                        config.DefaultUserSettings.episodePreviewEnabled = getNullableBoolSelect('#DefaultEpisodePreviewEnabled');
+                        config.DefaultUserSettings.previewAudioEnabled = getNullableBoolSelect('#DefaultPreviewAudioEnabled');
+                        config.DefaultUserSettings.seasonalSurprise = document.querySelector('#DefaultSeasonalSurprise').value || null;
 
                         var collectionCbs = document.querySelectorAll('.adminCollectionCb:checked');
                         var collectionIds = [];
@@ -3270,16 +3771,13 @@
                             libraryIds.push(libraryCbs[li].dataset.id);
                         }
                         config.DefaultUserSettings.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
-                        var genreCbs = document.querySelectorAll('.adminGenreCb:checked');
-                        var genreIds = [];
-                        for (var gi = 0; gi < genreCbs.length; gi++) {
-                            genreIds.push(genreCbs[gi].dataset.id);
-                        }
-                        config.DefaultUserSettings.mediaBarExcludedGenres = genreIds.length > 0 ? genreIds : null;
+
 
                         config.DefaultUserSettings.homeRowsStyle = document.querySelector('#DefaultHomeRowsStyle').value || null;
                         config.DefaultUserSettings.fullScreenRows = getNullableBoolSelect('#DefaultFullScreenRows');
-                        config.DefaultUserSettings.homeImageTypeContinueWatching = document.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
+                        config.DefaultUserSettings.homeRowInfoOverlay = getNullableBoolSelect('#DefaultHomeRowInfoOverlay');
+                        config.DefaultUserSettings.classicHomeRowsPadding = getNullableIntInput('#DefaultClassicHomeRowsPadding');
+                        config.DefaultUserSettings.modernHomeRowsPadding = getNullableIntInput('#DefaultModernHomeRowsPadding');
                         config.DefaultUserSettings.posterSize = document.querySelector('#DefaultPosterSize').value || null;
                         config.DefaultUserSettings.displayFavoritesRows = getNullableBoolSelect('#DefaultDisplayFavoritesRows');
                         config.DefaultUserSettings.displayCollectionsRows = getNullableBoolSelect('#DefaultDisplayCollectionsRows');
@@ -3294,25 +3792,35 @@
                         var homeSections = getHomeSectionsValue();
                         config.DefaultUserSettings.homeSections = homeSections;
                         config.DefaultUserSettings.homeRowOrder = getHomeRowOrderValue(homeSections);
-                        config.DefaultUserSettings.mergeContinueWatchingNextUp = document.querySelector('#DefaultMergeContinueWatchingNextUp').checked;
+                        config.DefaultUserSettings.mergeContinueWatchingNextUp = getNullableBoolSelect('#DefaultMergeContinueWatchingNextUp');
                         config.DefaultUserSettings.nextUpMaxDays = getNullableIntInput('#DefaultNextUpMaxDays');
 
-                        config.DefaultUserSettings.showShuffleButton = document.querySelector('#DefaultShowShuffleButton').checked;
-                        config.DefaultUserSettings.showGenresButton = document.querySelector('#DefaultShowGenresButton').checked;
-                        config.DefaultUserSettings.showFavoritesButton = document.querySelector('#DefaultShowFavoritesButton').checked;
-                        config.DefaultUserSettings.showCastButton = document.querySelector('#DefaultShowCastButton').checked;
-                        config.DefaultUserSettings.showSyncPlayButton = document.querySelector('#DefaultShowSyncPlayButton').checked;
-                        config.DefaultUserSettings.showLibrariesInToolbar = document.querySelector('#DefaultShowLibrariesInToolbar').checked;
+                        config.DefaultUserSettings.enableMultiServerLibraries = getNullableBoolSelect('#DefaultEnableMultiServerLibraries');
+                        config.DefaultUserSettings.mergeRecentRowsByType = getNullableBoolSelect('#DefaultMergeRecentRowsByType');
+                        config.DefaultUserSettings.groupItemsIntoCollections = getNullableBoolSelect('#DefaultGroupItemsIntoCollections');
+                        config.DefaultUserSettings.showMediaDetailsOnLibraryPage = getNullableBoolSelect('#DefaultShowMediaDetailsOnLibraryPage');
+                        config.DefaultUserSettings.useDetailedSubHeadings = getNullableBoolSelect('#DefaultUseDetailedSubHeadings');
+                        config.DefaultUserSettings.hideBackdropsInLibraries = getNullableBoolSelect('#DefaultHideBackdropsInLibraries');
+
+                        config.DefaultUserSettings.showShuffleButton = getNullableBoolSelect('#DefaultShowShuffleButton');
+                        config.DefaultUserSettings.showGenresButton = getNullableBoolSelect('#DefaultShowGenresButton');
+                        config.DefaultUserSettings.showFavoritesButton = getNullableBoolSelect('#DefaultShowFavoritesButton');
+                        config.DefaultUserSettings.showCastButton = getCheckbox('#DefaultShowCastButton');
+                        config.DefaultUserSettings.showSyncPlayButton = getCheckbox('#DefaultShowSyncPlayButton');
+                        config.DefaultUserSettings.showLibrariesInToolbar = getNullableBoolSelect('#DefaultShowLibrariesInToolbar');
 
                         config.DefaultUserSettings.mediaBarTrailerPreview = getNullableBoolSelect('#DefaultMediaBarTrailerPreview');
                         config.DefaultUserSettings.episodePreviewEnabled = getNullableBoolSelect('#DefaultEpisodePreviewEnabled');
                         config.DefaultUserSettings.previewAudioEnabled = getNullableBoolSelect('#DefaultPreviewAudioEnabled');
-                        config.DefaultUserSettings.mdblistEnabled = document.querySelector('#DefaultMdblistEnabled').checked;
-                        config.DefaultUserSettings.tmdbEpisodeRatingsEnabled = document.querySelector('#DefaultTmdbEpisodeRatingsEnabled').checked;
+                        config.DefaultUserSettings.mdblistEnabled = getCheckbox('#DefaultMdblistEnabled');
+                        config.DefaultUserSettings.tmdbEpisodeRatingsEnabled = getCheckbox('#DefaultTmdbEpisodeRatingsEnabled');
                         config.DefaultUserSettings.mdblistShowRatingBadges = getNullableBoolSelect('#DefaultMdblistShowRatingBadges');
                         config.DefaultUserSettings.mdblistShowRatingNames = getNullableBoolSelect('#DefaultMdblistShowRatingNames');
                         config.DefaultUserSettings.mdblistRatingSources = getRatingSourcesValue();
                         config.DefaultUserSettings.seerrBlockNsfw = getNullableBoolSelect('#DefaultSeerrBlockNsfw');
+                        var seerrVal = getSeerrDiscoveryValue();
+                        config.DefaultUserSettings.seerrRowOrder = seerrVal.order;
+                        config.DefaultUserSettings.hiddenSeerrRows = seerrVal.hidden;
 
                         return ApiClient.updatePluginConfiguration(MoonfinConfig.pluginUniqueId, config).then(function(result) {
                             Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1084,6 +1084,16 @@
                                     <option value="extraLarge">Extra Large</option>
                                 </select>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageTypeContinueWatching">Continue Watching Image Type</label>
+                                <select id="DefaultHomeImageTypeContinueWatching" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="Primary">Poster</option>
+                                    <option value="Backdrop">Backdrop</option>
+                                    <option value="Thumb">Thumbnail</option>
+                                    <option value="Banner">Banner</option>
+                                </select>
+                            </div>
                         </div>
 
                         <!-- 5. Home Sections -->
@@ -1277,6 +1287,11 @@
                                     <option value="true">Yes</option>
                                     <option value="false">No</option>
                                 </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Excluded Genres</label>
+                                <div id="DefaultGenrePicker" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
+                                <div class="fieldDescription">Titles in these genres never appear in the media bar.</div>
                             </div>
 
                             <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Seasonal Effects</h4>
@@ -2098,6 +2113,40 @@
                 { type: 'sonarr_calendar', label: 'Sonarr Upcoming' }
             ];
 
+            function loadAdminGenrePicker(selectedIds) {
+                var picker = document.querySelector('#DefaultGenrePicker');
+                if (!picker) return;
+                picker.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.5);font-size:0.9em;">Loading...</div>';
+
+                var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+                var token = ApiClient.accessToken ? ApiClient.accessToken() : '';
+                var headers = token ? { 'Authorization': 'MediaBrowser Token="' + token + '"' } : {};
+
+                fetch(serverUrl + '/Moonfin/Genres', { method: 'GET', headers: headers })
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        var genres = data.Items || data.items || [];
+                        if (genres.length === 0) {
+                            picker.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.5);font-size:0.9em;">No genres found.</div>';
+                            return;
+                        }
+                        var html = '';
+                        for (var i = 0; i < genres.length; i++) {
+                            var g = genres[i];
+                            var gId = g.id || g.Id;
+                            var gName = g.name || g.Name;
+                            var isChecked = selectedIds.indexOf(gId) !== -1;
+                            html += '<label style="display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:4px;cursor:pointer;' + (isChecked ? 'background:rgba(0,164,220,0.1);' : '') + '">' +
+                                '<input type="checkbox" class="adminGenreCb" data-id="' + esc(gId) + '"' + (isChecked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;">' +
+                                '<div style="flex:1;min-width:0;"><div style="font-size:0.9em;color:rgba(255,255,255,0.9);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + esc(gName) + '</div></div></label>';
+                        }
+                        picker.innerHTML = html;
+                    })
+                    .catch(function() {
+                        picker.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.5);font-size:0.9em;">Failed to load genres.</div>';
+                    });
+            }
+
             function loadRatingSourcesPicker(selectedIds) {
                 var container = document.querySelector('#DefaultMdblistRatingSourcesList');
                 if (!container) return;
@@ -2152,10 +2201,14 @@
                 return result.length > 0 ? result : null;
             }
 
+            // Same ids and declaration order as DetailButton in Core, so an untouched
+            // arrangement here matches what a fresh client shows.
             var DETAIL_BUTTONS = [
+                { id: 'seerrRequest', label: 'Request' },
+                { id: 'seerrRequest4k', label: 'Request 4K' },
                 { id: 'shuffle', label: 'Shuffle' },
-                { id: 'restart', label: 'Restart' },
-                { id: 'playOffline', label: 'Play Offline' },
+                { id: 'restart', label: 'Restart', canHide: false },
+                { id: 'playOffline', label: 'Play Offline', canHide: false },
                 { id: 'audio', label: 'Audio' },
                 { id: 'subtitles', label: 'Subtitles' },
                 { id: 'version', label: 'Version' },
@@ -2168,6 +2221,9 @@
                 { id: 'download', label: 'Download' },
                 { id: 'deleteFiles', label: 'Delete files' },
                 { id: 'goToSeries', label: 'Go to series' },
+                { id: 'seerrWatchlist', label: 'Watchlist' },
+                { id: 'seerrReportIssue', label: 'Report Issue' },
+                { id: 'seerrManage', label: 'Manage Requests' },
                 { id: 'admin', label: 'Admin' }
             ];
 
@@ -2182,11 +2238,21 @@
                 var ordered = [];
                 var addedSet = {};
 
+                function entryFor(btn) {
+                    var hideable = btn.canHide !== false;
+                    return {
+                        id: btn.id,
+                        label: btn.label,
+                        hideable: hideable,
+                        checked: hideable ? !hiddenSet[btn.id] : true
+                    };
+                }
+
                 if (order && Array.isArray(order) && order.length > 0) {
                     order.forEach(function(id) {
                         var btn = DETAIL_BUTTONS.find(function(b) { return b.id === id; });
                         if (btn) {
-                            ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                            ordered.push(entryFor(btn));
                             addedSet[btn.id] = true;
                         }
                     });
@@ -2194,7 +2260,7 @@
 
                 DETAIL_BUTTONS.forEach(function(btn) {
                     if (!addedSet[btn.id]) {
-                        ordered.push({ id: btn.id, label: btn.label, checked: !hiddenSet[btn.id] });
+                        ordered.push(entryFor(btn));
                     }
                 });
 
@@ -2205,7 +2271,9 @@
                     row.dataset.id = item.id;
                     row.style.cssText = 'display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:4px;margin-bottom:2px;background:rgba(255,255,255,0.03);';
                     row.innerHTML =
-                        '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">'
+                        (item.hideable
+                            ? '<input type="checkbox"' + (item.checked ? ' checked' : '') + ' style="accent-color:#00a4dc;width:16px;height:16px;flex-shrink:0;">'
+                            : '<span title="Always shown" style="width:16px;height:16px;flex-shrink:0;text-align:center;color:rgba(255,255,255,0.35);">&#x2713;</span>')
                         + '<span style="flex:1;font-size:0.9em;color:rgba(255,255,255,0.9);">' + esc(item.label) + '</span>'
                         + '<button type="button" class="detailButtonMoveBtn" data-dir="up" style="background:none;border:1px solid rgba(255,255,255,0.2);border-radius:3px;color:rgba(255,255,255,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2191;</button>'
                         + '<button type="button" class="detailButtonMoveBtn" data-dir="down" style="background:none;border:1px solid rgba(255,255,255,0.2);border-radius:3px;color:rgba(255,255,255,0.7);padding:1px 6px;cursor:pointer;font-size:0.85em;">&#x2193;</button>';
@@ -2318,22 +2386,30 @@
                 }
             }
 
-            function getSeerrDiscoveryValue() {
+            // Clients carry Seerr rows as seerrRows.rowOrder, which lists the visible
+            // rows in order and treats every row it leaves out as switched off.
+            function getSeerrDiscoveryRowOrder() {
                 var items = document.querySelectorAll('#DefaultSeerrDiscoveryList .seerrDiscoveryItem');
-                var order = [];
-                var hidden = [];
+                var rowOrder = [];
                 items.forEach(function(item) {
                     var cb = item.querySelector('input[type=checkbox]');
-                    var id = item.dataset.id;
-                    order.push(id);
-                    if (cb && !cb.checked) {
-                        hidden.push(id);
+                    if (!cb || cb.checked) {
+                        rowOrder.push(item.dataset.id);
                     }
                 });
-                return {
-                    order: order.length > 0 ? order : null,
-                    hidden: hidden.length > 0 ? hidden : null
-                };
+                return rowOrder.length > 0 ? rowOrder : null;
+            }
+
+            // Turns a stored rowOrder back into the picker's order plus hidden pair.
+            function seerrRowsToPicker(seerrRows) {
+                var rowOrder = seerrRows && Array.isArray(seerrRows.rowOrder) ? seerrRows.rowOrder : null;
+                if (!rowOrder || rowOrder.length === 0) return { order: null, hidden: null };
+                var visible = {};
+                rowOrder.forEach(function(id) { visible[id] = true; });
+                var hidden = SEERR_DISCOVERY_ROWS
+                    .filter(function(row) { return !visible[row.id]; })
+                    .map(function(row) { return row.id; });
+                return { order: rowOrder, hidden: hidden.length > 0 ? hidden : null };
             }
 
             var HOME_LAYOUT_TABS = [
@@ -3373,7 +3449,10 @@
                     setNullableBoolSelect('#DefaultDetailShowTechnicalDetails', defaults.detailShowTechnicalDetails);
                     setSelectValue('#DefaultRecommendationSystemSource', defaults.recommendationSystemSource, 'Configured source');
                     setNullableBoolSelect('#DefaultRecommendationsApplyParentalRatingCap', defaults.recommendationsApplyParentalRatingCap);
-                    loadDetailButtonsPicker(defaults.detailButtonOrder || null, defaults.hiddenDetailButtons || null);
+                    // One picker stands in for all three form factors.
+                    loadDetailButtonsPicker(
+                        defaults.detailButtonOrderTv || defaults.detailButtonOrderMobile || defaults.detailButtonOrderDesktop || null,
+                        defaults.hiddenDetailButtonsTv || defaults.hiddenDetailButtonsMobile || defaults.hiddenDetailButtonsDesktop || null);
                     setSelectValue('#DefaultFocusColor', defaults.focusColor, 'Configured color');
                     setSelectValue('#DefaultClockBehavior', defaults.clockBehavior, 'Configured clock');
                     setNullableBoolSelect('#DefaultUse24HourClock', defaults.use24HourClock);
@@ -3400,6 +3479,7 @@
                     setNullableBoolSelect('#DefaultShowSeerrButton', defaults.showSeerrButton);
 
                     setSelectValue('#DefaultMediaBarSourceType', defaults.mediaBarSourceType, 'Configured source');
+                    loadAdminGenrePicker(defaults.mediaBarExcludedGenres || []);
                     setSelectValue('#DefaultMediaBarMode', defaults.mediaBarMode, 'Configured mode');
                     setSelectValue('#DefaultMediaBarContentType', defaults.mediaBarContentType, 'Configured content type');
                     setSelectValue('#DefaultMediaBarItemCount', defaults.mediaBarItemCount, 'Configured item count');
@@ -3458,7 +3538,8 @@
                     setNullableBoolSelect('#DefaultMdblistShowRatingNames', defaults.mdblistShowRatingNames);
                     loadRatingSourcesPicker(defaults.mdblistRatingSources || null);
                     setNullableBoolSelect('#DefaultSeerrBlockNsfw', defaults.seerrBlockNsfw);
-                    loadSeerrDiscoveryPicker(defaults.seerrRowOrder || null, defaults.hiddenSeerrRows || null);
+                    var seerrPicker = seerrRowsToPicker(defaults.seerrRows);
+                    loadSeerrDiscoveryPicker(seerrPicker.order, seerrPicker.hidden);
 
                     var sourceSelect = document.querySelector('#DefaultMediaBarSourceType');
                     var collectionPickerSection = document.querySelector('#DefaultCollectionPickerSection');
@@ -3721,9 +3802,14 @@
                         config.DefaultUserSettings.detailShowTechnicalDetails = getNullableBoolSelect('#DefaultDetailShowTechnicalDetails');
                         config.DefaultUserSettings.recommendationSystemSource = document.querySelector('#DefaultRecommendationSystemSource').value || null;
                         config.DefaultUserSettings.recommendationsApplyParentalRatingCap = getNullableBoolSelect('#DefaultRecommendationsApplyParentalRatingCap');
+                        // Clients read a different key per form factor, so one arrangement covers all three.
                         var btnVal = getDetailButtonsValue();
-                        config.DefaultUserSettings.detailButtonOrder = btnVal.order;
-                        config.DefaultUserSettings.hiddenDetailButtons = btnVal.hidden;
+                        config.DefaultUserSettings.detailButtonOrderTv = btnVal.order;
+                        config.DefaultUserSettings.detailButtonOrderMobile = btnVal.order;
+                        config.DefaultUserSettings.detailButtonOrderDesktop = btnVal.order;
+                        config.DefaultUserSettings.hiddenDetailButtonsTv = btnVal.hidden;
+                        config.DefaultUserSettings.hiddenDetailButtonsMobile = btnVal.hidden;
+                        config.DefaultUserSettings.hiddenDetailButtonsDesktop = btnVal.hidden;
                         config.DefaultUserSettings.focusColor = document.querySelector('#DefaultFocusColor').value || null;
                         config.DefaultUserSettings.clockBehavior = document.querySelector('#DefaultClockBehavior').value || null;
                         config.DefaultUserSettings.use24HourClock = getNullableBoolSelect('#DefaultUse24HourClock');
@@ -3745,6 +3831,12 @@
                         config.DefaultUserSettings.showSeerrButton = getNullableBoolSelect('#DefaultShowSeerrButton');
 
                         config.DefaultUserSettings.mediaBarSourceType = document.querySelector('#DefaultMediaBarSourceType').value || null;
+                        var genreIds = [];
+                        var genreCbs = document.querySelectorAll('#DefaultGenrePicker .adminGenreCb:checked');
+                        for (var gi = 0; gi < genreCbs.length; gi++) {
+                            genreIds.push(genreCbs[gi].dataset.id);
+                        }
+                        config.DefaultUserSettings.mediaBarExcludedGenres = genreIds.length > 0 ? genreIds : null;
                         config.DefaultUserSettings.mediaBarMode = document.querySelector('#DefaultMediaBarMode').value || null;
                         config.DefaultUserSettings.mediaBarContentType = document.querySelector('#DefaultMediaBarContentType').value || null;
                         config.DefaultUserSettings.mediaBarItemCount = getNullableIntInput('#DefaultMediaBarItemCount');
@@ -3776,6 +3868,7 @@
                         config.DefaultUserSettings.classicHomeRowsPadding = getNullableIntInput('#DefaultClassicHomeRowsPadding');
                         config.DefaultUserSettings.modernHomeRowsPadding = getNullableIntInput('#DefaultModernHomeRowsPadding');
                         config.DefaultUserSettings.posterSize = document.querySelector('#DefaultPosterSize').value || null;
+                        config.DefaultUserSettings.homeImageTypeContinueWatching = document.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
                         config.DefaultUserSettings.displayFavoritesRows = getNullableBoolSelect('#DefaultDisplayFavoritesRows');
                         config.DefaultUserSettings.displayCollectionsRows = getNullableBoolSelect('#DefaultDisplayCollectionsRows');
                         config.DefaultUserSettings.displayGenresRows = getNullableBoolSelect('#DefaultDisplayGenresRows');
@@ -3814,9 +3907,10 @@
                         config.DefaultUserSettings.mdblistShowRatingNames = getNullableBoolSelect('#DefaultMdblistShowRatingNames');
                         config.DefaultUserSettings.mdblistRatingSources = getRatingSourcesValue();
                         config.DefaultUserSettings.seerrBlockNsfw = getNullableBoolSelect('#DefaultSeerrBlockNsfw');
-                        var seerrVal = getSeerrDiscoveryValue();
-                        config.DefaultUserSettings.seerrRowOrder = seerrVal.order;
-                        config.DefaultUserSettings.hiddenSeerrRows = seerrVal.hidden;
+                        // seerrRows carries more than the ordering, so merge rather than replace.
+                        var seerrRows = Object.assign({}, config.DefaultUserSettings.seerrRows || {});
+                        seerrRows.rowOrder = getSeerrDiscoveryRowOrder();
+                        config.DefaultUserSettings.seerrRows = seerrRows;
 
                         return ApiClient.updatePluginConfiguration(MoonfinConfig.pluginUniqueId, config).then(function(result) {
                             Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -3390,7 +3390,6 @@
                     setNullableRangeInput('#DefaultThemeMusicVolume', defaults.themeMusicVolume, '%');
                     setSelectValue('#DefaultWatchedIndicator', defaults.watchedIndicator, 'Configured mode');
                     setNullableBoolSelect('#DefaultCardFocusExpansion', defaults.cardFocusExpansion);
-                    setSelectValue('#DefaultScreensaverMode', defaults.screensaverMode, 'Configured mode');
 
                     setSelectValue('#DefaultNavbarPosition', defaults.navbarPosition, 'Configured position');
                     setSelectValue('#DefaultNavbarColor', defaults.navbarColor, 'Configured color');
@@ -3446,7 +3445,6 @@
                     setNullableBoolSelect('#DefaultShowShuffleButton', defaults.showShuffleButton);
                     setNullableBoolSelect('#DefaultShowGenresButton', defaults.showGenresButton);
                     setNullableBoolSelect('#DefaultShowFavoritesButton', defaults.showFavoritesButton);
-                    setCheckbox('#DefaultShowCastButton', defaults.showCastButton);
                     setCheckbox('#DefaultShowSyncPlayButton', defaults.showSyncPlayButton);
                     setNullableBoolSelect('#DefaultShowLibrariesInToolbar', defaults.showLibrariesInToolbar);
 
@@ -3738,7 +3736,6 @@
                         config.DefaultUserSettings.themeMusicLoop = getNullableBoolSelect('#DefaultThemeMusicLoop');
                         config.DefaultUserSettings.watchedIndicator = document.querySelector('#DefaultWatchedIndicator').value || null;
                         config.DefaultUserSettings.cardFocusExpansion = getNullableBoolSelect('#DefaultCardFocusExpansion');
-                        config.DefaultUserSettings.screensaverMode = document.querySelector('#DefaultScreensaverMode').value || null;
 
                         config.DefaultUserSettings.navbarPosition = document.querySelector('#DefaultNavbarPosition').value || null;
                         config.DefaultUserSettings.navbarColor = document.querySelector('#DefaultNavbarColor').value || null;
@@ -3805,7 +3802,6 @@
                         config.DefaultUserSettings.showShuffleButton = getNullableBoolSelect('#DefaultShowShuffleButton');
                         config.DefaultUserSettings.showGenresButton = getNullableBoolSelect('#DefaultShowGenresButton');
                         config.DefaultUserSettings.showFavoritesButton = getNullableBoolSelect('#DefaultShowFavoritesButton');
-                        config.DefaultUserSettings.showCastButton = getCheckbox('#DefaultShowCastButton');
                         config.DefaultUserSettings.showSyncPlayButton = getCheckbox('#DefaultShowSyncPlayButton');
                         config.DefaultUserSettings.showLibrariesInToolbar = getNullableBoolSelect('#DefaultShowLibrariesInToolbar');
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -860,7 +860,7 @@
                                 <div class="fieldDescription">Default layout for item detail pages. Keep Not set to let users choose.</div>
                             </div>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Details Background Opacity</label>
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDetailsScreenBlur">Details Screen Blur</label>
                                 <div style="display:flex; align-items:center; gap: 12px; margin-top: 6px; max-width: 440px;">
                                     <select id="DefaultDetailsScreenBlur_Set" is="emby-select" style="width: auto; min-width: 195px;">
                                         <option value="unset">Not set (user decides)</option>


### PR DESCRIPTION
# Pull Request

## Summary
The cleaning house PR. Makes the admin panel in Moonbase match Core as closely as possible in terms of headings, naming, values (e.g., sliders for 0-25 to match core), and so on. Adds interactive re-ordering pickers and visibility toggles for **Action Buttons** and **Seerr Discovery Rows** to the Moonfin admin settings pages across Jellyfin and Emby backends. Cleaned up legacy description text, fixed UI script null-safety, and added backend profile model properties (`SeerrRowOrder` and `HiddenSeerrRows`). All pushable to Core, Smart-TV, and Roku!

## Related Issues
Link related issues or tickets separated by commas.

- Closes #207 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [X] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added interactive Action Buttons re-ordering and visibility picker (**#DefaultDetailButtonsList**) to the **Details Screen** section containing all 16 enum options (**shuffle**, **restart**, **playOffline**, **audio**, **subtitles**, **version**, **cast**, **trailer**, **watchWithGroup**, **watched**, **favorite**, **playlist**, **download**, **deleteFiles**, **goToSeries**, **admin**).
- Added interactive Seerr Discovery Rows re-ordering and visibility picker (**#DefaultSeerrDiscoveryList**) under **Seerr** in the **Integrations** subtab containing all 12 discovery row types (**recent_requests**, **watchlist**, **recently_added**, **trending**, **popular_movies**, **movie_genres**, **upcoming_movies**, **studios**, **popular_series**, **series_genres**, **upcoming_series**, **networks**).
- Added `SeerrRowOrder` (`List<string>`) and `HiddenSeerrRows` (`List<string>`) to **MoonfinSettingsProfile.cs** in both Jellyfin and Emby backend models.
- Fixed frontend script null safety and bound static subtab button navigation (`bindDefaultSettingsSubTabs`).

Wired up and verified the following profile keys in the backend model (MoonfinSettingsProfile.cs) for syncing:
* recommendationSystemSource & recommendationsApplyParentalRatingCap
* detailShowTechnicalDetails & detailScreenStyle
* mediaBarContentType
* screensaverMode
* classicHomeRowsPadding & modernHomeRowsPadding
* themeMusicEnabled, themeMusicOnHomeRows, themeMusicVolume, themeMusicLoop
* mdblistRatingSources, mdblistShowRatingBadges, mdblistShowRatingNames
* showShuffleButton, showGenresButton, showFavoritesButton, showCastButton, showSyncPlayButton, showLibrariesInToolbar
* mergeContinueWatchingNextUp, nextUpMaxDays, enableMultiServerLibraries

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

detailButtonOrder: List<string>
hiddenDetailButtons: List<string>
seerrRowOrder: List<string>
hiddenSeerrRows: List<string>

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Windows Desktop
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built `Moonfin.Server.dll` (`v2.0.2.0`) and uploaded to `/volume1/@appdata/jellyfin/data/plugins/Moonbase_2.0.2.0/Moonfin.Server.dll` 
2. Restarted Jellyfin service on NAS and verified process running.
3. Loaded admin page, verified tab switching, Action Buttons picker, Seerr Discovery Rows picker, and settings save.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

Screenshots are in tab order.

### GENERAL STYLE
<img width="1536" height="1207" alt="2026-08-04_20-46-59_brave" src="https://github.com/user-attachments/assets/f986f472-4c3e-438c-b5b7-b1179c20cd62" />
<img width="1568" height="1158" alt="2026-08-04_20-47-08_brave" src="https://github.com/user-attachments/assets/4e4770d8-5223-42e9-8f3e-3fd20ecee1ac" />

### DETAILS SCREEN
<img width="1524" height="1008" alt="2026-08-04_20-47-31_brave" src="https://github.com/user-attachments/assets/500999ac-ba29-481f-8d12-0aa4e7a77dc7" />
<img width="1579" height="991" alt="2026-08-04_20-47-39_brave" src="https://github.com/user-attachments/assets/f5b758e6-d55d-4e11-9aa0-8715ea98f9a1" />

### NAVIGATION
<img width="1483" height="1090" alt="2026-08-04_20-47-49_brave" src="https://github.com/user-attachments/assets/81b01be4-7760-4929-8572-cfc9604fbc9a" />
<img width="1563" height="819" alt="2026-08-04_20-47-56_brave" src="https://github.com/user-attachments/assets/5b91acc0-eb23-429a-8a5b-4de7fac95f91" />

### HOME SCREEN
<img width="1574" height="1448" alt="2026-08-04_20-48-27_brave" src="https://github.com/user-attachments/assets/52fe3870-742b-402f-a2cf-d29bec17bef4" />

### HOME SECTIONS (unchanged)
<img width="1581" height="1114" alt="2026-08-04_20-48-36_brave" src="https://github.com/user-attachments/assets/542a6a37-0854-4455-97f5-c993562673de" />

### LIBRARIES
<img width="1498" height="1151" alt="2026-08-04_20-48-51_brave" src="https://github.com/user-attachments/assets/43b8215c-2a52-45d4-be56-d1f16d5f52bd" />

### EXTRAS
<img width="1499" height="1048" alt="2026-08-04_20-49-02_brave" src="https://github.com/user-attachments/assets/c9cd465e-2da5-447f-a849-f08167f5fcda" />
<img width="1277" height="1268" alt="2026-08-04_20-49-12_brave" src="https://github.com/user-attachments/assets/e5eb6b61-0c6c-4b2f-90bd-61cc6de2c69a" />
<img width="1255" height="699" alt="2026-08-04_20-49-34_brave" src="https://github.com/user-attachments/assets/f62ed5d5-0787-4a38-802e-c81b1e17b11b" />

### INTEGRATIONS
<img width="1590" height="1164" alt="2026-08-04_20-49-52_brave" src="https://github.com/user-attachments/assets/949df8e2-fc71-4825-a5dd-43331b9bdc6e" />
<img width="1589" height="949" alt="2026-08-04_20-50-05_brave" src="https://github.com/user-attachments/assets/c68f9acb-c46b-4878-a477-8e70e6c8ffb2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
