### PR TITLE
Seerr watchlist in default rows

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -858,7 +858,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { type: 'seerr_movie_genres', label: 'Seerr Movie Genres' },
         { type: 'seerr_studios', label: 'Seerr Studios' },
         { type: 'seerr_series_genres', label: 'Seerr Series Genres' },
-        { type: 'seerr_networks', label: 'Seerr Networks' }
+        { type: 'seerr_networks', label: 'Seerr Networks' },
+        { type: 'seerr_watchlist', label: 'Seerr Watchlist' }
     ];
 
     var HOME_LAYOUT_TABS = [
@@ -881,7 +882,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         seerr_movie_genres: true,
         seerr_studios: true,
         seerr_series_genres: true,
-        seerr_networks: true
+        seerr_networks: true,
+        seerr_watchlist: true
     };
 
     function isSeerrHomeSectionType(type) {

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -2245,6 +2245,7 @@
                 { type: 'seerr_studios', label: 'Seerr Studios' },
                 { type: 'seerr_series_genres', label: 'Seerr Series Genres' },
                 { type: 'seerr_networks', label: 'Seerr Networks' },
+                { type: 'seerr_watchlist', label: 'Seerr Watchlist' },
                 { type: 'imdb_top_250_movies', label: 'IMDB Top 250 Movies' },
                 { type: 'imdb_top_250_tv_shows', label: 'IMDB Top 250 Shows' },
                 { type: 'imdb_most_popular_movies', label: 'IMDB Most Popular Movies' },
@@ -2619,6 +2620,7 @@
                 seerr_studios: true,
                 seerr_series_genres: true,
                 seerr_networks: true,
+                seerr_watchlist: true,
                 radarr_calendar: true,
                 sonarr_calendar: true
             };


### PR DESCRIPTION
# Pull Request

## Summary
Add seerr watchlist to default rows config

## Related Issues
Link related issues or tickets separated by commas.

- Closes #247 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- add seerr_watchlist to row list (I made sure it matched core preference_constants.dart like the other seerr rows)
- add seerr_watchlist to seerr row group
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
