### PR TITLE
feat-homerows - Add home row sort order properties to MoonfinSettingsProfile for cross-device sync

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -86,8 +86,11 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("displayPlaylistsRows")] public bool? DisplayPlaylistsRows { get; set; }
         [JsonPropertyName("displayAudioRows")] public bool? DisplayAudioRows { get; set; }
         [JsonPropertyName("favoritesRowSortBy")] public string? FavoritesRowSortBy { get; set; }
+        [JsonPropertyName("favoritesRowSortOrder")] public string? FavoritesRowSortOrder { get; set; }
         [JsonPropertyName("collectionsRowSortBy")] public string? CollectionsRowSortBy { get; set; }
+        [JsonPropertyName("collectionsRowSortOrder")] public string? CollectionsRowSortOrder { get; set; }
         [JsonPropertyName("genresRowSortBy")] public string? GenresRowSortBy { get; set; }
+        [JsonPropertyName("genresRowSortOrder")] public string? GenresRowSortOrder { get; set; }
         [JsonPropertyName("genresRowItemFilter")] public string? GenresRowItemFilter { get; set; }
         [JsonPropertyName("navbarAlwaysExpanded")] public bool? NavbarAlwaysExpanded { get; set; }
         [JsonPropertyName("mediaBarTrailerCaptions")] public bool? MediaBarTrailerCaptions { get; set; }
@@ -253,7 +256,9 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("showMediaDetailsOnLibraryPage")] public bool? ShowMediaDetailsOnLibraryPage { get; set; }
         [JsonPropertyName("hideBackdropsInLibraries")] public bool? HideBackdropsInLibraries { get; set; }
         [JsonPropertyName("playlistsRowSortBy")] public string? PlaylistsRowSortBy { get; set; }
+        [JsonPropertyName("playlistsRowSortOrder")] public string? PlaylistsRowSortOrder { get; set; }
         [JsonPropertyName("audioRowsSortBy")] public string? AudioRowsSortBy { get; set; }
+        [JsonPropertyName("audioRowsSortOrder")] public string? AudioRowsSortOrder { get; set; }
         [JsonPropertyName("epgMobileView")] public string? EpgMobileView { get; set; }
         [JsonPropertyName("sinceYouWatched1Enabled")] public bool? SinceYouWatched1Enabled { get; set; }
         [JsonPropertyName("sinceYouWatched2Enabled")] public bool? SinceYouWatched2Enabled { get; set; }

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -299,11 +299,20 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("favoritesRowSortBy")]
     public string? FavoritesRowSortBy { get; set; }
 
+    [JsonPropertyName("favoritesRowSortOrder")]
+    public string? FavoritesRowSortOrder { get; set; }
+
     [JsonPropertyName("collectionsRowSortBy")]
     public string? CollectionsRowSortBy { get; set; }
 
+    [JsonPropertyName("collectionsRowSortOrder")]
+    public string? CollectionsRowSortOrder { get; set; }
+
     [JsonPropertyName("genresRowSortBy")]
     public string? GenresRowSortBy { get; set; }
+
+    [JsonPropertyName("genresRowSortOrder")]
+    public string? GenresRowSortOrder { get; set; }
 
     [JsonPropertyName("genresRowItemFilter")]
     public string? GenresRowItemFilter { get; set; }
@@ -710,8 +719,14 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("playlistsRowSortBy")]
     public string? PlaylistsRowSortBy { get; set; }
 
+    [JsonPropertyName("playlistsRowSortOrder")]
+    public string? PlaylistsRowSortOrder { get; set; }
+
     [JsonPropertyName("audioRowsSortBy")]
     public string? AudioRowsSortBy { get; set; }
+
+    [JsonPropertyName("audioRowsSortOrder")]
+    public string? AudioRowsSortOrder { get; set; }
 
     [JsonPropertyName("epgMobileView")]
     public string? EpgMobileView { get; set; }


### PR DESCRIPTION
# Pull Request

## Summary
Add 5 home row sort order properties (`favoritesRowSortOrder`, `collectionsRowSortOrder`, `genresRowSortOrder`, `playlistsRowSortOrder`, `audioRowsSortOrder`) to `MoonfinSettingsProfile` in both Jellyfin and Emby server plugin models to support cross-device synchronization for Moonfin client preferences.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1120 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `FavoritesRowSortOrder`, `CollectionsRowSortOrder`, `GenresRowSortOrder`, `PlaylistsRowSortOrder`, and `AudioRowsSortOrder` nullable string properties to `MoonfinSettingsProfile` in **Jellyfin/backend/Models/MoonfinSettingsProfile.cs**.
- Added corresponding properties to `MoonfinSettingsProfile` in **Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs**.


## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1120 
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `favoritesRowSortOrder`
  - `collectionsRowSortOrder`
  - `genresRowSortOrder`
  - `playlistsRowSortOrder`
  - `audioRowsSortOrder`
 
## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why): Just adding keys and only have one device of each type 😂 

### Test Steps
1. Build `Moonfin.Server.csproj` via `dotnet build`.
2. Sync preferences from Moonfin-Core with server profile.
3. Verify all 5 sort order fields deserialize and persist in `MoonfinSettingsProfile`.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
