### PR TITLE
bugfix-audiobooks - Ensure Bookmarks and Notes are backed up and synced across clients

### DIFF
--- a/Jellyfin/backend/Api/UserBookmarksController.cs
+++ b/Jellyfin/backend/Api/UserBookmarksController.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moonfin.Server.Models;
+using Moonfin.Server.Services;
+
+namespace Moonfin.Server.Api;
+
+/// <summary>
+/// Controller for managing user audiobook and book bookmarks &amp; notes sync.
+/// </summary>
+[ApiController]
+[Route("Moonfin/Bookmarks")]
+[Produces(MediaTypeNames.Application.Json)]
+public class UserBookmarksController : ControllerBase
+{
+    private readonly UserBookmarksService _bookmarksService;
+    private readonly ILogger<UserBookmarksController> _logger;
+
+    public UserBookmarksController(
+        UserBookmarksService bookmarksService,
+        ILogger<UserBookmarksController> logger)
+    {
+        _bookmarksService = bookmarksService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets all bookmarks and notes for the authenticated user across all items.
+    /// </summary>
+    [HttpGet]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<UserBookmarksEnvelope>> GetAllBookmarks()
+    {
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { Error = "User not authenticated" });
+        }
+
+        var envelope = await _bookmarksService.GetUserBookmarksAsync(userId.Value);
+        return Ok(envelope);
+    }
+
+    /// <summary>
+    /// Gets bookmarks and notes for a specific item for the authenticated user.
+    /// </summary>
+    [HttpGet("{itemId}")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<UserItemUserDataDto>> GetItemUserData([FromRoute] string itemId)
+    {
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { Error = "User not authenticated" });
+        }
+
+        var data = await _bookmarksService.GetItemUserDataAsync(userId.Value, itemId);
+        return Ok(data);
+    }
+
+    /// <summary>
+    /// Saves bookmarks for a specific item for the authenticated user.
+    /// </summary>
+    [HttpPost("{itemId}")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult> SaveItemBookmarks(
+        [FromRoute] string itemId,
+        [FromBody] List<BookmarkDto> bookmarks)
+    {
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { Error = "User not authenticated" });
+        }
+
+        await _bookmarksService.SaveItemBookmarksAsync(userId.Value, itemId, bookmarks ?? new List<BookmarkDto>());
+        return Ok(new { Success = true, ItemId = itemId });
+    }
+
+    /// <summary>
+    /// Saves notes for a specific item for the authenticated user.
+    /// </summary>
+    [HttpPost("{itemId}/Notes")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult> SaveItemNotes(
+        [FromRoute] string itemId,
+        [FromBody] List<NoteDto> notes)
+    {
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { Error = "User not authenticated" });
+        }
+
+        await _bookmarksService.SaveItemNotesAsync(userId.Value, itemId, notes ?? new List<NoteDto>());
+        return Ok(new { Success = true, ItemId = itemId });
+    }
+}

--- a/Jellyfin/backend/Api/UserBookmarksController.cs
+++ b/Jellyfin/backend/Api/UserBookmarksController.cs
@@ -45,8 +45,15 @@ public class UserBookmarksController : ControllerBase
             return Unauthorized(new { Error = "User not authenticated" });
         }
 
-        var envelope = await _bookmarksService.GetUserBookmarksAsync(userId.Value);
-        return Ok(envelope);
+        try
+        {
+            return Ok(await _bookmarksService.GetUserBookmarksAsync(userId.Value));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading bookmarks for user {UserId}", userId);
+            return StatusCode(500, "Error reading bookmarks.");
+        }
     }
 
     /// <summary>
@@ -64,8 +71,15 @@ public class UserBookmarksController : ControllerBase
             return Unauthorized(new { Error = "User not authenticated" });
         }
 
-        var data = await _bookmarksService.GetItemUserDataAsync(userId.Value, itemId);
-        return Ok(data);
+        try
+        {
+            return Ok(await _bookmarksService.GetItemUserDataAsync(userId.Value, itemId));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading bookmarks for user {UserId}, item {ItemId}", userId, itemId);
+            return StatusCode(500, "Error reading bookmarks.");
+        }
     }
 
     /// <summary>
@@ -85,8 +99,16 @@ public class UserBookmarksController : ControllerBase
             return Unauthorized(new { Error = "User not authenticated" });
         }
 
