### PR TITLE
Home image type

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1304,8 +1304,7 @@
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageTypeContinueWatching">Continue Watching Image Type</label>
                                 <select id="DefaultHomeImageTypeContinueWatching" is="emby-select">
                                     <option value="">Not set (user decides)</option>
-                                    <option value="Primary">Poster</option>
-                                    <option value="Backdrop">Backdrop</option>
+                                    <option value="Poster">Poster</option>
                                     <option value="Thumb">Thumbnail</option>
                                     <option value="Banner">Banner</option>
                                 </select>

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1089,8 +1089,7 @@
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultHomeImageTypeContinueWatching">Continue Watching Image Type</label>
                                 <select id="DefaultHomeImageTypeContinueWatching" is="emby-select">
                                     <option value="">Not set (user decides)</option>
-                                    <option value="Primary">Poster</option>
-                                    <option value="Backdrop">Backdrop</option>
+                                    <option value="Poster">Poster</option>
                                     <option value="Thumb">Thumbnail</option>
                                     <option value="Banner">Banner</option>
                                 </select>


### PR DESCRIPTION
# Pull Request

## Summary
Core/base had the options misaligned for image types

This pr aligns them so client changes reflect what the user pushes in the plugin

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #221
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- change the old options list: primary, backdrop, thumb, banner
- to the core options list: poster, thumb, banner
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one: desktop)
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Select continue watching image type on moonbase and push to user
2. See change accurately reflected in the client (tested on desktop)
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
