### PR TITLE
feat-sync - Add user preference sync for spoiler toggles and a couple small fixes

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -117,6 +117,9 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("mediaBarContentType")] public string? MediaBarContentType { get; set; }
 
         [JsonPropertyName("detailShowTechnicalDetails")] public bool? DetailShowTechnicalDetails { get; set; }
+        [JsonPropertyName("hideDetailsMediaDescription")] public bool? HideDetailsMediaDescription { get; set; }
+        [JsonPropertyName("detailUseSeriesThumbnails")] public bool? DetailUseSeriesThumbnails { get; set; }
+        [JsonPropertyName("hideHomeMediaDescription")] public bool? HideHomeMediaDescription { get; set; }
         [JsonPropertyName("recommendationSystemSource")] public string? RecommendationSystemSource { get; set; }
         [JsonPropertyName("recommendationsApplyParentalRatingCap")] public bool? RecommendationsApplyParentalRatingCap { get; set; }
 

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1950,19 +1950,19 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.stillWatchingBehavior = view.querySelector('#DefaultStillWatchingBehavior').value || null;
 
             if (view.querySelector('#DefaultCollectionPicker .adminCollectionCb')) {
-                var collectionIds = Array.prototype.slice.call(view.querySelectorAll('.adminCollectionCb:checked')).map(function (cb) { return cb.dataset.id; });
+                var collectionIds = Array.prototype.slice.call(view.querySelectorAll('#DefaultCollectionPicker .adminCollectionCb:checked')).map(function (cb) { return cb.dataset.id; });
                 d.mediaBarCollectionIds = collectionIds.length > 0 ? collectionIds : null;
             }
             if (view.querySelector('#DefaultLibraryPicker .adminLibraryCb')) {
-                var libraryIds = Array.prototype.slice.call(view.querySelectorAll('.adminLibraryCb:checked')).map(function (cb) { return cb.dataset.id; });
+                var libraryIds = Array.prototype.slice.call(view.querySelectorAll('#DefaultLibraryPicker .adminLibraryCb:checked')).map(function (cb) { return cb.dataset.id; });
                 d.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
             }
 
             d.homeRowsStyle = view.querySelector('#DefaultHomeRowsStyle').value || null;
             d.fullScreenRows = getNullableBoolSelect(view, '#DefaultFullScreenRows');
             d.homeRowInfoOverlay = getNullableBoolSelect(view, '#DefaultHomeRowInfoOverlay');
-            d.classicHomeRowsPadding = getNullableIntInput(view, '#DefaultClassicHomeRowsPadding');
-            d.modernHomeRowsPadding = getNullableIntInput(view, '#DefaultModernHomeRowsPadding');
+            d.classicHomeRowsPadding = getNullableRangeInput(view, '#DefaultClassicHomeRowsPadding');
+            d.modernHomeRowsPadding = getNullableRangeInput(view, '#DefaultModernHomeRowsPadding');
             d.posterSize = view.querySelector('#DefaultPosterSize').value || null;
             d.homeImageTypeContinueWatching = view.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
             d.displayFavoritesRows = getNullableBoolSelect(view, '#DefaultDisplayFavoritesRows');

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1949,10 +1949,14 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.nextUpTimeout = getNullableIntInput(view, '#DefaultNextUpTimeout');
             d.stillWatchingBehavior = view.querySelector('#DefaultStillWatchingBehavior').value || null;
 
-            var collectionIds = Array.prototype.slice.call(view.querySelectorAll('.adminCollectionCb:checked')).map(function (cb) { return cb.dataset.id; });
-            d.mediaBarCollectionIds = collectionIds.length > 0 ? collectionIds : null;
-            var libraryIds = Array.prototype.slice.call(view.querySelectorAll('.adminLibraryCb:checked')).map(function (cb) { return cb.dataset.id; });
-            d.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
+            if (view.querySelector('#DefaultCollectionPicker .adminCollectionCb')) {
+                var collectionIds = Array.prototype.slice.call(view.querySelectorAll('.adminCollectionCb:checked')).map(function (cb) { return cb.dataset.id; });
+                d.mediaBarCollectionIds = collectionIds.length > 0 ? collectionIds : null;
+            }
+            if (view.querySelector('#DefaultLibraryPicker .adminLibraryCb')) {
+                var libraryIds = Array.prototype.slice.call(view.querySelectorAll('.adminLibraryCb:checked')).map(function (cb) { return cb.dataset.id; });
+                d.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
+            }
 
             d.homeRowsStyle = view.querySelector('#DefaultHomeRowsStyle').value || null;
             d.fullScreenRows = getNullableBoolSelect(view, '#DefaultFullScreenRows');

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -328,6 +328,15 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("detailShowTechnicalDetails")]
     public bool? DetailShowTechnicalDetails { get; set; }
 