-        await _bookmarksService.SaveItemBookmarksAsync(userId.Value, itemId, bookmarks ?? new List<BookmarkDto>());
-        return Ok(new { Success = true, ItemId = itemId });
+        try
+        {
+            await _bookmarksService.SaveItemBookmarksAsync(userId.Value, itemId, bookmarks ?? new List<BookmarkDto>());
+            return Ok(new { Success = true, ItemId = itemId });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving bookmarks for user {UserId}, item {ItemId}", userId, itemId);
+            return StatusCode(500, "Error saving bookmarks.");
+        }
     }
 
     /// <summary>
@@ -106,7 +128,15 @@ public class UserBookmarksController : ControllerBase
             return Unauthorized(new { Error = "User not authenticated" });
         }
 
-        await _bookmarksService.SaveItemNotesAsync(userId.Value, itemId, notes ?? new List<NoteDto>());
-        return Ok(new { Success = true, ItemId = itemId });
+        try
+        {
+            await _bookmarksService.SaveItemNotesAsync(userId.Value, itemId, notes ?? new List<NoteDto>());
+            return Ok(new { Success = true, ItemId = itemId });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving notes for user {UserId}, item {ItemId}", userId, itemId);
+            return StatusCode(500, "Error saving notes.");
+        }
     }
 }

