### PR TITLE
Recently released series type

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -292,6 +292,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("collectionsRowShowEpisodes")] public bool? CollectionsRowShowEpisodes { get; set; }
         [JsonPropertyName("mergeRecentRowsByType")] public bool? MergeRecentRowsByType { get; set; }
         [JsonPropertyName("playlistsRowShowEpisodes")] public bool? PlaylistsRowShowEpisodes { get; set; }
+        [JsonPropertyName("recentlyReleasedSeriesType")] public string? RecentlyReleasedSeriesType { get; set; }
     }
 
     /// <summary>

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1350,6 +1350,16 @@
                                 </select>
                                 <div class="fieldDescription">Combines recently added media from different libraries of the same type into unified rows.</div>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRecentlyReleasedSeriesType">Recently Released Series Sort By</label>
+                                <select id="DefaultRecentlyReleasedSeriesType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="series">Series</option>
+                                    <option value="season">Season</option>
+                                    <option value="episode">Episode</option>
+                                </select>
+                                <div class="fieldDescription">Sort Recently Released Series home rows by series, latest season, or latest episode air date.</div>
+                            </div>
 
                             <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Library View</h4>
                             <div class="inputContainer">

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1817,6 +1817,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
             setNullableBoolSelect(view, '#DefaultEnableMultiServerLibraries', defaults.enableMultiServerLibraries);
             setNullableBoolSelect(view, '#DefaultMergeRecentRowsByType', defaults.mergeRecentRowsByType);
+            setSelectValue(view, '#DefaultRecentlyReleasedSeriesType', defaults.recentlyReleasedSeriesType, 'Configured sort');
             setNullableBoolSelect(view, '#DefaultGroupItemsIntoCollections', defaults.groupItemsIntoCollections);
             setNullableBoolSelect(view, '#DefaultShowMediaDetailsOnLibraryPage', defaults.showMediaDetailsOnLibraryPage);
             setNullableBoolSelect(view, '#DefaultUseDetailedSubHeadings', defaults.useDetailedSubHeadings);
@@ -1978,6 +1979,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
             d.enableMultiServerLibraries = getNullableBoolSelect(view, '#DefaultEnableMultiServerLibraries');
             d.mergeRecentRowsByType = getNullableBoolSelect(view, '#DefaultMergeRecentRowsByType');
+            d.recentlyReleasedSeriesType = view.querySelector('#DefaultRecentlyReleasedSeriesType').value || null;
             d.groupItemsIntoCollections = getNullableBoolSelect(view, '#DefaultGroupItemsIntoCollections');
             d.showMediaDetailsOnLibraryPage = getNullableBoolSelect(view, '#DefaultShowMediaDetailsOnLibraryPage');
             d.useDetailedSubHeadings = getNullableBoolSelect(view, '#DefaultUseDetailedSubHeadings');

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -820,6 +820,9 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("playlistsRowShowEpisodes")]
     public bool? PlaylistsRowShowEpisodes { get; set; }
+
+    [JsonPropertyName("recentlyReleasedSeriesType")]
+    public string? RecentlyReleasedSeriesType { get; set; }
 }
 
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1135,6 +1135,16 @@
                                 </select>
                                 <div class="fieldDescription">Combines recently added media from different libraries of the same type into unified rows.</div>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRecentlyReleasedSeriesType">Recently Released Series Sort By</label>
+                                <select id="DefaultRecentlyReleasedSeriesType" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="series">Series</option>
+                                    <option value="season">Season</option>
+                                    <option value="episode">Episode</option>
+                                </select>
+                                <div class="fieldDescription">Sort Recently Released Series home rows by series, latest season, or latest episode air date.</div>
+                            </div>
 
                             <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Library View</h4>
                             <div class="inputContainer">
@@ -3682,6 +3692,7 @@
 
                     setNullableBoolSelect('#DefaultEnableMultiServerLibraries', defaults.enableMultiServerLibraries);
                     setNullableBoolSelect('#DefaultMergeRecentRowsByType', defaults.mergeRecentRowsByType);
+                    setSelectValue('#DefaultRecentlyReleasedSeriesType', defaults.recentlyReleasedSeriesType, 'Configured sort');
                     setNullableBoolSelect('#DefaultGroupItemsIntoCollections', defaults.groupItemsIntoCollections);
                     setNullableBoolSelect('#DefaultShowMediaDetailsOnLibraryPage', defaults.showMediaDetailsOnLibraryPage);
                     setNullableBoolSelect('#DefaultUseDetailedSubHeadings', defaults.useDetailedSubHeadings);
@@ -4087,6 +4098,7 @@
 
                         config.DefaultUserSettings.enableMultiServerLibraries = getNullableBoolSelect('#DefaultEnableMultiServerLibraries');
                         config.DefaultUserSettings.mergeRecentRowsByType = getNullableBoolSelect('#DefaultMergeRecentRowsByType');
+                        config.DefaultUserSettings.recentlyReleasedSeriesType = document.querySelector('#DefaultRecentlyReleasedSeriesType').value || null;
                         config.DefaultUserSettings.groupItemsIntoCollections = getNullableBoolSelect('#DefaultGroupItemsIntoCollections');
                         config.DefaultUserSettings.showMediaDetailsOnLibraryPage = getNullableBoolSelect('#DefaultShowMediaDetailsOnLibraryPage');
                         config.DefaultUserSettings.useDetailedSubHeadings = getNullableBoolSelect('#DefaultUseDetailedSubHeadings');


### PR DESCRIPTION
# Pull Request

## Summary
Make new "recently released series sort by" option syncable on jellyfin and emby

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to https://github.com/Moonfin-Client/Moonfin-Core/pull/1155 https://github.com/Moonfin-Client/Roku/pull/231 https://github.com/Moonfin-Client/Smart-TV/pull/361

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- add recentlyReleasedSeriesType to settings for jellyfin/emby
- add it to config page for defaults config
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1155 
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