+    [JsonPropertyName("hideDetailsMediaDescription")]
+    public bool? HideDetailsMediaDescription { get; set; }
+
+    [JsonPropertyName("detailUseSeriesThumbnails")]
+    public bool? DetailUseSeriesThumbnails { get; set; }
+
+    [JsonPropertyName("hideHomeMediaDescription")]
+    public bool? HideHomeMediaDescription { get; set; }
+
     [JsonPropertyName("recommendationSystemSource")]
     public string? RecommendationSystemSource { get; set; }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -3997,7 +3997,7 @@
                         config.DefaultUserSettings.use24HourClock = getNullableBoolSelect('#DefaultUse24HourClock');
                         config.DefaultUserSettings.desktopUiScale = document.querySelector('#DefaultDesktopUiScale').value || null;
                         config.DefaultUserSettings.backdropEnabled = getNullableBoolSelect('#DefaultBackdropEnabled');
-                        config.DefaultUserSettings.browsingBlur = getNullableIntInput('#DefaultBrowsingBlur');
+                        config.DefaultUserSettings.browsingBlur = getNullableRangeInput('#DefaultBrowsingBlur');
                         config.DefaultUserSettings.detailsScreenBlur = getNullableRangeInput('#DefaultDetailsScreenBlur');
                         config.DefaultUserSettings.themeMusicEnabled = getNullableBoolSelect('#DefaultThemeMusicEnabled');
                         config.DefaultUserSettings.themeMusicOnHomeRows = getNullableBoolSelect('#DefaultThemeMusicOnHomeRows');
@@ -4007,7 +4007,7 @@
 
                         config.DefaultUserSettings.navbarPosition = document.querySelector('#DefaultNavbarPosition').value || null;
                         config.DefaultUserSettings.navbarColor = document.querySelector('#DefaultNavbarColor').value || null;
-                        config.DefaultUserSettings.navbarOpacity = getNullableIntInput('#DefaultNavbarOpacity');
+                        config.DefaultUserSettings.navbarOpacity = getNullableRangeInput('#DefaultNavbarOpacity');
                         config.DefaultUserSettings.navbarAlwaysExpanded = getNullableBoolSelect('#DefaultNavbarAlwaysExpanded');
                         config.DefaultUserSettings.enableFolderView = getNullableBoolSelect('#DefaultEnableFolderView');
                         config.DefaultUserSettings.showSeerrButton = getNullableBoolSelect('#DefaultShowSeerrButton');
@@ -4070,8 +4070,8 @@
                         config.DefaultUserSettings.homeRowsStyle = document.querySelector('#DefaultHomeRowsStyle').value || null;
                         config.DefaultUserSettings.fullScreenRows = getNullableBoolSelect('#DefaultFullScreenRows');
                         config.DefaultUserSettings.homeRowInfoOverlay = getNullableBoolSelect('#DefaultHomeRowInfoOverlay');
-                        config.DefaultUserSettings.classicHomeRowsPadding = getNullableIntInput('#DefaultClassicHomeRowsPadding');
-                        config.DefaultUserSettings.modernHomeRowsPadding = getNullableIntInput('#DefaultModernHomeRowsPadding');
+                        config.DefaultUserSettings.classicHomeRowsPadding = getNullableRangeInput('#DefaultClassicHomeRowsPadding');
+                        config.DefaultUserSettings.modernHomeRowsPadding = getNullableRangeInput('#DefaultModernHomeRowsPadding');
                         config.DefaultUserSettings.posterSize = document.querySelector('#DefaultPosterSize').value || null;
                         config.DefaultUserSettings.homeImageTypeContinueWatching = document.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
                         config.DefaultUserSettings.displayFavoritesRows = getNullableBoolSelect('#DefaultDisplayFavoritesRows');

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -3998,7 +3998,7 @@
                         config.DefaultUserSettings.desktopUiScale = document.querySelector('#DefaultDesktopUiScale').value || null;
                         config.DefaultUserSettings.backdropEnabled = getNullableBoolSelect('#DefaultBackdropEnabled');
                         config.DefaultUserSettings.browsingBlur = getNullableIntInput('#DefaultBrowsingBlur');