--- a/Jellyfin/backend/Models/UserBookmarkModel.cs
+++ b/Jellyfin/backend/Models/UserBookmarkModel.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Moonfin.Server.Models;
+
+public class BookmarkDto
+{
+    [JsonPropertyName("positionMs")]
+    public int PositionMs { get; set; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class NoteDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("positionMs")]
+    public int PositionMs { get; set; }
+
+    [JsonPropertyName("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [JsonPropertyName("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class UserItemUserDataDto
+{
+    [JsonPropertyName("bookmarks")]
+    public List<BookmarkDto> Bookmarks { get; set; } = new();
+
+    [JsonPropertyName("notes")]
+    public List<NoteDto> Notes { get; set; } = new();
+}
+
+public class UserBookmarksEnvelope
+{
+    [JsonPropertyName("userId")]
+    public Guid UserId { get; set; }
+
+    [JsonPropertyName("items")]
+    public Dictionary<string, UserItemUserDataDto> Items { get; set; } = new();
+}

--- a/Jellyfin/backend/PluginServiceRegistrator.cs
+++ b/Jellyfin/backend/PluginServiceRegistrator.cs
@@ -36,6 +36,7 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<RdbService>();
         serviceCollection.AddSingleton<GameThumbService>();
         serviceCollection.AddSingleton<LaunchBoxService>();
+        serviceCollection.AddSingleton<UserBookmarksService>();
         serviceCollection.AddHttpClient();
 
         // Auto-register file transformations on plugin load (no manual task needed)

--- a/Jellyfin/backend/Services/UserBookmarksService.cs
+++ b/Jellyfin/backend/Services/UserBookmarksService.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moonfin.Server.Models;
+
+namespace Moonfin.Server.Services;
+
+/// <summary>
+/// Service for persisting and managing user audiobook &amp; book bookmarks &amp; notes server-side.
+/// </summary>
+public class UserBookmarksService
+{
+    private readonly string _dataPath;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly ILogger<UserBookmarksService> _logger;
+    private static readonly SemaphoreSlim _lock = new(1, 1);
+
+    public UserBookmarksService(ILogger<UserBookmarksService> logger)
+    {
+        _logger = logger;
+        _dataPath = Path.Combine(
+            MoonfinPlugin.Instance?.DataFolderPath 
+                ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Jellyfin", "plugins", "Moonfin"),
+            "Bookmarks");
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        EnsureDirectory();
+    }
+
+    private void EnsureDirectory()
+    {
+        if (!Directory.Exists(_dataPath))
+        {
+            Directory.CreateDirectory(_dataPath);
+        }
+    }
+
+    private string GetFilePath(Guid userId) => Path.Combine(_dataPath, $"{userId}.json");
+
+    public async Task<UserBookmarksEnvelope> GetUserBookmarksAsync(Guid userId)
+    {
+        var path = GetFilePath(userId);
+        await _lock.WaitAsync();
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return new UserBookmarksEnvelope { UserId = userId };
+            }
+
+            var json = await File.ReadAllTextAsync(path);
+            var envelope = JsonSerializer.Deserialize<UserBookmarksEnvelope>(json, _jsonOptions);
+            return envelope ?? new UserBookmarksEnvelope { UserId = userId };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading bookmarks for user {UserId}", userId);
+            return new UserBookmarksEnvelope { UserId = userId };
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task<UserItemUserDataDto> GetItemUserDataAsync(Guid userId, string itemId)
+    {
+        var env = await GetUserBookmarksAsync(userId);
+        if (env.Items.TryGetValue(itemId, out var data))
+        {
+            return data;
+        }
+        return new UserItemUserDataDto();
+    }
+
+    public async Task SaveItemUserDataAsync(Guid userId, string itemId, UserItemUserDataDto data)
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            var path = GetFilePath(userId);
+            UserBookmarksEnvelope env;
+            if (File.Exists(path))
+            {
+                var json = await File.ReadAllTextAsync(path);
+                env = JsonSerializer.Deserialize<UserBookmarksEnvelope>(json, _jsonOptions) ?? new UserBookmarksEnvelope { UserId = userId };
+            }
+            else
+            {
+                env = new UserBookmarksEnvelope { UserId = userId };
+            }
+
+            env.Items[itemId] = data;
+
+            var outJson = JsonSerializer.Serialize(env, _jsonOptions);
+            AtomicFile.WriteAllText(path, outJson);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving item user data for user {UserId}, item {ItemId}", userId, itemId);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task SaveItemBookmarksAsync(Guid userId, string itemId, List<BookmarkDto> bookmarks)
+    {
+        var current = await GetItemUserDataAsync(userId, itemId);
+        current.Bookmarks = bookmarks;
+        await SaveItemUserDataAsync(userId, itemId, current);
+    }
+
+    public async Task SaveItemNotesAsync(Guid userId, string itemId, List<NoteDto> notes)
+    {
+        var current = await GetItemUserDataAsync(userId, itemId);
+        current.Notes = notes;
+        await SaveItemUserDataAsync(userId, itemId, current);
+    }
+}

--- a/Jellyfin/backend/Services/UserBookmarksService.cs
+++ b/Jellyfin/backend/Services/UserBookmarksService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -17,7 +18,9 @@ public class UserBookmarksService
     private readonly string _dataPath;
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly ILogger<UserBookmarksService> _logger;
-    private static readonly SemaphoreSlim _lock = new(1, 1);
+    /// One gate per user rather than one for the server, so a large file for
+    /// one account doesn't hold up every other account's saves.
+    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> _locks = new();
 
     public UserBookmarksService(ILogger<UserBookmarksService> logger)
     {
@@ -47,29 +50,42 @@ public class UserBookmarksService
 
     private string GetFilePath(Guid userId) => Path.Combine(_dataPath, $"{userId}.json");
 
-    public async Task<UserBookmarksEnvelope> GetUserBookmarksAsync(Guid userId)
+    private static SemaphoreSlim GateFor(Guid userId) =>
+        _locks.GetOrAdd(userId, _ => new SemaphoreSlim(1, 1));
+
+    /// Reads without taking the gate. Callers hold it around whatever they are
+    /// doing, so a read followed by a write stays one operation.
+    private async Task<UserBookmarksEnvelope> ReadEnvelopeAsync(Guid userId)
     {
         var path = GetFilePath(userId);
-        await _lock.WaitAsync();
+        if (!File.Exists(path))
+        {
+            return new UserBookmarksEnvelope { UserId = userId };
+        }
+
+        var json = await File.ReadAllTextAsync(path);
+        return JsonSerializer.Deserialize<UserBookmarksEnvelope>(json, _jsonOptions)
+            ?? new UserBookmarksEnvelope { UserId = userId };
+    }
+
+    public async Task<UserBookmarksEnvelope> GetUserBookmarksAsync(Guid userId)
+    {
+        var gate = GateFor(userId);
+        await gate.WaitAsync();
         try
         {
-            if (!File.Exists(path))
-            {
-                return new UserBookmarksEnvelope { UserId = userId };
-            }
-
-            var json = await File.ReadAllTextAsync(path);
-            var envelope = JsonSerializer.Deserialize<UserBookmarksEnvelope>(json, _jsonOptions);
-            return envelope ?? new UserBookmarksEnvelope { UserId = userId };
+            return await ReadEnvelopeAsync(userId);
         }
         catch (Exception ex)
         {
+            // Answering with an empty envelope would read as "you have none",
+            // and a client that trusts that clears what it is holding.
             _logger.LogError(ex, "Error reading bookmarks for user {UserId}", userId);
-            return new UserBookmarksEnvelope { UserId = userId };
+            throw;
         }
         finally
         {
-            _lock.Release();
+            gate.Release();
         }
     }
 
@@ -83,49 +99,46 @@ public class UserBookmarksService
         return new UserItemUserDataDto();
     }
 
-    public async Task SaveItemUserDataAsync(Guid userId, string itemId, UserItemUserDataDto data)
+    /// Reads, applies the change and writes under a single hold on the gate.
+    /// Splitting those apart lets a bookmark save and a note save for the same
+    /// item interleave, and the second one written wins for both lists.
+    private async Task UpdateItemAsync(
+        Guid userId,
+        string itemId,
+        Action<UserItemUserDataDto> apply)
     {
-        await _lock.WaitAsync();
+        var gate = GateFor(userId);
+        await gate.WaitAsync();
         try
         {
-            var path = GetFilePath(userId);
-            UserBookmarksEnvelope env;
-            if (File.Exists(path))
+            var env = await ReadEnvelopeAsync(userId);
+            if (!env.Items.TryGetValue(itemId, out var data))
             {
-                var json = await File.ReadAllTextAsync(path);
-                env = JsonSerializer.Deserialize<UserBookmarksEnvelope>(json, _jsonOptions) ?? new UserBookmarksEnvelope { UserId = userId };
-            }
-            else
-            {
-                env = new UserBookmarksEnvelope { UserId = userId };
+                data = new UserItemUserDataDto();
+                env.Items[itemId] = data;
             }
 
-            env.Items[itemId] = data;
-
-            var outJson = JsonSerializer.Serialize(env, _jsonOptions);
-            AtomicFile.WriteAllText(path, outJson);
+            apply(data);
+            AtomicFile.WriteAllText(
+                GetFilePath(userId),
+                JsonSerializer.Serialize(env, _jsonOptions));
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error saving item user data for user {UserId}, item {ItemId}", userId, itemId);
+            // Reporting success on a write that never landed lets the client
+            // drop the copy it was holding.
+            _logger.LogError(ex, "Error saving user data for user {UserId}, item {ItemId}", userId, itemId);
+            throw;
         }
         finally
         {
-            _lock.Release();
+            gate.Release();
         }
     }
 
-    public async Task SaveItemBookmarksAsync(Guid userId, string itemId, List<BookmarkDto> bookmarks)
-    {
-        var current = await GetItemUserDataAsync(userId, itemId);
-        current.Bookmarks = bookmarks;
-        await SaveItemUserDataAsync(userId, itemId, current);
-    }
+    public Task SaveItemBookmarksAsync(Guid userId, string itemId, List<BookmarkDto> bookmarks) =>
+        UpdateItemAsync(userId, itemId, data => data.Bookmarks = bookmarks);
 
-    public async Task SaveItemNotesAsync(Guid userId, string itemId, List<NoteDto> notes)
-    {
-        var current = await GetItemUserDataAsync(userId, itemId);
-        current.Notes = notes;
-        await SaveItemUserDataAsync(userId, itemId, current);
-    }
+    public Task SaveItemNotesAsync(Guid userId, string itemId, List<NoteDto> notes) =>
+        UpdateItemAsync(userId, itemId, data => data.Notes = notes);
 }


### PR DESCRIPTION
# Pull Request

## Summary
Adds server-side persistence and REST endpoints for user audiobook & book bookmarks and freeform notes, preventing data loss across app reinstalls and updates. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [X] Other / shared

## Changes Made
List the key changes included in this PR.

- Added **UserBookmarkModel.cs** containing DTO definitions for `BookmarkDto`, `NoteDto`, `UserItemUserDataDto`, and `UserBookmarksEnvelope`.
- Added **UserBookmarksService.cs** to manage per-user bookmark and note storage under `PluginConfigurationsPath/Moonfin/Bookmarks/{userId}.json`.
- Added **UserBookmarksController.cs** with REST endpoints (`GET /Moonfin/Bookmarks`, `GET /Moonfin/Bookmarks/{itemId}`, `POST /Moonfin/Bookmarks/{itemId}`, `POST /Moonfin/Bookmarks/{itemId}/Notes`).
- Registered `UserBookmarksService` in **PluginServiceRegistrator.cs**.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1186
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why): Verified logic via emulator.

### Test Steps
1. Built Moonbase plugin with `dotnet build` (0 errors, 0 warnings).
2. Verified GET/POST endpoints for `/Moonfin/Bookmarks/{itemId}`.
3. Verified JSON storage creation under plugin data folder.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
