### PR TITLE
bugfix-mediadetails - Moonbase Does TV Studios

### DIFF
--- a/Jellyfin/backend/Services/StudioLogoFetchService.cs
+++ b/Jellyfin/backend/Services/StudioLogoFetchService.cs
@@ -56,7 +56,9 @@ public class StudioLogoFetchService
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         var details = JsonSerializer.Deserialize<TmdbDetailsResponse>(json, JsonOptions);
-        var companies = details?.ProductionCompanies ?? new List<TmdbCompany>();
+        var companies = new List<TmdbCompany>();
+        if (details?.ProductionCompanies != null) companies.AddRange(details.ProductionCompanies);
+        if (details?.Networks != null) companies.AddRange(details.Networks);
 
         var entries = new List<StudioCompanyEntry>();
         foreach (var company in companies)
@@ -149,6 +151,9 @@ public class StudioLogoFetchService
     {
         [JsonPropertyName("production_companies")]
         public List<TmdbCompany>? ProductionCompanies { get; set; }
+
+        [JsonPropertyName("networks")]
+        public List<TmdbCompany>? Networks { get; set; }
     }
 
     private class TmdbCompany


### PR DESCRIPTION
# Pull Request

## Summary
Includes TMDB networks alongside production companies when fetching studio logos for TV shows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1240

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [X] Other / shared

## Changes Made
List the key changes included in this PR.

- Updated **StudioLogoFetchService.cs** to deserialize `networks` in addition to `production_companies` when querying TMDB TV item details (`/3/tv/{id}`).
- Enables caching and returning logo images for major TV networks (such as Apple TV+, AMC, HBO, Hulu, etc.) on TV show detail screens.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1240
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built **Moonfin.Server.dll** and deployed to Jellyfin plugins folder.
2. Verified that TMDB network logos for TV titles are fetched and returned via `/Moonfin/Tmdb/ProductionCompanies`.
3. Verified live logo rendering on TV show detail screens (e.g., Deadwood, Dark Winds).

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

Screenshots included on https://github.com/Moonfin-Client/Moonfin-Core/pull/1240 

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