-                        config.DefaultUserSettings.detailsScreenBlur = getNullableIntInput('#DefaultDetailsScreenBlur');
+                        config.DefaultUserSettings.detailsScreenBlur = getNullableRangeInput('#DefaultDetailsScreenBlur');
                         config.DefaultUserSettings.themeMusicEnabled = getNullableBoolSelect('#DefaultThemeMusicEnabled');
                         config.DefaultUserSettings.themeMusicOnHomeRows = getNullableBoolSelect('#DefaultThemeMusicOnHomeRows');
                         config.DefaultUserSettings.themeMusicLoop = getNullableBoolSelect('#DefaultThemeMusicLoop');
@@ -4049,18 +4049,22 @@
                         config.DefaultUserSettings.nextUpTimeout = getNullableIntInput('#DefaultNextUpTimeout');
                         config.DefaultUserSettings.stillWatchingBehavior = document.querySelector('#DefaultStillWatchingBehavior').value || null;
 
-                        var collectionCbs = document.querySelectorAll('.adminCollectionCb:checked');
-                        var collectionIds = [];
-                        for (var ci = 0; ci < collectionCbs.length; ci++) {
-                            collectionIds.push(collectionCbs[ci].dataset.id);
+                        if (document.querySelector('#DefaultCollectionPicker .adminCollectionCb') != null) {
+                            var collectionCbs = document.querySelectorAll('#DefaultCollectionPicker .adminCollectionCb:checked');
+                            var collectionIds = [];
+                            for (var ci = 0; ci < collectionCbs.length; ci++) {
+                                collectionIds.push(collectionCbs[ci].dataset.id);
+                            }
+                            config.DefaultUserSettings.mediaBarCollectionIds = collectionIds.length > 0 ? collectionIds : null;
                         }
-                        config.DefaultUserSettings.mediaBarCollectionIds = collectionIds.length > 0 ? collectionIds : null;
-                        var libraryCbs = document.querySelectorAll('.adminLibraryCb:checked');
-                        var libraryIds = [];
-                        for (var li = 0; li < libraryCbs.length; li++) {
-                            libraryIds.push(libraryCbs[li].dataset.id);
+                        if (document.querySelector('#DefaultLibraryPicker .adminLibraryCb') != null) {
+                            var libraryCbs = document.querySelectorAll('#DefaultLibraryPicker .adminLibraryCb:checked');
+                            var libraryIds = [];
+                            for (var li = 0; li < libraryCbs.length; li++) {
+                                libraryIds.push(libraryCbs[li].dataset.id);
+                            }
+                            config.DefaultUserSettings.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
                         }
-                        config.DefaultUserSettings.mediaBarLibraryIds = libraryIds.length > 0 ? libraryIds : null;
 
 
                         config.DefaultUserSettings.homeRowsStyle = document.querySelector('#DefaultHomeRowsStyle').value || null;


### PR DESCRIPTION
# Pull Request

## Summary
Adds settings profile backend sync properties for 3 spoiler-free preference toggles (`hideDetailsMediaDescription`, `detailUseSeriesThumbnails`, `hideHomeMediaDescription`), fixes `detailsScreenBlur` background opacity/blur linking on the config page, and safeguards media bar collection/library sources from being cleared on save.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes # https://github.com/Moonfin-Client/Moonfin-Core/issues/1087
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1088

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `hideDetailsMediaDescription`, `detailUseSeriesThumbnails`, and `hideHomeMediaDescription` properties to **MoonfinSettingsProfile.cs** in both Jellyfin and Emby backend models to enable multi-device profile sync (`desktop`, `mobile`, `tv`).
- Fixed `detailsScreenBlur` save logic in **configPage.html** to save via `getNullableRangeInput('#DefaultDetailsScreenBlur')` as a numeric string (e.g. `'10'`) matching C# models and per-device profile syncing.
- Safeguarded `mediaBarCollectionIds` and `mediaBarLibraryIds` save logic in **configPage.html** and **moonfin.js** so saving settings forms when the collection/library picker is unrendered does not overwrite saved collection IDs with `null`.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1088
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `hideDetailsMediaDescription` (bool?)
  - `detailUseSeriesThumbnails` (bool?)
  - `hideHomeMediaDescription` (bool?)

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [ X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Verified JSON property names and types match Moonfin-Core `synced_fields.dart` keys exactly.
2. Verified `detailsScreenBlur` range input string formatting matches C# `string? DetailsScreenBlur` model expectations.
3. Verified `mediaBarCollectionIds` and `mediaBarLibraryIds` DOM existence checks prevent null overwrites on hidden tabs.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
