### PR TITLE
add home row toggles to default config page

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1283,8 +1283,128 @@
                                     <div id="DefaultHomeAvailableRows" class="homeLayoutList"></div>
                                 </div>
                             </div>
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Toggles/h4>
+                            <div class="fieldDescription" style="margin-bottom:0.75em;">Toggle the switches for these home row categories to make them available in the home sections page by default.</div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayAudioRows">Audio Rows</label>
+                                <select id="DefaultDisplayAudioRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultAudioRowsSortBy">Audio Rows Sorting</label>
+                                <select id="DefaultAudioRowsSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayCollectionsRows">Collections Rows</label>
+                                <select id="DefaultDisplayCollectionsRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultCollectionsRowSortBy">Collections Rows Sorting</label>
+                                <select id="DefaultCollectionsRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayFavoritesRows">Favorites Rows</label>
+                                <select id="DefaultDisplayFavoritesRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFavoritesRowSortBy">Favorites Rows Sorting</label>
+                                <select id="DefaultFavoritesRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayGenresRows">Genres Rows</label>
+                                <select id="DefaultDisplayGenresRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultGenresRowSortBy">Genres Rows Sorting</label>
+                                <select id="DefaultGenresRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayPlaylistsRows">Playlists Rows</label>
+                                <select id="DefaultDisplayPlaylistsRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultPlaylistsRowSortBy">Playlists Rows Sorting</label>
+                                <select id="DefaultPlaylistsRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayRewatchRow">Rewatch Row</label>
+                                <select id="DefaultDisplayRewatchRow" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRewatchSortBy">Rewatch Row Sorting</label>
+                                <select id="DefaultRewatchSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="recentlyWatched">Recently Watched</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplaySinceYouWatchedRows">Since You Watched Rows</label>
+                                <select id="DefaultDisplaySinceYouWatchedRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
-
                         <!-- 6. Libraries -->
                         <div class="defaultsSubtabPanel" data-subtab="libraries">
                             <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">General</h4>

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1756,9 +1756,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setNullableBoolSelect(view, '#DefaultDisplayAudioRows', defaults.displayAudioRows);
             setSelectValue(view, '#DefaultAudioRowsSortBy', defaults.audioRowsSortBy, 'Configured sort');
             setNullableBoolSelect(view, '#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
-            setNullableBoolSelect(view, '#DefaultDisplayRewatchRow' defaults.displayRewatchRow);
+            setNullableBoolSelect(view, '#DefaultDisplayRewatchRow', defaults.displayRewatchRow);
             setSelectValue(view, '#DefaultRewatchSortBy', defaults.rewatchSortBy, 'Configured sort');
-            setNullableBoolSelect(view, '#DefaultDisplaySinceYouWatchedRows', defaults.sinceYouWatchedRows);
+            setNullableBoolSelect(view, '#DefaultDisplaySinceYouWatchedRows', defaults.displaySinceYouWatchedRows);
             loadHomeSectionsEditor(view, defaults.homeSections || null, defaults.homeRowOrder || null);
             setNullableBoolSelect(view, '#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
             setSelectValue(view, '#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1663,7 +1663,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             loadGameLibraryPicker(view, config.GameLibraryIds || []);
             initGameCores(view, view.__moonfinState);
 
-            var defaults = camelKeysDeep(config.DefaultUserSettings) || {};
+            var defaults = camelKeysDeep(d) || {};
             setSelectValue(view, '#DefaultInterfaceStyle', defaults.interfaceStyle, 'Configured style');
             setSelectValue(view, '#DefaultVisualTheme', defaults.visualTheme, 'Configured theme');
             setSelectValue(view, '#DefaultDetailScreenStyle', defaults.detailScreenStyle, 'Configured style');
@@ -1743,13 +1743,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             bindNullableRangeInput(view, '#DefaultModernHomeRowsPadding', 'px');
             setNullableRangeInput(view, '#DefaultModernHomeRowsPadding', defaults.modernHomeRowsPadding, 'px');
             setSelectValue(view, '#DefaultPosterSize', defaults.posterSize, 'Configured size');
-            setSelectValue(view, '#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
-            setNullableBoolSelect(view, '#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
-            setNullableBoolSelect(view, '#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
-            setNullableBoolSelect(view, '#DefaultDisplayGenresRows', defaults.displayGenresRows);
-            setNullableBoolSelect(view, '#DefaultDisplayPlaylistsRows', defaults.displayPlaylistsRows);
-            setNullableBoolSelect(view, '#DefaultDisplayAudioRows', defaults.displayAudioRows);
-            setNullableBoolSelect(view, '#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
+            setSelectValue('#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
+            setSelectValue('#DefaultPosterSize', defaults.posterSize, 'Configured size');
+            setNullableBoolSelect('#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
+            setSelectValue('#DefaultFavoritesRowSortBy', defaults.favoritesRowSortBy, 'Configured sort');
+            setNullableBoolSelect('#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
+            setSelectValue('#DefaultCollectionsRowSortBy', defaults.collectionsRowSortBy, 'Configured sort');
+            setNullableBoolSelect('#DefaultDisplayGenresRows', defaults.displayGenresRows);
+            setSelectValue('#DefaultGenresRowSortBy', defaults.genresRowSortBy, 'Configured sort');
+            setNullableBoolSelect('#DefaultDisplayPlaylistsRows', defaults.displayPlaylistsRows);
+            setSelectValue('#DefaultPlaylistsRowSortBy', defaults.playlistsRowSortBy, 'Configured sort');
+            setNullableBoolSelect('#DefaultDisplayAudioRows', defaults.displayAudioRows);
+            setSelectValue('#DefaultAudioRowsSortBy', defaults.audioRowsSortBy, 'Configured sort');
+            setNullableBoolSelect('#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
+            setNullableBoolSelect('#DefaultDisplayRewatchRow' defaults.displayRewatchRow);
+            setSelectValue('#DefaultRewatchSortBy', defaults.rewatchSortBy, 'Configured sort');
+            setNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows', defaults.sinceYouWatchedRows);
             loadHomeSectionsEditor(view, defaults.homeSections || null, defaults.homeRowOrder || null);
             setNullableBoolSelect(view, '#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
             setSelectValue(view, '#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');
@@ -1820,7 +1829,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             config.GameLibraryIds = Array.prototype.slice.call(view.querySelectorAll('.gameLibraryCb:checked'))
                 .map(function (cb) { return cb.getAttribute('data-id'); });
 
-            var d = camelKeysDeep(config.DefaultUserSettings) || {};
+            var d = camelKeysDeep(d) || {};
             d.interfaceStyle = view.querySelector('#DefaultInterfaceStyle').value || null;
             d.visualTheme = view.querySelector('#DefaultVisualTheme').value || null;
             d.detailScreenStyle = view.querySelector('#DefaultDetailScreenStyle').value || null;
@@ -1908,12 +1917,20 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.modernHomeRowsPadding = getNullableRangeInput(view, '#DefaultModernHomeRowsPadding');
             d.posterSize = view.querySelector('#DefaultPosterSize').value || null;
             d.homeImageTypeContinueWatching = view.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
-            d.displayFavoritesRows = getNullableBoolSelect(view, '#DefaultDisplayFavoritesRows');
-            d.displayCollectionsRows = getNullableBoolSelect(view, '#DefaultDisplayCollectionsRows');
-            d.displayGenresRows = getNullableBoolSelect(view, '#DefaultDisplayGenresRows');
-            d.displayPlaylistsRows = getNullableBoolSelect(view, '#DefaultDisplayPlaylistsRows');
-            d.displayAudioRows = getNullableBoolSelect(view, '#DefaultDisplayAudioRows');
-            d.homeImageUseSeriesImage = getNullableBoolSelect(view, '#DefaultHomeImageUseSeriesImage');
+            d.displayFavoritesRows = getNullableBoolSelect('#DefaultDisplayFavoritesRows');
+            d.favoritesRowSortBy = view.querySelector('#DefaultFavoritesRowSortBy').value || null;
+            d.displayCollectionsRows = getNullableBoolSelect('#DefaultDisplayCollectionsRows');
+            d.collectionsRowSortBy = view.querySelector('#DefaultCollectionsRowSortBy').value || null;
+            d.displayGenresRows = getNullableBoolSelect('#DefaultDisplayGenresRows');
+            d.genresRowSortBy = view.querySelector('#DefaultGenresRowSortBy').value || null;
+            d.displayPlaylistsRows = getNullableBoolSelect('#DefaultDisplayPlaylistsRows');
+            d.playlistsRowSortBy = view.querySelector('#DefaultPlaylistsRowSortBy').value || null;
+            d.displayAudioRows = getNullableBoolSelect('#DefaultDisplayAudioRows');
+            d.audioRowsSortBy = view.querySelector('#DefaultAudioRowsSortBy').value || null;
+            d.displayRewatchRow = getNullableBoolSelect('#DefaultDisplayRewatchRow');
+            d.rewatchSortBy = view.querySelector('#DefaultRewatchSortBy').value || null;
+            d.displaySinceYouWatchedRows = getNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows');
+            d.homeImageUseSeriesImage = getNullableBoolSelect('#DefaultHomeImageUseSeriesImage');
             var homeSections = getHomeSectionsValue(view);
             d.homeSections = homeSections;
             d.homeRowOrder = getHomeRowOrderValue(view, homeSections);
@@ -1947,7 +1964,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             seerrRows.rowOrder = getSeerrDiscoveryRowOrder(view);
             d.seerrRows = seerrRows;
 
-            config.DefaultUserSettings = d;
+            d = d;
 
             return ApiClient.updatePluginConfiguration(PluginUniqueId, config).then(function (result) {
                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1663,7 +1663,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             loadGameLibraryPicker(view, config.GameLibraryIds || []);
             initGameCores(view, view.__moonfinState);
 
-            var defaults = camelKeysDeep(d) || {};
+            var defaults = camelKeysDeep(config.DefaultUserSettings) || {};
             setSelectValue(view, '#DefaultInterfaceStyle', defaults.interfaceStyle, 'Configured style');
             setSelectValue(view, '#DefaultVisualTheme', defaults.visualTheme, 'Configured theme');
             setSelectValue(view, '#DefaultDetailScreenStyle', defaults.detailScreenStyle, 'Configured style');
@@ -1743,22 +1743,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             bindNullableRangeInput(view, '#DefaultModernHomeRowsPadding', 'px');
             setNullableRangeInput(view, '#DefaultModernHomeRowsPadding', defaults.modernHomeRowsPadding, 'px');
             setSelectValue(view, '#DefaultPosterSize', defaults.posterSize, 'Configured size');
-            setSelectValue('#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
-            setSelectValue('#DefaultPosterSize', defaults.posterSize, 'Configured size');
-            setNullableBoolSelect('#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
-            setSelectValue('#DefaultFavoritesRowSortBy', defaults.favoritesRowSortBy, 'Configured sort');
-            setNullableBoolSelect('#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
-            setSelectValue('#DefaultCollectionsRowSortBy', defaults.collectionsRowSortBy, 'Configured sort');
-            setNullableBoolSelect('#DefaultDisplayGenresRows', defaults.displayGenresRows);
-            setSelectValue('#DefaultGenresRowSortBy', defaults.genresRowSortBy, 'Configured sort');
-            setNullableBoolSelect('#DefaultDisplayPlaylistsRows', defaults.displayPlaylistsRows);
-            setSelectValue('#DefaultPlaylistsRowSortBy', defaults.playlistsRowSortBy, 'Configured sort');
-            setNullableBoolSelect('#DefaultDisplayAudioRows', defaults.displayAudioRows);
-            setSelectValue('#DefaultAudioRowsSortBy', defaults.audioRowsSortBy, 'Configured sort');
-            setNullableBoolSelect('#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
-            setNullableBoolSelect('#DefaultDisplayRewatchRow' defaults.displayRewatchRow);
-            setSelectValue('#DefaultRewatchSortBy', defaults.rewatchSortBy, 'Configured sort');
-            setNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows', defaults.sinceYouWatchedRows);
+            setSelectValue(view, '#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
+            setSelectValue(view, '#DefaultPosterSize', defaults.posterSize, 'Configured size');
+            setNullableBoolSelect(view, '#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
+            setSelectValue(view, '#DefaultFavoritesRowSortBy', defaults.favoritesRowSortBy, 'Configured sort');
+            setNullableBoolSelect(view, '#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
+            setSelectValue(view, '#DefaultCollectionsRowSortBy', defaults.collectionsRowSortBy, 'Configured sort');
+            setNullableBoolSelect(view, '#DefaultDisplayGenresRows', defaults.displayGenresRows);
+            setSelectValue(view, '#DefaultGenresRowSortBy', defaults.genresRowSortBy, 'Configured sort');
+            setNullableBoolSelect(view, '#DefaultDisplayPlaylistsRows', defaults.displayPlaylistsRows);
+            setSelectValue(view, '#DefaultPlaylistsRowSortBy', defaults.playlistsRowSortBy, 'Configured sort');
+            setNullableBoolSelect(view, '#DefaultDisplayAudioRows', defaults.displayAudioRows);
+            setSelectValue(view, '#DefaultAudioRowsSortBy', defaults.audioRowsSortBy, 'Configured sort');
+            setNullableBoolSelect(view, '#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
+            setNullableBoolSelect(view, '#DefaultDisplayRewatchRow' defaults.displayRewatchRow);
+            setSelectValue(view, '#DefaultRewatchSortBy', defaults.rewatchSortBy, 'Configured sort');
+            setNullableBoolSelect(view, '#DefaultDisplaySinceYouWatchedRows', defaults.sinceYouWatchedRows);
             loadHomeSectionsEditor(view, defaults.homeSections || null, defaults.homeRowOrder || null);
             setNullableBoolSelect(view, '#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
             setSelectValue(view, '#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');
@@ -1829,7 +1829,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             config.GameLibraryIds = Array.prototype.slice.call(view.querySelectorAll('.gameLibraryCb:checked'))
                 .map(function (cb) { return cb.getAttribute('data-id'); });
 
-            var d = camelKeysDeep(d) || {};
+            var d = camelKeysDeep(config.DefaultUserSettings) || {};
             d.interfaceStyle = view.querySelector('#DefaultInterfaceStyle').value || null;
             d.visualTheme = view.querySelector('#DefaultVisualTheme').value || null;
             d.detailScreenStyle = view.querySelector('#DefaultDetailScreenStyle').value || null;
@@ -1917,20 +1917,20 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.modernHomeRowsPadding = getNullableRangeInput(view, '#DefaultModernHomeRowsPadding');
             d.posterSize = view.querySelector('#DefaultPosterSize').value || null;
             d.homeImageTypeContinueWatching = view.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
-            d.displayFavoritesRows = getNullableBoolSelect('#DefaultDisplayFavoritesRows');
+            d.displayFavoritesRows = getNullableBoolSelect(view, '#DefaultDisplayFavoritesRows');
             d.favoritesRowSortBy = view.querySelector('#DefaultFavoritesRowSortBy').value || null;
-            d.displayCollectionsRows = getNullableBoolSelect('#DefaultDisplayCollectionsRows');
+            d.displayCollectionsRows = getNullableBoolSelect(view, '#DefaultDisplayCollectionsRows');
             d.collectionsRowSortBy = view.querySelector('#DefaultCollectionsRowSortBy').value || null;
-            d.displayGenresRows = getNullableBoolSelect('#DefaultDisplayGenresRows');
+            d.displayGenresRows = getNullableBoolSelect(view, '#DefaultDisplayGenresRows');
             d.genresRowSortBy = view.querySelector('#DefaultGenresRowSortBy').value || null;
-            d.displayPlaylistsRows = getNullableBoolSelect('#DefaultDisplayPlaylistsRows');
+            d.displayPlaylistsRows = getNullableBoolSelect(view, '#DefaultDisplayPlaylistsRows');
             d.playlistsRowSortBy = view.querySelector('#DefaultPlaylistsRowSortBy').value || null;
-            d.displayAudioRows = getNullableBoolSelect('#DefaultDisplayAudioRows');
+            d.displayAudioRows = getNullableBoolSelect(view, '#DefaultDisplayAudioRows');
             d.audioRowsSortBy = view.querySelector('#DefaultAudioRowsSortBy').value || null;
-            d.displayRewatchRow = getNullableBoolSelect('#DefaultDisplayRewatchRow');
+            d.displayRewatchRow = getNullableBoolSelect(view, '#DefaultDisplayRewatchRow');
             d.rewatchSortBy = view.querySelector('#DefaultRewatchSortBy').value || null;
-            d.displaySinceYouWatchedRows = getNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows');
-            d.homeImageUseSeriesImage = getNullableBoolSelect('#DefaultHomeImageUseSeriesImage');
+            d.displaySinceYouWatchedRows = getNullableBoolSelect(view, '#DefaultDisplaySinceYouWatchedRows');
+            d.homeImageUseSeriesImage = getNullableBoolSelect(view, '#DefaultHomeImageUseSeriesImage');
             var homeSections = getHomeSectionsValue(view);
             d.homeSections = homeSections;
             d.homeRowOrder = getHomeRowOrderValue(view, homeSections);
@@ -1964,7 +1964,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             seerrRows.rowOrder = getSeerrDiscoveryRowOrder(view);
             d.seerrRows = seerrRows;
 
-            d = d;
+            config.DefaultUserSettings = d;
 
             return ApiClient.updatePluginConfiguration(PluginUniqueId, config).then(function (result) {
                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -3819,9 +3819,9 @@
                     setNullableBoolSelect('#DefaultDisplayAudioRows', defaults.displayAudioRows);
                     setSelectValue('#DefaultAudioRowsSortBy', defaults.audioRowsSortBy, 'Configured sort');
                     setNullableBoolSelect('#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
-                    setNullableBoolSelect('#DefaultDisplayRewatchRow' defaults.displayRewatchRow);
+                    setNullableBoolSelect('#DefaultDisplayRewatchRow', defaults.displayRewatchRow);
                     setSelectValue('#DefaultRewatchSortBy', defaults.rewatchSortBy, 'Configured sort');
-                    setNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows', defaults.sinceYouWatchedRows);
+                    setNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows', defaults.displaySinceYouWatchedRows);
                     loadHomeSectionsEditor(defaults.homeSections || null, defaults.homeRowOrder || null);
                     setNullableBoolSelect('#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
                     setSelectValue('#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1112,8 +1112,128 @@
                                     <div id="DefaultHomeAvailableRows" class="homeLayoutList"></div>
                                 </div>
                             </div>
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Toggles/h4>
+                            <div class="fieldDescription" style="margin-bottom:0.75em;">Toggle the switches for these home row categories to make them available in the home sections page by default.</div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayAudioRows">Audio Rows</label>
+                                <select id="DefaultDisplayAudioRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultAudioRowsSortBy">Audio Rows Sorting</label>
+                                <select id="DefaultAudioRowsSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayCollectionsRows">Collections Rows</label>
+                                <select id="DefaultDisplayCollectionsRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultCollectionsRowSortBy">Collections Rows Sorting</label>
+                                <select id="DefaultCollectionsRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayFavoritesRows">Favorites Rows</label>
+                                <select id="DefaultDisplayFavoritesRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFavoritesRowSortBy">Favorites Rows Sorting</label>
+                                <select id="DefaultFavoritesRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayGenresRows">Genres Rows</label>
+                                <select id="DefaultDisplayGenresRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultGenresRowSortBy">Genres Rows Sorting</label>
+                                <select id="DefaultGenresRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayPlaylistsRows">Playlists Rows</label>
+                                <select id="DefaultDisplayPlaylistsRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultPlaylistsRowSortBy">Playlists Rows Sorting</label>
+                                <select id="DefaultPlaylistsRowSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="name">Name</option>
+                                    <option value="dateAdded">Date Added</option>
+                                    <option value="premiereDate">Release Date</option>
+                                    <option value="runtime">Runtime</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayRewatchRow">Rewatch Row</label>
+                                <select id="DefaultDisplayRewatchRow" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultRewatchSortBy">Rewatch Row Sorting</label>
+                                <select id="DefaultRewatchSortBy" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="recentlyWatched">Recently Watched</option>
+                                    <option value="random">Random</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultDisplaySinceYouWatchedRows">Since You Watched Rows</label>
+                                <select id="DefaultDisplaySinceYouWatchedRows" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
-
                         <!-- 6. Libraries -->
                         <div class="defaultsSubtabPanel" data-subtab="libraries">
                             <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">General</h4>
@@ -3689,11 +3809,19 @@
                     setSelectValue('#DefaultHomeImageTypeContinueWatching', defaults.homeImageTypeContinueWatching, 'Configured image type');
                     setSelectValue('#DefaultPosterSize', defaults.posterSize, 'Configured size');
                     setNullableBoolSelect('#DefaultDisplayFavoritesRows', defaults.displayFavoritesRows);
+                    setSelectValue('#DefaultFavoritesRowSortBy', defaults.favoritesRowSortBy, 'Configured sort');
                     setNullableBoolSelect('#DefaultDisplayCollectionsRows', defaults.displayCollectionsRows);
+                    setSelectValue('#DefaultCollectionsRowSortBy', defaults.collectionsRowSortBy, 'Configured sort');
                     setNullableBoolSelect('#DefaultDisplayGenresRows', defaults.displayGenresRows);
+                    setSelectValue('#DefaultGenresRowSortBy', defaults.genresRowSortBy, 'Configured sort');
                     setNullableBoolSelect('#DefaultDisplayPlaylistsRows', defaults.displayPlaylistsRows);
+                    setSelectValue('#DefaultPlaylistsRowSortBy', defaults.playlistsRowSortBy, 'Configured sort');
                     setNullableBoolSelect('#DefaultDisplayAudioRows', defaults.displayAudioRows);
+                    setSelectValue('#DefaultAudioRowsSortBy', defaults.audioRowsSortBy, 'Configured sort');
                     setNullableBoolSelect('#DefaultHomeImageUseSeriesImage', defaults.homeImageUseSeriesImage);
+                    setNullableBoolSelect('#DefaultDisplayRewatchRow' defaults.displayRewatchRow);
+                    setSelectValue('#DefaultRewatchSortBy', defaults.rewatchSortBy, 'Configured sort');
+                    setNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows', defaults.sinceYouWatchedRows);
                     loadHomeSectionsEditor(defaults.homeSections || null, defaults.homeRowOrder || null);
                     setNullableBoolSelect('#DefaultMergeContinueWatchingNextUp', defaults.mergeContinueWatchingNextUp);
                     setSelectValue('#DefaultNextUpMaxDays', defaults.nextUpMaxDays, 'Configured max days');
@@ -4101,10 +4229,18 @@
                         config.DefaultUserSettings.posterSize = document.querySelector('#DefaultPosterSize').value || null;
                         config.DefaultUserSettings.homeImageTypeContinueWatching = document.querySelector('#DefaultHomeImageTypeContinueWatching').value || null;
                         config.DefaultUserSettings.displayFavoritesRows = getNullableBoolSelect('#DefaultDisplayFavoritesRows');
+                        config.DefaultUserSettings.favoritesRowSortBy = document.querySelector('#DefaultFavoritesRowSortBy').value || null;
                         config.DefaultUserSettings.displayCollectionsRows = getNullableBoolSelect('#DefaultDisplayCollectionsRows');
+                        config.DefaultUserSettings.collectionsRowSortBy = document.querySelector('#DefaultCollectionsRowSortBy').value || null;
                         config.DefaultUserSettings.displayGenresRows = getNullableBoolSelect('#DefaultDisplayGenresRows');
+                        config.DefaultUserSettings.genresRowSortBy = document.querySelector('#DefaultGenresRowSortBy').value || null;
                         config.DefaultUserSettings.displayPlaylistsRows = getNullableBoolSelect('#DefaultDisplayPlaylistsRows');
+                        config.DefaultUserSettings.playlistsRowSortBy = document.querySelector('#DefaultPlaylistsRowSortBy').value || null;
                         config.DefaultUserSettings.displayAudioRows = getNullableBoolSelect('#DefaultDisplayAudioRows');
+                        config.DefaultUserSettings.audioRowsSortBy = document.querySelector('#DefaultAudioRowsSortBy').value || null;
+                        config.DefaultUserSettings.displayRewatchRow = getNullableBoolSelect('#DefaultDisplayRewatchRow');
+                        config.DefaultUserSettings.rewatchSortBy = document.querySelector('#DefaultRewatchSortBy').value || null;
+                        config.DefaultUserSettings.displaySinceYouWatchedRows = getNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows');
                         config.DefaultUserSettings.homeImageUseSeriesImage = getNullableBoolSelect('#DefaultHomeImageUseSeriesImage');
                         var homeSections = getHomeSectionsValue();
                         config.DefaultUserSettings.homeSections = homeSections;


### PR DESCRIPTION
# Pull Request

## Summary
Home row toggles were removed in the last update, this re-adds them. 

Includes all home row toggles, and sort options

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- added home row toggles section under home layout section in home sections page
- add all home row toggles
- for each toggle, add corresponding sort order menu
- do same for jellyfin and emby

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
