### PR TITLE
auto toggle home row switches when pushing related home row

### DIFF
--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1112,7 +1112,7 @@
                                     <div id="DefaultHomeAvailableRows" class="homeLayoutList"></div>
                                 </div>
                             </div>
-                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Toggles/h4>
+                            <h4 style="margin: 1em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Home Row Toggles</h4>
                             <div class="fieldDescription" style="margin-bottom:0.75em;">Toggle the switches for these home row categories to make them available in the home sections page by default.</div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultDisplayAudioRows">Audio Rows</label>
@@ -4244,6 +4244,16 @@
                         config.DefaultUserSettings.rewatchSortBy = document.querySelector('#DefaultRewatchSortBy').value || null;
                         config.DefaultUserSettings.displaySinceYouWatchedRows = getNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows');
                         config.DefaultUserSettings.homeImageUseSeriesImage = getNullableBoolSelect('#DefaultHomeImageUseSeriesImage');
+                        // before saving home rows, make sure required toggles are active
+                        HOME_LAYOUT_STATE.sections.map(function(section) {
+                            if (section.pluginSource === 'collections') {
+                                config.DefaultUserSettings.displayCollectionsRows = true;
+                            } else if (section.pluginSource === 'playlists') {
+                                config.DefaultUserSettings.displayPlaylistsRows = true;
+                            } else if (section.pluginSource === 'genres') {
+                                config.DefaultUserSettings.displayGenresRows = true;
+                            }
+                        });
                         var homeSections = getHomeSectionsValue();
                         config.DefaultUserSettings.homeSections = homeSections;
                         config.DefaultUserSettings.homeRowOrder = getHomeRowOrderValue(homeSections);

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -2776,6 +2776,14 @@
                 return !!HOME_LAYOUT_EXTERNAL_LISTS[type];
             }
 
+            // A pushed genre, collection or playlist row renders for the user only
+            // when its category toggle is on, so saving a row switches its toggle on.
+            var HOME_LAYOUT_ROW_TOGGLES = {
+                collections: { setting: 'displayCollectionsRows', select: '#DefaultDisplayCollectionsRows' },
+                playlists: { setting: 'displayPlaylistsRows', select: '#DefaultDisplayPlaylistsRows' },
+                genres: { setting: 'displayGenresRows', select: '#DefaultDisplayGenresRows' }
+            };
+
             var HOME_LAYOUT_STATE = {
                 sections: [],
                 selectedIndex: null,
@@ -4244,15 +4252,13 @@
                         config.DefaultUserSettings.rewatchSortBy = document.querySelector('#DefaultRewatchSortBy').value || null;
                         config.DefaultUserSettings.displaySinceYouWatchedRows = getNullableBoolSelect('#DefaultDisplaySinceYouWatchedRows');
                         config.DefaultUserSettings.homeImageUseSeriesImage = getNullableBoolSelect('#DefaultHomeImageUseSeriesImage');
-                        // before saving home rows, make sure required toggles are active
-                        HOME_LAYOUT_STATE.sections.map(function(section) {
-                            if (section.pluginSource === 'collections') {
-                                config.DefaultUserSettings.displayCollectionsRows = true;
-                            } else if (section.pluginSource === 'playlists') {
-                                config.DefaultUserSettings.displayPlaylistsRows = true;
-                            } else if (section.pluginSource === 'genres') {
-                                config.DefaultUserSettings.displayGenresRows = true;
-                            }
+                        HOME_LAYOUT_STATE.sections.forEach(function(section) {
+                            var toggle = HOME_LAYOUT_ROW_TOGGLES[section.pluginSource];
+                            if (!toggle || config.DefaultUserSettings[toggle.setting] === true) return;
+                            config.DefaultUserSettings[toggle.setting] = true;
+                            // Keep the select in step, otherwise it goes on reading No
+                            // until the page is reloaded.
+                            setNullableBoolSelect(toggle.select, true);
                         });
                         var homeSections = getHomeSectionsValue();
                         config.DefaultUserSettings.homeSections = homeSections;


### PR DESCRIPTION
# Pull Request

## Summary
Now when users push a genre/collection/playlist row, moonbase will automatically toggle the displayXRows home row toggle, so that the rows will actually show for users when pushed to them

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #249 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [X] Other / shared

## Changes Made
List the key changes included in this PR.

- before saving the home rows list, go through and check if any of them need their toggles enabled (regardless of what was previously set for the toggles)
- fixed a typo with a missing '<' causing formatting issues (lol)
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [ ] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one: core android mobile)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. add 1 or more genre/collection/playlist row(s)
2. save defaults
3. refresh the page
4. see the toggles are now set to "yes"
5. optionally, push to a user
6. the user will now have those toggles enabled, and the rows show up automatically

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.
<img width="1089" height="1568" alt="image" src="https://github.com/user-attachments/assets/3725337f-735a-46f9-9165-8cc8f1396471" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
