### PR TITLE
Fix IMDb chart 403s by sending Origin and Referer headers

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Services/ImdbChartFetcher.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/ImdbChartFetcher.cs
@@ -74,6 +74,8 @@ namespace Emby.Plugins.Moonfin.Services
             };
             request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
             request.Headers.Accept.ParseAdd("application/json");
+            request.Headers.TryAddWithoutValidation("Origin", "https://www.imdb.com");
+            request.Headers.Referrer = new Uri("https://www.imdb.com/");
 
             using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/Jellyfin/backend/Services/ImdbListsTask.cs
+++ b/Jellyfin/backend/Services/ImdbListsTask.cs
@@ -131,6 +131,8 @@ public class ImdbListsTask : IScheduledTask
         };
         request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
         request.Headers.Accept.ParseAdd("application/json");
+        request.Headers.TryAddWithoutValidation("Origin", "https://www.imdb.com");
+        request.Headers.Referrer = new Uri("https://www.imdb.com/");
 
         using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes IMDb chart requests returning HTTP 403 from `https://caching.graphql.imdb.com/`.

IMDb's GraphQL endpoint currently requires requests to include both an `Origin` and `Referer` matching `https://www.imdb.com`. Moonfin already sends a browser User-Agent and `Accept: application/json`, but without these two headers all six built-in IMDb chart requests return 403.

This PR adds the two required request headers to `ImdbListsTask`:

- `Origin: https://www.imdb.com`
- `Referer: https://www.imdb.com/`

No other request or plugin behavior is changed.

## Related Issues
- Closes #
- Fixes #242
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [x] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Add `Origin: https://www.imdb.com` to IMDb GraphQL requests.
- Add `Referer: https://www.imdb.com/` to IMDb GraphQL requests.
- Preserve the existing IMDb chart request, parsing, caching, and scheduled-task behavior unchanged.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [x] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
No settings-profile or schema changes are made by this PR.

- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [x] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Tested with Moonfin Server plugin 2.0.3.0 on Jellyfin 10.11.11 and Moonfin Web 2.4.0.

Before applying the change, the same IMDb GraphQL request produced:

- Existing Moonfin headers: HTTP 403
- Existing headers + `Origin` only: HTTP 403
- Existing headers + both `Origin` and `Referer`: HTTP 200 with valid `chartTitles` JSON

The behavior was reproduced across all six built-in IMDb charts:

- Top Rated Movies
- Top Rated TV Shows
- Most Popular Movies
- Most Popular TV Shows
- Lowest Rated Movies
- Top Rated English Movies

The plugin was then built with only these two header additions and deployed to a live Jellyfin server. After restarting Jellyfin, IMDb-backed Moonfin rows populated successfully, including Top 250 Movies and Most Popular Movies.

- [x] Built the plugin and deployed to a Jellyfin server
- [x] Verified against a live client (which one: Moonfin Web 2.4.0)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Enable IMDb lists in the Moonfin plugin and enable an IMDb-backed custom home row.
2. Run the `Moonfin IMDb Lists Sync` scheduled task or trigger an on-demand IMDb list fetch.
3. Confirm the IMDb GraphQL request returns HTTP 200 and that the corresponding Moonfin home row populates with IMDb titles.

## Screenshots (if applicable)
Issue #242 includes the original Jellyfin log showing the HTTP 403 failure. After applying this patch, the IMDb-backed rows populated normally in Moonfin.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
- [x] Any new setting keys match the client-side keys exactly