### PR TITLE
feat(messages): write messages your users can read in the app

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Api/AuthHelpers.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/AuthHelpers.cs
@@ -23,6 +23,13 @@ namespace Emby.Plugins.Moonfin.Api
             catch { return null; }
         }
 
+        /// <summary>True when the caller is a server admin, the same check the "Admin" role uses.</summary>
+        public static bool IsCurrentUserAdmin(IRequest request, IAuthorizationContext authContext)
+        {
+            try { return GetCurrentUser(request, authContext)?.Policy?.IsAdministrator == true; }
+            catch { return false; }
+        }
+
         /// <summary>Returns all server user GUIDs, or null if the user manager is unavailable.</summary>
         public static IReadOnlyCollection<Guid>? GetAllServerUserIds()
         {

--- a/Emby/Emby.Plugins.Moonfin/Api/MessagesRequests.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/MessagesRequests.cs
@@ -18,10 +18,26 @@ namespace Emby.Plugins.Moonfin.Api
         public System.IO.Stream RequestStream { get; set; } = null!;
     }
 
+    [Route("/Moonfin/Admin/Messages/Order", "POST")]
+    [Authenticated(Roles = "Admin")]
+    public class ReorderMessagesRequest : IReturn<object>, IRequiresRequestStream
+    {
+        public System.IO.Stream RequestStream { get; set; } = null!;
+    }
+
     [Route("/Moonfin/Admin/Messages/{MessageId}", "DELETE")]
     [Authenticated(Roles = "Admin")]
     public class DeleteMessageRequest : IReturn<object>
     {
         public string? MessageId { get; set; }
+    }
+}
+
+namespace Emby.Plugins.Moonfin.Api
+{
+    /// <summary>Body for the message reorder endpoint.</summary>
+    public class MessageOrderBody
+    {
+        public System.Collections.Generic.List<string>? Ids { get; set; }
     }
 }

--- a/Emby/Emby.Plugins.Moonfin/Api/MessagesRequests.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/MessagesRequests.cs
@@ -1,0 +1,27 @@
+using MediaBrowser.Controller.Net;
+using MediaBrowser.Model.Services;
+
+namespace Emby.Plugins.Moonfin.Api
+{
+    [Route("/Moonfin/Messages", "GET")]
+    [Authenticated]
+    public class GetMessagesRequest : IReturn<object> { }
+
+    [Route("/Moonfin/Admin/Messages", "GET")]
+    [Authenticated(Roles = "Admin")]
+    public class GetAdminMessagesRequest : IReturn<object> { }
+
+    [Route("/Moonfin/Admin/Messages", "POST")]
+    [Authenticated(Roles = "Admin")]
+    public class SaveMessageRequest : IReturn<object>, IRequiresRequestStream
+    {
+        public System.IO.Stream RequestStream { get; set; } = null!;
+    }
+
+    [Route("/Moonfin/Admin/Messages/{MessageId}", "DELETE")]
+    [Authenticated(Roles = "Admin")]
+    public class DeleteMessageRequest : IReturn<object>
+    {
+        public string? MessageId { get; set; }
+    }
+}

--- a/Emby/Emby.Plugins.Moonfin/Api/MessagesService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/MessagesService.cs
@@ -39,8 +39,6 @@ namespace Emby.Plugins.Moonfin.Api
             var now = DateTime.UtcNow;
             var items = config.Messages
                 .Where(m => m.IsVisibleTo(userId.Value, isAdmin, now))
-                .OrderByDescending(m => m.Pinned)
-                .ThenByDescending(m => m.CreatedUtc)
                 .ToList();
 
             return Json(new { items });
@@ -53,8 +51,6 @@ namespace Emby.Plugins.Moonfin.Api
             return Json(new
             {
                 items = messages
-                    .OrderByDescending(m => m.Pinned)
-                    .ThenByDescending(m => m.CreatedUtc)
                     .ToList()
             });
         }
@@ -81,16 +77,18 @@ namespace Emby.Plugins.Moonfin.Api
             {
                 message.CreatedUtc = existing.CreatedUtc;
                 message.CreatedByUserId = existing.CreatedByUserId;
-                messages.Remove(existing);
+                // Replaced in place, so editing a message does not move it in the list.
+                messages[messages.IndexOf(existing)] = message;
             }
             else
             {
                 message.Id = Guid.NewGuid().ToString("N");
                 message.CreatedUtc = DateTime.UtcNow;
                 message.CreatedByUserId = AuthHelpers.GetCurrentUserId(Request, _authContext)?.ToString("N");
+                // Newest first by default. The admin can move it with the arrows.
+                messages.Insert(0, message);
             }
 
-            messages.Add(message);
             ServerMessage.Prune(messages);
             plugin.UpdateConfiguration(config);
 
@@ -102,6 +100,42 @@ namespace Emby.Plugins.Moonfin.Api
                 SendPush(message);
 
             return Json(new { success = true, item = message });
+        }
+
+        /// <summary>
+        /// Reorders the stored messages to match the IDs given. The app shows them in this
+        /// order, so this is what the up and down arrows in the config page drive.
+        /// </summary>
+        public async Task<object> Post(ReorderMessagesRequest request)
+        {
+            var plugin = Plugin.Instance;
+            var config = plugin?.Configuration;
+            if (plugin == null || config == null) return Json(503, new { error = "Plugin is not ready" });
+
+            var body = await MoonfinJson.ReadBodyAsync<MessageOrderBody>(request.RequestStream).ConfigureAwait(false);
+            var ids = body?.Ids;
+            if (ids == null || ids.Count == 0) return Json(400, new { error = "ids is required" });
+
+            var messages = config.Messages;
+            var reordered = new List<ServerMessage>(messages.Count);
+
+            foreach (var id in ids)
+            {
+                var match = messages.FirstOrDefault(m =>
+                    string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase));
+                if (match != null && !reordered.Contains(match))
+                    reordered.Add(match);
+            }
+
+            // Anything the caller left out keeps its place at the end, so a stale list from
+            // the config page cannot delete messages.
+            reordered.AddRange(messages.Where(m => !reordered.Contains(m)));
+
+            config.Messages = reordered;
+            plugin.UpdateConfiguration(config);
+            Plugin.Instance?.SettingsService?.BroadcastSystemEvent("messagesChanged");
+
+            return Json(new { success = true });
         }
 
         public object Delete(DeleteMessageRequest request)

--- a/Emby/Emby.Plugins.Moonfin/Api/MessagesService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/MessagesService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MediaBrowser.Common;
+using MediaBrowser.Controller.Net;
+using MediaBrowser.Model.Services;
+
+namespace Emby.Plugins.Moonfin.Api
+{
+    public class MessagesService : IService, IRequiresRequest, IHasResultFactory
+    {
+        private readonly IAuthorizationContext _authContext;
+
+        public IRequest Request { get; set; } = null!;
+        public IHttpResultFactory ResultFactory { get; set; } = null!;
+
+        public MessagesService(IApplicationHost appHost)
+        {
+            _authContext = appHost.Resolve<IAuthorizationContext>();
+            ResultFactory = appHost.Resolve<IHttpResultFactory>();
+        }
+
+        private object Json(object? body) => MoonfinJson.Result(Request, ResultFactory, body);
+        private object Json(int statusCode, object? body) { Request.Response.StatusCode = statusCode; return Json(body); }
+
+        public object Get(GetMessagesRequest request)
+        {
+            var config = Plugin.Instance?.Configuration;
+            if (config?.EnableSettingsSync != true)
+                return Json(503, new { error = "Settings sync is disabled" });
+
+            var userId = AuthHelpers.GetCurrentUserId(Request, _authContext);
+            if (userId == null) return Json(401, new { error = "A valid user token is required" });
+
+            // Filtering happens here, not on the client. Sending everything and hiding it in
+            // the app would let any user read messages meant for someone else.
+            var isAdmin = AuthHelpers.IsCurrentUserAdmin(Request, _authContext);
+            var now = DateTime.UtcNow;
+            var items = config.Messages
+                .Where(m => m.IsVisibleTo(userId.Value, isAdmin, now))
+                .OrderByDescending(m => m.Pinned)
+                .ThenByDescending(m => m.CreatedUtc)
+                .ToList();
+
+            return Json(new { items });
+        }
+
+        public object Get(GetAdminMessagesRequest request)
+        {
+            var messages = Plugin.Instance?.Configuration?.Messages ?? new List<ServerMessage>();
+
+            return Json(new
+            {
+                items = messages
+                    .OrderByDescending(m => m.Pinned)
+                    .ThenByDescending(m => m.CreatedUtc)
+                    .ToList()
+            });
+        }
+
+        public async Task<object> Post(SaveMessageRequest request)
+        {
+            var plugin = Plugin.Instance;
+            var config = plugin?.Configuration;
+            if (plugin == null || config == null) return Json(503, new { error = "Plugin is not ready" });
+
+            var message = await MoonfinJson.ReadBodyAsync<ServerMessage>(request.RequestStream).ConfigureAwait(false);
+            if (message == null) return Json(400, new { error = "A message body is required" });
+
+            message.Sanitize();
+
+            if (message.Title.Length == 0 && message.Body.Length == 0)
+                return Json(400, new { error = "A title or a body is required" });
+
+            var messages = config.Messages;
+            var existing = messages.FirstOrDefault(m =>
+                string.Equals(m.Id, message.Id, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null)
+            {
+                message.CreatedUtc = existing.CreatedUtc;
+                message.CreatedByUserId = existing.CreatedByUserId;
+                messages.Remove(existing);
+            }
+            else
+            {
+                message.Id = Guid.NewGuid().ToString("N");
+                message.CreatedUtc = DateTime.UtcNow;
+                message.CreatedByUserId = AuthHelpers.GetCurrentUserId(Request, _authContext)?.ToString("N");
+            }
+
+            messages.Add(message);
+            ServerMessage.Prune(messages);
+            plugin.UpdateConfiguration(config);
+
+            Plugin.Instance?.SettingsService?.BroadcastSystemEvent("messagesChanged");
+
+            // Only push for messages meant to interrupt. An inbox message can wait until the
+            // user opens the app.
+            if (existing == null && message.Delivery != ServerMessage.DeliveryInbox)
+                SendPush(message);
+
+            return Json(new { success = true, item = message });
+        }
+
+        public object Delete(DeleteMessageRequest request)
+        {
+            var plugin = Plugin.Instance;
+            var config = plugin?.Configuration;
+            if (plugin == null || config == null) return Json(503, new { error = "Plugin is not ready" });
+
+            var messageId = request.MessageId ?? string.Empty;
+            var removed = config.Messages
+                .RemoveAll(m => string.Equals(m.Id, messageId, StringComparison.OrdinalIgnoreCase));
+
+            if (removed == 0) return Json(404, new { error = "Message not found" });
+
+            plugin.UpdateConfiguration(config);
+            Plugin.Instance?.SettingsService?.BroadcastSystemEvent("messagesChanged");
+
+            return Json(new { success = true });
+        }
+
+        /// <summary>
+        /// Queues a push so the message also reaches users who do not have the app open.
+        /// The route tells the app to open the messages window on tap.
+        /// </summary>
+        private static void SendPush(ServerMessage message)
+        {
+            // Admin-only messages get no push, since the notification store does not know who
+            // is an admin. Admins still see them next time they open the app.
+            if (message.Audience == ServerMessage.AudienceAdmins) return;
+
+            var store = Plugin.Instance?.NotificationStore;
+            var pushDelivery = Plugin.Instance?.PushDelivery;
+            if (store == null || pushDelivery == null) return;
+
+            var title = message.Title.Length > 0 ? message.Title : "Message from your server";
+
+            foreach (var userId in store.GetUsersWithDevices())
+            {
+                if (message.Audience == ServerMessage.AudienceUsers &&
+                    !message.TargetUserIds.Any(id =>
+                        Guid.TryParse(id, out var target) && target == userId))
+                {
+                    continue;
+                }
+
+                pushDelivery.QueueToUser(userId, title, message.Body, route: "messages");
+            }
+        }
+    }
+}

--- a/Emby/Emby.Plugins.Moonfin/Api/SettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/SettingsService.cs
@@ -81,6 +81,9 @@ namespace Emby.Plugins.Moonfin.Api
                 jellyseerrUrl = seerrUrl,
                 mdblistAvailable = !string.IsNullOrWhiteSpace(config?.MdblistApiKey),
                 tmdbAvailable = !string.IsNullOrWhiteSpace(config?.TmdbApiKey),
+                // Older plugins leave this out, which the app reads as false and hides the
+                // messages button.
+                messagesSupported = true,
                 defaultSettings = config?.DefaultUserSettings
             });
         }
@@ -341,9 +344,29 @@ namespace Emby.Plugins.Moonfin.Api
 
             var deliveries = Settings.BroadcastMessage(message);
 
+            // Also save it, so users who were not connected still find it in the app. Older
+            // clients keep reading the "adminMessage" event above and ignore this.
+            var config = Plugin.Instance?.Configuration;
+            if (Plugin.Instance != null && config != null)
+            {
+                config.Messages.Add(new ServerMessage
+                {
+                    Id = Guid.NewGuid().ToString("N"),
+                    Body = message,
+                    Severity = ServerMessage.SeverityInfo,
+                    Delivery = ServerMessage.DeliveryPopup,
+                    Audience = ServerMessage.AudienceAll,
+                    CreatedUtc = DateTime.UtcNow,
+                    CreatedByUserId = AuthHelpers.GetCurrentUserId(Request, _authContext)?.ToString("N")
+                });
+                ServerMessage.Prune(config.Messages);
+                Plugin.Instance.UpdateConfiguration(config);
+                Settings.BroadcastSystemEvent("messagesChanged");
+            }
+
             // The websocket only reaches clients that are open right now, so push
-            // covers backgrounded and killed apps. The route is left blank because
-            // the client ignores blank routes and just opens the app on a tap.
+            // covers backgrounded and killed apps. The route opens the messages window
+            // on tap.
             var pushTargets = 0;
             var store = Plugin.Instance?.NotificationStore;
             var pushDelivery = Plugin.Instance?.PushDelivery;
@@ -351,7 +374,7 @@ namespace Emby.Plugins.Moonfin.Api
             {
                 foreach (var userId in store.GetUsersWithDevices())
                 {
-                    pushDelivery.QueueToUser(userId, "Message from your server", message, route: "");
+                    pushDelivery.QueueToUser(userId, "Message from your server", message, route: "messages");
                     pushTargets++;
                 }
             }

--- a/Emby/Emby.Plugins.Moonfin/Api/SettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/SettingsService.cs
@@ -353,7 +353,7 @@ namespace Emby.Plugins.Moonfin.Api
                 {
                     Id = Guid.NewGuid().ToString("N"),
                     Body = message,
-                    Severity = ServerMessage.SeverityInfo,
+                    Color = ServerMessage.ColorWhite,
                     Delivery = ServerMessage.DeliveryPopup,
                     Audience = ServerMessage.AudienceAll,
                     CreatedUtc = DateTime.UtcNow,

--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -300,6 +300,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("use24HourClock")] public bool? Use24HourClock { get; set; }
         [JsonPropertyName("homeRowInfoOverlay")] public bool? HomeRowInfoOverlay { get; set; }
         [JsonPropertyName("showSeerrButton")] public bool? ShowSeerrButton { get; set; }
+        [JsonPropertyName("showServerMessagesButton")] public bool? ShowServerMessagesButton { get; set; }
         [JsonPropertyName("crashReportsEnabled")] public bool? CrashReportsEnabled { get; set; }
         [JsonPropertyName("diagnosticLoggingEnabled")] public bool? DiagnosticLoggingEnabled { get; set; }
         [JsonPropertyName("updateNotificationsEnabled")] public bool? UpdateNotificationsEnabled { get; set; }

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1923,9 +1923,9 @@
                                 <option value="popup">Open the message in the app</option>
                             </select>
                             <div class="fieldDescription">
-                                Notify adds the message to the unread count on the menu button. Open shows it
-                                the next time the user opens the app, and also sends a phone notification to
-                                users who turned them on.
+                                Notify adds the message to the unread count on the menu button. Open makes the
+                                message window come up on its own, once. Open also sends a phone notification, if
+                                this server has push set up.
                             </div>
                         </div>
 

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1909,14 +1909,15 @@
                         </div>
 
                         <div class="selectContainer">
-                            <label class="selectLabel" for="MessageDelivery">How loud</label>
+                            <label class="selectLabel" for="MessageDelivery">How to show it</label>
                             <select is="emby-select" id="MessageDelivery">
-                                <option value="inbox">Quiet: only a dot on the button</option>
-                                <option value="toast">Small popup in the corner</option>
-                                <option value="popup">Open the message window once</option>
+                                <option value="inbox">Notify on the menu button</option>
+                                <option value="popup">Open the message in the app</option>
                             </select>
                             <div class="fieldDescription">
-                                The last two also send a phone notification to users who turned them on.
+                                Notify adds the message to the unread count on the menu button. Open shows it
+                                the next time the user opens the app, and also sends a phone notification to
+                                users who turned them on.
                             </div>
                         </div>
 
@@ -1963,12 +1964,6 @@
                             </div>
                         </div>
 
-                        <div class="checkboxContainer">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="MessagePinned" is="emby-checkbox" />
-                                <span>Keep this message at the top of the list</span>
-                            </label>
-                        </div>
 
                         <div style="display:flex; flex-wrap:wrap; align-items:center; gap:0.6em; margin-top:0.8em;">
                             <button is="emby-button" type="button" id="MessageSaveBtn" class="raised">
@@ -1984,7 +1979,7 @@
                     <div class="verticalSection">
                         <h3 class="sectionTitle">Saved Messages</h3>
                         <div class="fieldDescription" style="margin-bottom: 0.8em;">
-                            Up to 50 messages are kept. Past that, the oldest unpinned ones are dropped.
+                            Shown in this order in the app. Up to 50 are kept, then the oldest are dropped.
                         </div>
                         <div id="MessagesList" style="max-height:340px;overflow-y:auto;border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:6px;"></div>
                     </div>

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1169,6 +1169,14 @@
                                     <option value="false">No</option>
                                 </select>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowServerMessagesButton">Show Messages Button</label>
+                                <select id="DefaultShowServerMessagesButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
 
                         <!-- 4. Home Screen -->

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1888,17 +1888,24 @@
 
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="MessageBody">Message</label>
-                            <textarea id="MessageBody" is="emby-textarea" rows="4" maxlength="2000" placeholder="Plain text only. Links and formatting are not shown."></textarea>
+                            <textarea id="MessageBody" is="emby-textarea" rows="12" maxlength="2000" style="width:100%;box-sizing:border-box;font-family:inherit;" placeholder="Write your message here."></textarea>
+                            <div class="fieldDescription">
+                                Formatting uses Markdown. Only CommonMark is supported:
+                                <a href="https://commonmark.org/help/" target="_blank">syntax reference</a>.
+                                Images are not shown, even though that page lists them.
+                            </div>
                         </div>
 
                         <div class="selectContainer">
-                            <label class="selectLabel" for="MessageSeverity">Importance</label>
-                            <select is="emby-select" id="MessageSeverity">
-                                <option value="info">Info (green)</option>
-                                <option value="warning">Warning (yellow)</option>
-                                <option value="critical">Critical (red)</option>
+                            <label class="selectLabel" for="MessageColor">Colour</label>
+                            <select is="emby-select" id="MessageColor">
+                                <option value="white">White</option>
+                                <option value="green">Green</option>
+                                <option value="blue">Blue</option>
+                                <option value="yellow">Yellow</option>
+                                <option value="red">Red</option>
                             </select>
-                            <div class="fieldDescription">Sets the colour of the message and of the button in the app menu.</div>
+                            <div class="fieldDescription">Colours the message in the app. The menu button stays neutral.</div>
                         </div>
 
                         <div class="selectContainer">

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1887,7 +1887,7 @@
                         </div>
 
                         <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="MessageBody">Message</label>
+                            <label class="inputLabel inputLabelUnfocused" for="MessageBody" style="display:block;">Message</label>
                             <textarea id="MessageBody" is="emby-textarea" rows="12" maxlength="2000" style="width:100%;box-sizing:border-box;font-family:inherit;" placeholder="Write your message here."></textarea>
                             <div class="fieldDescription">
                                 Formatting uses Markdown. Only CommonMark is supported:

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -567,6 +567,10 @@
                             <svg class="moonfinNavIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5H16c2.76 0 5-2.24 5-5 0-4.42-4.03-8-9-8zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 9 6.5 9 8 9.67 8 10.5 7.33 12 6.5 12zm3-4C8.67 8 8 7.33 8 6.5S8.67 5 9.5 5s1.5.67 1.5 1.5S10.33 8 9.5 8zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 5 14.5 5s1.5.67 1.5 1.5S15.33 8 14.5 8zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 9 17.5 9s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>
                             <span class="moonfinNavText"><span class="moonfinNavLabel">Themes</span><span class="moonfinNavSub">Upload &amp; catalog</span></span>
                         </button>
+                        <button type="button" class="moonfinNavItem" data-tab="messages">
+                            <svg class="moonfinNavIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5S10.5 3.17 10.5 4v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/></svg>
+                            <span class="moonfinNavText"><span class="moonfinNavLabel">Messages</span><span class="moonfinNavSub">News for your users</span></span>
+                        </button>
                         <button type="button" class="moonfinNavItem" data-tab="actions">
                             <svg class="moonfinNavIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M18 11v2h4v-2h-4zm-2 6.61c.96.71 2.21 1.65 3.2 2.39.4-.53.8-1.07 1.2-1.6-.99-.74-2.24-1.68-3.2-2.4-.4.54-.8 1.08-1.2 1.61zM20.4 5.6c-.4-.53-.8-1.07-1.2-1.6-.99.74-2.24 1.68-3.2 2.4.4.53.8 1.07 1.2 1.6.96-.72 2.21-1.65 3.2-2.4zM4 9c-1.1 0-2 .9-2 2v2c0 1.1.9 2 2 2h1v4h2v-4h1l5 3V6L8 9H4zm11.5 3c0-1.33-.58-2.53-1.5-3.35v6.69c.92-.81 1.5-2.01 1.5-3.34z"/></svg>
                             <span class="moonfinNavText"><span class="moonfinNavLabel">Actions</span><span class="moonfinNavSub">Apply Defaults &amp; Broadcast</span></span>
@@ -1868,6 +1872,117 @@
                     </div>
 
                     </section>
+                    <section class="moonfinTabPanel" data-tab="messages">
+                    <div class="verticalSection">
+                        <h3 class="sectionTitle">Messages</h3>
+                        <div class="fieldDescription" style="margin-bottom: 0.8em;">
+                            Write news, updates or warnings for your users. They read them from the messages
+                            button in the app menu. Messages are saved, so users still see them if the app was
+                            closed when you posted.
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageTitle">Title</label>
+                            <input type="text" id="MessageTitle" is="emby-input" maxlength="120" placeholder="Server maintenance on Saturday" />
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageBody">Message</label>
+                            <textarea id="MessageBody" is="emby-textarea" rows="4" maxlength="2000" placeholder="Plain text only. Links and formatting are not shown."></textarea>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="MessageSeverity">Importance</label>
+                            <select is="emby-select" id="MessageSeverity">
+                                <option value="info">Info (green)</option>
+                                <option value="warning">Warning (yellow)</option>
+                                <option value="critical">Critical (red)</option>
+                            </select>
+                            <div class="fieldDescription">Sets the colour of the message and of the button in the app menu.</div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="MessageDelivery">How loud</label>
+                            <select is="emby-select" id="MessageDelivery">
+                                <option value="inbox">Quiet: only a dot on the button</option>
+                                <option value="toast">Small popup in the corner</option>
+                                <option value="popup">Open the message window once</option>
+                            </select>
+                            <div class="fieldDescription">
+                                The last two also send a phone notification to users who turned them on.
+                            </div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="MessageAudience">Who sees it</label>
+                            <select is="emby-select" id="MessageAudience">
+                                <option value="all">Everyone</option>
+                                <option value="users">Only the users I pick</option>
+                                <option value="admins">Only admins</option>
+                            </select>
+                        </div>
+
+                        <div class="selectContainer" id="MessageTargetsRow" style="display:none;">
+                            <label class="selectLabel" for="MessageTargets">Users</label>
+                            <select is="emby-select" id="MessageTargets" multiple size="6"></select>
+                            <div class="fieldDescription">Hold Ctrl or Cmd to pick more than one.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageStart">Show from (optional)</label>
+                            <input type="datetime-local" id="MessageStart" is="emby-input" />
+                            <div class="fieldDescription">Leave empty to show it right away.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageEnd">Hide after (optional)</label>
+                            <input type="datetime-local" id="MessageEnd" is="emby-input" />
+                            <div class="fieldDescription">
+                                Leave empty to keep it forever. Messages past this date are deleted on the next save.
+                            </div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageActionLabel">Button text (optional)</label>
+                            <input type="text" id="MessageActionLabel" is="emby-input" maxlength="40" placeholder="Read more" />
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageActionUrl">Button link (optional)</label>
+                            <input type="text" id="MessageActionUrl" is="emby-input" placeholder="https://example.com/news" />
+                            <div class="fieldDescription">
+                                Must start with http:// or https://. On TV the app shows it as a QR code.
+                                A link needs a button text, and a button text needs a link.
+                            </div>
+                        </div>
+
+                        <div class="checkboxContainer">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" id="MessagePinned" is="emby-checkbox" />
+                                <span>Keep this message at the top of the list</span>
+                            </label>
+                        </div>
+
+                        <div style="display:flex; flex-wrap:wrap; align-items:center; gap:0.6em; margin-top:0.8em;">
+                            <button is="emby-button" type="button" id="MessageSaveBtn" class="raised">
+                                <span>Save Message</span>
+                            </button>
+                            <button is="emby-button" type="button" id="MessageResetBtn" class="raised" style="display:none;">
+                                <span>Cancel Edit</span>
+                            </button>
+                        </div>
+                        <div id="MessageSaveResult" class="fieldDescription" style="display:none; margin-top:0.8em;"></div>
+                    </div>
+
+                    <div class="verticalSection">
+                        <h3 class="sectionTitle">Saved Messages</h3>
+                        <div class="fieldDescription" style="margin-bottom: 0.8em;">
+                            Up to 50 messages are kept. Past that, the oldest unpinned ones are dropped.
+                        </div>
+                        <div id="MessagesList" style="max-height:340px;overflow-y:auto;border:1px solid rgba(128,128,128,0.3);border-radius:4px;padding:6px;"></div>
+                    </div>
+
+                    </section>
                     <section class="moonfinTabPanel" data-tab="actions">
                     <div class="verticalSection">
                         <h3 class="sectionTitle">Push Defaults To Existing Users</h3>
@@ -1889,8 +2004,9 @@
                     <div class="verticalSection">
                         <h3 class="sectionTitle">Broadcast Message</h3>
                         <div class="fieldDescription" style="margin-bottom: 0.8em;">
-                            Send a live message to all currently connected Moonfin clients.
-                            This message is not saved and only appears for users with an active connection.
+                            Send a message to all connected Moonfin clients right now. It is also saved to
+                            the Messages tab, so users who were offline still see it later.
+                            For anything you want to write properly, use the Messages tab instead.
                         </div>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="BroadcastMessageText">Message</label>

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1702,6 +1702,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setNullableBoolSelect(view, '#DefaultNavbarAlwaysExpanded', defaults.navbarAlwaysExpanded);
             setNullableBoolSelect(view, '#DefaultEnableFolderView', defaults.enableFolderView);
             setNullableBoolSelect(view, '#DefaultShowSeerrButton', defaults.showSeerrButton);
+            setNullableBoolSelect(view, '#DefaultShowServerMessagesButton', defaults.showServerMessagesButton);
 
             setSelectValue(view, '#DefaultMediaBarSourceType', defaults.mediaBarSourceType, 'Configured source');
             loadAdminGenrePicker(view, defaults.mediaBarExcludedGenres || []);
@@ -1868,6 +1869,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.navbarAlwaysExpanded = getNullableBoolSelect(view, '#DefaultNavbarAlwaysExpanded');
             d.enableFolderView = getNullableBoolSelect(view, '#DefaultEnableFolderView');
             d.showSeerrButton = getNullableBoolSelect(view, '#DefaultShowSeerrButton');
+            d.showServerMessagesButton = getNullableBoolSelect(view, '#DefaultShowServerMessagesButton');
 
             d.mediaBarSourceType = view.querySelector('#DefaultMediaBarSourceType').value || null;
             var genreIds = Array.prototype.slice.call(view.querySelectorAll('.adminGenreCb:checked')).map(function (cb) { return cb.dataset.id; });

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -2068,10 +2068,12 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         });
     }
 
-    var moonfinSeverityColors = {
-        info: '#52b54b',
-        warning: '#f0ad4e',
-        critical: '#d9534f'
+    var moonfinMessageColors = {
+        white: '#e8eaed',
+        green: '#4caf6d',
+        blue: '#4a9ee0',
+        yellow: '#e0b040',
+        red: '#e05260'
     };
 
     var moonfinDeliveryLabels = {
@@ -2146,7 +2148,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
         view.querySelector('#MessageTitle').value = '';
         view.querySelector('#MessageBody').value = '';
-        view.querySelector('#MessageSeverity').value = 'info';
+        view.querySelector('#MessageColor').value = 'white';
         view.querySelector('#MessageDelivery').value = 'inbox';
         view.querySelector('#MessageAudience').value = 'all';
         view.querySelector('#MessageStart').value = '';
@@ -2175,7 +2177,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
         view.querySelector('#MessageTitle').value = item.Title || item.title || '';
         view.querySelector('#MessageBody').value = item.Body || item.body || '';
-        view.querySelector('#MessageSeverity').value = item.Severity || item.severity || 'info';
+        view.querySelector('#MessageColor').value = item.Color || item.color || 'white';
         view.querySelector('#MessageDelivery').value = item.Delivery || item.delivery || 'inbox';
         view.querySelector('#MessageAudience').value = item.Audience || item.audience || 'all';
         view.querySelector('#MessageStart').value = messageDateToInput(item.StartUtc || item.startUtc);
@@ -2223,14 +2225,14 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             var id = item.Id || item.id || '';
             var title = item.Title || item.title || '';
             var body = item.Body || item.body || '';
-            var severity = item.Severity || item.severity || 'info';
+            var pick = item.Color || item.color || 'white';
             var delivery = item.Delivery || item.delivery || 'inbox';
             var audience = item.Audience || item.audience || 'all';
             var pinned = !!(item.Pinned || item.pinned);
             var start = item.StartUtc || item.startUtc;
             var end = item.EndUtc || item.endUtc;
             var targets = item.TargetUserIds || item.targetUserIds || [];
-            var color = moonfinSeverityColors[severity] || moonfinSeverityColors.info;
+            var color = moonfinMessageColors[pick] || moonfinMessageColors.white;
 
             var state = 'Showing now';
             if (start && new Date(start) > now) {
@@ -2314,7 +2316,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             Id: view.__moonfinEditingMessageId || '',
             Title: title,
             Body: body,
-            Severity: view.querySelector('#MessageSeverity').value,
+            Color: view.querySelector('#MessageColor').value,
             Delivery: view.querySelector('#MessageDelivery').value,
             Audience: audience,
             TargetUserIds: targetUserIds,

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -2068,6 +2068,323 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         });
     }
 
+    var moonfinSeverityColors = {
+        info: '#52b54b',
+        warning: '#f0ad4e',
+        critical: '#d9534f'
+    };
+
+    var moonfinDeliveryLabels = {
+        inbox: 'Quiet',
+        toast: 'Corner popup',
+        popup: 'Opens the window'
+    };
+
+    function setMessageResult(view, text, color) {
+        var result = view.querySelector('#MessageSaveResult');
+        if (!result) return;
+
+        if (!text) {
+            result.style.display = 'none';
+            result.textContent = '';
+            return;
+        }
+
+        result.style.display = '';
+        result.style.color = color || '';
+        result.textContent = text;
+    }
+
+    // The date inputs work in the admin's own time zone, but the server stores UTC.
+    function messageDateToInput(utcValue) {
+        if (!utcValue) return '';
+
+        var date = new Date(utcValue);
+        if (isNaN(date.getTime())) return '';
+
+        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
+        return date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate()) +
+            'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+    }
+
+    function messageDateFromInput(value) {
+        if (!value) return null;
+        var date = new Date(value);
+        return isNaN(date.getTime()) ? null : date.toISOString();
+    }
+
+    function formatMessageDate(utcValue) {
+        if (!utcValue) return '';
+        var date = new Date(utcValue);
+        return isNaN(date.getTime()) ? '' : date.toLocaleString();
+    }
+
+    function toggleMessageTargets(view) {
+        var audience = view.querySelector('#MessageAudience');
+        var row = view.querySelector('#MessageTargetsRow');
+        if (!audience || !row) return;
+        row.style.display = audience.value === 'users' ? '' : 'none';
+    }
+
+    function loadMessageTargetUsers(view) {
+        var select = view.querySelector('#MessageTargets');
+        if (!select || !ApiClient.getUsers) return Promise.resolve();
+
+        return ApiClient.getUsers().then(function (users) {
+            select.innerHTML = '';
+            (users || []).forEach(function (user) {
+                var option = document.createElement('option');
+                option.value = user.Id;
+                option.textContent = user.Name;
+                select.appendChild(option);
+            });
+        }).catch(function () {});
+    }
+
+    function resetMessageForm(view) {
+        view.__moonfinEditingMessageId = null;
+
+        view.querySelector('#MessageTitle').value = '';
+        view.querySelector('#MessageBody').value = '';
+        view.querySelector('#MessageSeverity').value = 'info';
+        view.querySelector('#MessageDelivery').value = 'inbox';
+        view.querySelector('#MessageAudience').value = 'all';
+        view.querySelector('#MessageStart').value = '';
+        view.querySelector('#MessageEnd').value = '';
+        view.querySelector('#MessageActionLabel').value = '';
+        view.querySelector('#MessageActionUrl').value = '';
+        view.querySelector('#MessagePinned').checked = false;
+
+        var targets = view.querySelector('#MessageTargets');
+        if (targets) {
+            Array.prototype.forEach.call(targets.options, function (option) { option.selected = false; });
+        }
+
+        var saveBtn = view.querySelector('#MessageSaveBtn');
+        if (saveBtn) saveBtn.querySelector('span').textContent = 'Save Message';
+
+        var resetBtn = view.querySelector('#MessageResetBtn');
+        if (resetBtn) resetBtn.style.display = 'none';
+
+        toggleMessageTargets(view);
+        setMessageResult(view, '', '');
+    }
+
+    function editMessage(view, item) {
+        view.__moonfinEditingMessageId = item.Id || item.id || null;
+
+        view.querySelector('#MessageTitle').value = item.Title || item.title || '';
+        view.querySelector('#MessageBody').value = item.Body || item.body || '';
+        view.querySelector('#MessageSeverity').value = item.Severity || item.severity || 'info';
+        view.querySelector('#MessageDelivery').value = item.Delivery || item.delivery || 'inbox';
+        view.querySelector('#MessageAudience').value = item.Audience || item.audience || 'all';
+        view.querySelector('#MessageStart').value = messageDateToInput(item.StartUtc || item.startUtc);
+        view.querySelector('#MessageEnd').value = messageDateToInput(item.EndUtc || item.endUtc);
+        view.querySelector('#MessageActionLabel').value = item.ActionLabel || item.actionLabel || '';
+        view.querySelector('#MessageActionUrl').value = item.ActionUrl || item.actionUrl || '';
+        view.querySelector('#MessagePinned').checked = !!(item.Pinned || item.pinned);
+
+        var selected = item.TargetUserIds || item.targetUserIds || [];
+        var targets = view.querySelector('#MessageTargets');
+        if (targets) {
+            Array.prototype.forEach.call(targets.options, function (option) {
+                option.selected = selected.some(function (id) {
+                    return String(id).toLowerCase() === String(option.value).toLowerCase();
+                });
+            });
+        }
+
+        var saveBtn = view.querySelector('#MessageSaveBtn');
+        if (saveBtn) saveBtn.querySelector('span').textContent = 'Update Message';
+
+        var resetBtn = view.querySelector('#MessageResetBtn');
+        if (resetBtn) resetBtn.style.display = '';
+
+        toggleMessageTargets(view);
+        setMessageResult(view, '', '');
+
+        var titleInput = view.querySelector('#MessageTitle');
+        if (titleInput) titleInput.focus();
+    }
+
+    function renderMessagesList(view, items) {
+        var container = view.querySelector('#MessagesList');
+        if (!container) return;
+
+        if (!items || items.length === 0) {
+            container.innerHTML = '<div style="padding:8px;opacity:0.6;font-size:0.9em;">No messages yet.</div>';
+            return;
+        }
+
+        var now = new Date();
+        var html = '';
+
+        items.forEach(function (item) {
+            var id = item.Id || item.id || '';
+            var title = item.Title || item.title || '';
+            var body = item.Body || item.body || '';
+            var severity = item.Severity || item.severity || 'info';
+            var delivery = item.Delivery || item.delivery || 'inbox';
+            var audience = item.Audience || item.audience || 'all';
+            var pinned = !!(item.Pinned || item.pinned);
+            var start = item.StartUtc || item.startUtc;
+            var end = item.EndUtc || item.endUtc;
+            var targets = item.TargetUserIds || item.targetUserIds || [];
+            var color = moonfinSeverityColors[severity] || moonfinSeverityColors.info;
+
+            var state = 'Showing now';
+            if (start && new Date(start) > now) {
+                state = 'Starts ' + formatMessageDate(start);
+            } else if (end && new Date(end) <= now) {
+                state = 'Expired';
+            } else if (end) {
+                state = 'Until ' + formatMessageDate(end);
+            }
+
+            var who = audience === 'admins'
+                ? 'Admins only'
+                : audience === 'users'
+                    ? targets.length + (targets.length === 1 ? ' user' : ' users')
+                    : 'Everyone';
+
+            html += '<div style="display:flex;align-items:flex-start;gap:10px;padding:8px;border:1px solid rgba(128,128,128,0.3);border-left:3px solid ' + color + ';border-radius:4px;margin-bottom:6px;">' +
+                '<div style="flex:1;min-width:0;">' +
+                '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">' +
+                '<strong style="font-size:0.95em;color:' + color + ';">' + esc(title || '(no title)') + '</strong>' +
+                (pinned ? '<span style="font-size:0.72em;opacity:0.7;border:1px solid rgba(128,128,128,0.4);border-radius:3px;padding:0 4px;">PINNED</span>' : '') +
+                '</div>' +
+                '<div style="font-size:0.82em;opacity:0.8;margin-top:4px;white-space:pre-wrap;">' + esc(body.length > 160 ? body.slice(0, 160) + '…' : body) + '</div>' +
+                '<div style="font-size:0.78em;opacity:0.6;margin-top:4px;">' +
+                esc(state) + ' • ' + esc(who) + ' • ' + esc(moonfinDeliveryLabels[delivery] || delivery) +
+                '</div>' +
+                '</div>' +
+                '<button type="button" class="moonfinMessageEditBtn" data-message-id="' + esc(id) + '" title="Edit message" style="background:none;border:1px solid rgba(128,128,128,0.5);border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">Edit</button>' +
+                '<button type="button" class="moonfinMessageDeleteBtn" data-message-id="' + esc(id) + '" title="Delete message" style="background:none;border:1px solid rgba(239,68,68,0.6);color:#ef4444;border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">&#x2715;</button>' +
+                '</div>';
+        });
+
+        container.innerHTML = html;
+    }
+
+    function loadMessagesList(view) {
+        var container = view.querySelector('#MessagesList');
+        if (!container) return;
+
+        var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+        container.innerHTML = '<div style="padding:8px;opacity:0.6;font-size:0.9em;">Loading messages...</div>';
+
+        fetch(serverUrl + '/Moonfin/Admin/Messages', { method: 'GET', headers: moonfinAuthHeaders() })
+            .then(parseJsonResponse)
+            .then(function (payload) {
+                var items = payload.items || payload.Items || [];
+                view.__moonfinMessagesCache = items;
+                renderMessagesList(view, items);
+            })
+            .catch(function (error) {
+                container.innerHTML = '<div style="padding:8px;color:#d9534f;font-size:0.9em;">' +
+                    esc((error && error.message) ? error.message : 'Failed to load messages.') + '</div>';
+            });
+    }
+
+    function saveMessage(view) {
+        var saveBtn = view.querySelector('#MessageSaveBtn');
+        var title = (view.querySelector('#MessageTitle').value || '').trim();
+        var body = (view.querySelector('#MessageBody').value || '').trim();
+
+        if (!title && !body) {
+            setMessageResult(view, 'Enter a title or a message.', '#d9534f');
+            return;
+        }
+
+        var audience = view.querySelector('#MessageAudience').value;
+        var targetSelect = view.querySelector('#MessageTargets');
+        var targetUserIds = [];
+        if (audience === 'users' && targetSelect) {
+            targetUserIds = Array.prototype.filter.call(targetSelect.options, function (option) {
+                return option.selected;
+            }).map(function (option) { return option.value; });
+
+            if (targetUserIds.length === 0) {
+                setMessageResult(view, 'Pick at least one user, or change who sees it.', '#d9534f');
+                return;
+            }
+        }
+
+        var payload = {
+            Id: view.__moonfinEditingMessageId || '',
+            Title: title,
+            Body: body,
+            Severity: view.querySelector('#MessageSeverity').value,
+            Delivery: view.querySelector('#MessageDelivery').value,
+            Audience: audience,
+            TargetUserIds: targetUserIds,
+            Pinned: view.querySelector('#MessagePinned').checked,
+            ActionLabel: (view.querySelector('#MessageActionLabel').value || '').trim(),
+            ActionUrl: (view.querySelector('#MessageActionUrl').value || '').trim(),
+            StartUtc: messageDateFromInput(view.querySelector('#MessageStart').value),
+            EndUtc: messageDateFromInput(view.querySelector('#MessageEnd').value)
+        };
+
+        var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+        var wasEditing = !!view.__moonfinEditingMessageId;
+
+        if (saveBtn) saveBtn.disabled = true;
+        setMessageResult(view, '', '');
+
+        fetch(serverUrl + '/Moonfin/Admin/Messages', {
+            method: 'POST',
+            headers: moonfinAuthHeaders(),
+            body: JSON.stringify(payload)
+        })
+            .then(parseJsonResponse)
+            .then(function (response) {
+                var saved = response.item || response.Item || {};
+                var warnings = [];
+
+                if (payload.ActionUrl && !(saved.ActionUrl || saved.actionUrl)) {
+                    warnings.push('the link was dropped, it must start with http:// or https://');
+                }
+                if (payload.EndUtc && !(saved.EndUtc || saved.endUtc)) {
+                    warnings.push('the end date was dropped, it was before the start date');
+                }
+
+                var message = wasEditing ? 'Message updated.' : 'Message saved.';
+                if (warnings.length) message += ' Note: ' + warnings.join(', ') + '.';
+
+                // resetMessageForm clears the result line, so set it afterwards.
+                resetMessageForm(view);
+                setMessageResult(view, message, warnings.length ? '#f0ad4e' : '#52b54b');
+                loadMessagesList(view);
+            })
+            .catch(function (error) {
+                setMessageResult(view, (error && error.message) ? error.message : 'Save failed.', '#d9534f');
+            })
+            .finally(function () {
+                if (saveBtn) saveBtn.disabled = false;
+            });
+    }
+
+    function deleteMessage(view, messageId) {
+        if (!messageId) return;
+        if (!window.confirm('Delete this message?')) return;
+
+        var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+
+        fetch(serverUrl + '/Moonfin/Admin/Messages/' + encodeURIComponent(messageId), {
+            method: 'DELETE',
+            headers: moonfinAuthHeaders()
+        })
+            .then(parseJsonResponse)
+            .then(function () {
+                if (view.__moonfinEditingMessageId === messageId) resetMessageForm(view);
+                setMessageResult(view, 'Message deleted.', '#52b54b');
+                loadMessagesList(view);
+            })
+            .catch(function (error) {
+                setMessageResult(view, (error && error.message) ? error.message : 'Delete failed.', '#d9534f');
+            });
+    }
+
     function initializeDefaultsSubtabs(view) {
         var subnav = view.querySelector('.defaultsSubnavBar');
         if (!subnav || subnav.dataset.bound) return;
@@ -2144,6 +2461,36 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         var broadcastBtn = view.querySelector('#BroadcastMessageBtn');
         if (broadcastBtn) broadcastBtn.addEventListener('click', function () { broadcast(view); });
 
+        var messageAudience = view.querySelector('#MessageAudience');
+        if (messageAudience) {
+            messageAudience.addEventListener('change', function () { toggleMessageTargets(view); });
+        }
+
+        var messageSaveBtn = view.querySelector('#MessageSaveBtn');
+        if (messageSaveBtn) messageSaveBtn.addEventListener('click', function () { saveMessage(view); });
+
+        var messageResetBtn = view.querySelector('#MessageResetBtn');
+        if (messageResetBtn) messageResetBtn.addEventListener('click', function () { resetMessageForm(view); });
+
+        var messagesListContainer = view.querySelector('#MessagesList');
+        if (messagesListContainer) {
+            messagesListContainer.addEventListener('click', function (event) {
+                var editButton = event.target.closest('.moonfinMessageEditBtn');
+                if (editButton) {
+                    var editId = editButton.getAttribute('data-message-id') || '';
+                    var cached = view.__moonfinMessagesCache || [];
+                    var found = cached.filter(function (item) {
+                        return (item.Id || item.id) === editId;
+                    })[0];
+                    if (found) editMessage(view, found);
+                    return;
+                }
+
+                var deleteButton = event.target.closest('.moonfinMessageDeleteBtn');
+                if (deleteButton) deleteMessage(view, deleteButton.getAttribute('data-message-id') || '');
+            });
+        }
+
         var mdblistTestBtn = view.querySelector('#MdblistTestKeyBtn');
         if (mdblistTestBtn) mdblistTestBtn.addEventListener('click', function () { testMdblistKey(view); });
 
@@ -2164,6 +2511,11 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         clearSelectedThemeFile(view);
         setThemeUploadResult(view, '', '');
         loadAdminThemesList(view);
+        // The user list must be there before the form can preselect targets on edit.
+        loadMessageTargetUsers(view).then(function () {
+            resetMessageForm(view);
+            loadMessagesList(view);
+        });
         loadConfig(view);
     };
 

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -2077,9 +2077,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     };
 
     var moonfinDeliveryLabels = {
-        inbox: 'Quiet',
-        toast: 'Corner popup',
-        popup: 'Opens the window'
+        inbox: 'Notify',
+        popup: 'Opens in app'
     };
 
     function setMessageResult(view, text, color) {
@@ -2155,7 +2154,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         view.querySelector('#MessageEnd').value = '';
         view.querySelector('#MessageActionLabel').value = '';
         view.querySelector('#MessageActionUrl').value = '';
-        view.querySelector('#MessagePinned').checked = false;
 
         var targets = view.querySelector('#MessageTargets');
         if (targets) {
@@ -2184,7 +2182,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         view.querySelector('#MessageEnd').value = messageDateToInput(item.EndUtc || item.endUtc);
         view.querySelector('#MessageActionLabel').value = item.ActionLabel || item.actionLabel || '';
         view.querySelector('#MessageActionUrl').value = item.ActionUrl || item.actionUrl || '';
-        view.querySelector('#MessagePinned').checked = !!(item.Pinned || item.pinned);
 
         var selected = item.TargetUserIds || item.targetUserIds || [];
         var targets = view.querySelector('#MessageTargets');
@@ -2221,14 +2218,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         var now = new Date();
         var html = '';
 
-        items.forEach(function (item) {
+        items.forEach(function (item, index) {
             var id = item.Id || item.id || '';
             var title = item.Title || item.title || '';
             var body = item.Body || item.body || '';
             var pick = item.Color || item.color || 'white';
             var delivery = item.Delivery || item.delivery || 'inbox';
             var audience = item.Audience || item.audience || 'all';
-            var pinned = !!(item.Pinned || item.pinned);
             var start = item.StartUtc || item.startUtc;
             var end = item.EndUtc || item.endUtc;
             var targets = item.TargetUserIds || item.targetUserIds || [];
@@ -2253,12 +2249,15 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
                 '<div style="flex:1;min-width:0;">' +
                 '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">' +
                 '<strong style="font-size:0.95em;color:' + color + ';">' + esc(title || '(no title)') + '</strong>' +
-                (pinned ? '<span style="font-size:0.72em;opacity:0.7;border:1px solid rgba(128,128,128,0.4);border-radius:3px;padding:0 4px;">PINNED</span>' : '') +
                 '</div>' +
                 '<div style="font-size:0.82em;opacity:0.8;margin-top:4px;white-space:pre-wrap;">' + esc(body.length > 160 ? body.slice(0, 160) + '…' : body) + '</div>' +
                 '<div style="font-size:0.78em;opacity:0.6;margin-top:4px;">' +
                 esc(state) + ' • ' + esc(who) + ' • ' + esc(moonfinDeliveryLabels[delivery] || delivery) +
                 '</div>' +
+                '</div>' +
+                '<div style="display:flex;flex-direction:column;gap:2px;">' +
+                '<button type="button" class="moonfinMessageUpBtn" data-message-id="' + esc(id) + '" title="Move up"' + (index === 0 ? ' disabled' : '') + ' style="background:none;border:1px solid rgba(128,128,128,0.5);border-radius:4px;padding:0 6px;cursor:pointer;line-height:1.3;">&#9650;</button>' +
+                '<button type="button" class="moonfinMessageDownBtn" data-message-id="' + esc(id) + '" title="Move down"' + (index === items.length - 1 ? ' disabled' : '') + ' style="background:none;border:1px solid rgba(128,128,128,0.5);border-radius:4px;padding:0 6px;cursor:pointer;line-height:1.3;">&#9660;</button>' +
                 '</div>' +
                 '<button type="button" class="moonfinMessageEditBtn" data-message-id="' + esc(id) + '" title="Edit message" style="background:none;border:1px solid rgba(128,128,128,0.5);border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">Edit</button>' +
                 '<button type="button" class="moonfinMessageDeleteBtn" data-message-id="' + esc(id) + '" title="Delete message" style="background:none;border:1px solid rgba(239,68,68,0.6);color:#ef4444;border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">&#x2715;</button>' +
@@ -2285,6 +2284,44 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             .catch(function (error) {
                 container.innerHTML = '<div style="padding:8px;color:#d9534f;font-size:0.9em;">' +
                     esc((error && error.message) ? error.message : 'Failed to load messages.') + '</div>';
+            });
+    }
+
+    // Moves one message up or down and saves the whole order, so the app shows
+    // them in the same sequence as this list.
+    function moveMessage(view, messageId, delta) {
+        var items = (view.__moonfinMessagesCache || []).slice();
+        var from = -1;
+        for (var i = 0; i < items.length; i++) {
+            if ((items[i].Id || items[i].id) === messageId) { from = i; break; }
+        }
+
+        var to = from + delta;
+        if (from < 0 || to < 0 || to >= items.length) return;
+
+        var moved = items.splice(from, 1)[0];
+        items.splice(to, 0, moved);
+
+        // Redrawn straight away so the arrows feel instant, then saved.
+        view.__moonfinMessagesCache = items;
+        renderMessagesList(view, items);
+
+        var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+        fetch(serverUrl + '/Moonfin/Admin/Messages/Order', {
+            method: 'POST',
+            headers: moonfinAuthHeaders(),
+            body: JSON.stringify({
+                Ids: items.map(function (item) { return item.Id || item.id; })
+            })
+        })
+            .then(parseJsonResponse)
+            .catch(function (error) {
+                setMessageResult(
+                    view,
+                    (error && error.message) ? error.message : 'Could not save the new order.',
+                    '#d9534f'
+                );
+                loadMessagesList(view);
             });
     }
 
@@ -2320,7 +2357,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             Delivery: view.querySelector('#MessageDelivery').value,
             Audience: audience,
             TargetUserIds: targetUserIds,
-            Pinned: view.querySelector('#MessagePinned').checked,
             ActionLabel: (view.querySelector('#MessageActionLabel').value || '').trim(),
             ActionUrl: (view.querySelector('#MessageActionUrl').value || '').trim(),
             StartUtc: messageDateFromInput(view.querySelector('#MessageStart').value),
@@ -2477,6 +2513,18 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         var messagesListContainer = view.querySelector('#MessagesList');
         if (messagesListContainer) {
             messagesListContainer.addEventListener('click', function (event) {
+                var upButton = event.target.closest('.moonfinMessageUpBtn');
+                if (upButton) {
+                    moveMessage(view, upButton.getAttribute('data-message-id') || '', -1);
+                    return;
+                }
+
+                var downButton = event.target.closest('.moonfinMessageDownBtn');
+                if (downButton) {
+                    moveMessage(view, downButton.getAttribute('data-message-id') || '', 1);
+                    return;
+                }
+
                 var editButton = event.target.closest('.moonfinMessageEditBtn');
                 if (editButton) {
                     var editId = editButton.getAttribute('data-message-id') || '';

--- a/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
+++ b/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
@@ -242,9 +242,11 @@ namespace Emby.Plugins.Moonfin
         /// <summary>Body length cap, so a huge paste cannot break the app layout.</summary>
         public const int MaxBodyLength = 2000;
 
-        public const string SeverityInfo = "info";
-        public const string SeverityWarning = "warning";
-        public const string SeverityCritical = "critical";
+        public const string ColorGreen = "green";
+        public const string ColorRed = "red";
+        public const string ColorYellow = "yellow";
+        public const string ColorBlue = "blue";
+        public const string ColorWhite = "white";
 
         /// <summary>Shows in the list only.</summary>
         public const string DeliveryInbox = "inbox";
@@ -262,7 +264,7 @@ namespace Emby.Plugins.Moonfin
         public string Id { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
         public string Body { get; set; } = string.Empty;
-        public string Severity { get; set; } = SeverityInfo;
+        public string Color { get; set; } = ColorWhite;
         public string Delivery { get; set; } = DeliveryInbox;
         public bool Pinned { get; set; }
         public string? ActionLabel { get; set; }
@@ -315,11 +317,13 @@ namespace Emby.Plugins.Moonfin
             if (Body.Length > MaxBodyLength)
                 Body = Body.Substring(0, MaxBodyLength);
 
-            Severity = Severity switch
+            Color = Color switch
             {
-                SeverityWarning => SeverityWarning,
-                SeverityCritical => SeverityCritical,
-                _ => SeverityInfo
+                ColorGreen => ColorGreen,
+                ColorRed => ColorRed,
+                ColorYellow => ColorYellow,
+                ColorBlue => ColorBlue,
+                _ => ColorWhite
             };
 
             Delivery = Delivery switch

--- a/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
+++ b/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
@@ -242,6 +242,9 @@ namespace Emby.Plugins.Moonfin
         /// <summary>Body length cap, so a huge paste cannot break the app layout.</summary>
         public const int MaxBodyLength = 2000;
 
+        /// <summary>Title length cap, the same limit the config page puts on its field.</summary>
+        public const int MaxTitleLength = 120;
+
         public const string ColorGreen = "green";
         public const string ColorRed = "red";
         public const string ColorYellow = "yellow";
@@ -313,6 +316,9 @@ namespace Emby.Plugins.Moonfin
             if (Body.Length > MaxBodyLength)
                 Body = Body.Substring(0, MaxBodyLength);
 
+            if (Title.Length > MaxTitleLength)
+                Title = Title.Substring(0, MaxTitleLength);
+
             Color = Color switch
             {
                 ColorGreen => ColorGreen,
@@ -372,7 +378,8 @@ namespace Emby.Plugins.Moonfin
                 (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
                 return null;
 
-            return uri.ToString();
+            // AbsoluteUri keeps the escaping the admin typed, where ToString would decode it.
+            return uri.AbsoluteUri;
         }
 
         /// <summary>

--- a/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
+++ b/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
@@ -248,11 +248,8 @@ namespace Emby.Plugins.Moonfin
         public const string ColorBlue = "blue";
         public const string ColorWhite = "white";
 
-        /// <summary>Shows in the list only.</summary>
+        /// <summary>Only marks the menu button as unread.</summary>
         public const string DeliveryInbox = "inbox";
-
-        /// <summary>Shows a small toast when it arrives.</summary>
-        public const string DeliveryToast = "toast";
 
         /// <summary>Opens the message window once, until the user reads it.</summary>
         public const string DeliveryPopup = "popup";
@@ -266,7 +263,6 @@ namespace Emby.Plugins.Moonfin
         public string Body { get; set; } = string.Empty;
         public string Color { get; set; } = ColorWhite;
         public string Delivery { get; set; } = DeliveryInbox;
-        public bool Pinned { get; set; }
         public string? ActionLabel { get; set; }
         public string? ActionUrl { get; set; }
 
@@ -326,12 +322,7 @@ namespace Emby.Plugins.Moonfin
                 _ => ColorWhite
             };
 
-            Delivery = Delivery switch
-            {
-                DeliveryToast => DeliveryToast,
-                DeliveryPopup => DeliveryPopup,
-                _ => DeliveryInbox
-            };
+            Delivery = Delivery == DeliveryPopup ? DeliveryPopup : DeliveryInbox;
 
             Audience = Audience switch
             {
@@ -397,8 +388,7 @@ namespace Emby.Plugins.Moonfin
                 return;
 
             var extra = messages
-                .OrderBy(m => m.Pinned)
-                .ThenBy(m => m.CreatedUtc)
+                .OrderBy(m => m.CreatedUtc)
                 .Take(messages.Count - MaxStored)
                 .ToList();
 

--- a/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
+++ b/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
@@ -130,6 +130,12 @@ namespace Emby.Plugins.Moonfin
         /// <summary>Metadata index for uploaded custom themes stored in the plugin data folder.</summary>
         public List<UploadedThemeEntry> UploadedThemes { get; set; } = new List<UploadedThemeEntry>();
 
+        /// <summary>
+        /// Admin messages shown to users in the app. They are only a few KB of text, so they
+        /// live in the config instead of the data folder.
+        /// </summary>
+        public List<ServerMessage> Messages { get; set; } = new List<ServerMessage>();
+
         // Retro games (EmulatorJS) configuration.
         public bool GamesEnabled { get; set; } = false;
         public List<string> GameLibraryIds { get; set; } = new List<string>();
@@ -223,5 +229,177 @@ namespace Emby.Plugins.Moonfin
         public DateTimeOffset UploadedAtUtc { get; set; }
         public string? UploadedByUserId { get; set; }
         public string ChecksumSha256 { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// One message the admin wrote for users to read in the app.
+    /// </summary>
+    public class ServerMessage
+    {
+        /// <summary>Highest number of messages kept. Older ones are dropped on save.</summary>
+        public const int MaxStored = 50;
+
+        /// <summary>Body length cap, so a huge paste cannot break the app layout.</summary>
+        public const int MaxBodyLength = 2000;
+
+        public const string SeverityInfo = "info";
+        public const string SeverityWarning = "warning";
+        public const string SeverityCritical = "critical";
+
+        /// <summary>Shows in the list only.</summary>
+        public const string DeliveryInbox = "inbox";
+
+        /// <summary>Shows a small toast when it arrives.</summary>
+        public const string DeliveryToast = "toast";
+
+        /// <summary>Opens the message window once, until the user reads it.</summary>
+        public const string DeliveryPopup = "popup";
+
+        public const string AudienceAll = "all";
+        public const string AudienceUsers = "users";
+        public const string AudienceAdmins = "admins";
+
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public string Severity { get; set; } = SeverityInfo;
+        public string Delivery { get; set; } = DeliveryInbox;
+        public bool Pinned { get; set; }
+        public string? ActionLabel { get; set; }
+        public string? ActionUrl { get; set; }
+
+        /// <summary>When the message starts showing. Null means right away.</summary>
+        public DateTime? StartUtc { get; set; }
+
+        /// <summary>When the message stops showing. Null means never.</summary>
+        public DateTime? EndUtc { get; set; }
+
+        public string Audience { get; set; } = AudienceAll;
+
+        /// <summary>User IDs to show this to. Only used when Audience is "users".</summary>
+        public List<string> TargetUserIds { get; set; } = new List<string>();
+
+        public DateTime CreatedUtc { get; set; }
+        public string? CreatedByUserId { get; set; }
+
+        /// <summary>
+        /// True when this message should show right now, for this user.
+        /// </summary>
+        public bool IsVisibleTo(Guid userId, bool isAdmin, DateTime nowUtc)
+        {
+            if (StartUtc.HasValue && nowUtc < StartUtc.Value)
+                return false;
+
+            if (EndUtc.HasValue && nowUtc >= EndUtc.Value)
+                return false;
+
+            return Audience switch
+            {
+                AudienceAdmins => isAdmin,
+                AudienceUsers => TargetUserIds.Any(id =>
+                    Guid.TryParse(id, out var target) && target == userId),
+                _ => true
+            };
+        }
+
+        /// <summary>
+        /// Cleans admin input before it is saved. Bad values fall back to the default instead
+        /// of being rejected, except the action URL which is dropped when it is not http or
+        /// https.
+        /// </summary>
+        public void Sanitize()
+        {
+            Title = (Title ?? string.Empty).Trim();
+            Body = (Body ?? string.Empty).Trim();
+
+            if (Body.Length > MaxBodyLength)
+                Body = Body.Substring(0, MaxBodyLength);
+
+            Severity = Severity switch
+            {
+                SeverityWarning => SeverityWarning,
+                SeverityCritical => SeverityCritical,
+                _ => SeverityInfo
+            };
+
+            Delivery = Delivery switch
+            {
+                DeliveryToast => DeliveryToast,
+                DeliveryPopup => DeliveryPopup,
+                _ => DeliveryInbox
+            };
+
+            Audience = Audience switch
+            {
+                AudienceUsers => AudienceUsers,
+                AudienceAdmins => AudienceAdmins,
+                _ => AudienceAll
+            };
+
+            if (Audience != AudienceUsers)
+            {
+                TargetUserIds = new List<string>();
+            }
+            else
+            {
+                TargetUserIds = TargetUserIds
+                    .Where(id => Guid.TryParse(id, out _))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+
+            ActionLabel = string.IsNullOrWhiteSpace(ActionLabel) ? null : ActionLabel.Trim();
+            ActionUrl = SanitizeActionUrl(ActionUrl);
+
+            // A link with no label is useless to the user, and a label with no link does nothing.
+            if (ActionUrl == null)
+                ActionLabel = null;
+            else if (ActionLabel == null)
+                ActionUrl = null;
+
+            // An end date before the start date would hide the message forever.
+            if (StartUtc.HasValue && EndUtc.HasValue && EndUtc.Value <= StartUtc.Value)
+                EndUtc = null;
+        }
+
+        /// <summary>
+        /// Keeps only real http and https links. Anything else is dropped, since this URL gets
+        /// opened on the user's device.
+        /// </summary>
+        private static string? SanitizeActionUrl(string? rawUrl)
+        {
+            if (string.IsNullOrWhiteSpace(rawUrl))
+                return null;
+
+            var value = rawUrl.Trim().Trim('"', '\'').Trim();
+
+            if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                return null;
+
+            return uri.ToString();
+        }
+
+        /// <summary>
+        /// Drops expired messages, then the oldest ones if the list is still too long. Keeps
+        /// the config file from growing forever without needing a scheduled task.
+        /// </summary>
+        public static void Prune(List<ServerMessage> messages)
+        {
+            var now = DateTime.UtcNow;
+            messages.RemoveAll(m => m.EndUtc.HasValue && m.EndUtc.Value < now);
+
+            if (messages.Count <= MaxStored)
+                return;
+
+            var extra = messages
+                .OrderBy(m => m.Pinned)
+                .ThenBy(m => m.CreatedUtc)
+                .Take(messages.Count - MaxStored)
+                .ToList();
+
+            foreach (var message in extra)
+                messages.Remove(message);
+        }
     }
 }

--- a/Jellyfin/backend/Api/ControllerExtensions.cs
+++ b/Jellyfin/backend/Api/ControllerExtensions.cs
@@ -13,6 +13,13 @@ public static class ControllerExtensions
         return Guid.TryParse(userIdClaim, out var userId) ? userId : null;
     }
 
+    /// <summary>
+    /// True when the caller is a server admin. This is the same role the "RequiresElevation"
+    /// policy checks, so it matches what Jellyfin itself allows.
+    /// </summary>
+    public static bool IsAdminFromClaims(this ControllerBase controller) =>
+        controller.User.IsInRole("Administrator");
+
     public static string? GetDeviceIdFromClaims(this ControllerBase controller)
     {
         var deviceId = controller.User.FindFirst("Jellyfin-DeviceId")?.Value;

--- a/Jellyfin/backend/Api/MoonfinController.cs
+++ b/Jellyfin/backend/Api/MoonfinController.cs
@@ -83,6 +83,7 @@ public class MoonfinController : ControllerBase
                 : null,
             MdblistAvailable = !string.IsNullOrWhiteSpace(config?.MdblistApiKey),
             TmdbAvailable = !string.IsNullOrWhiteSpace(config?.TmdbApiKey),
+            MessagesSupported = true,
             DefaultSettings = config?.DefaultUserSettings
         });
     }
@@ -506,13 +507,30 @@ public class MoonfinController : ControllerBase
 
         var deliveries = _settingsService.BroadcastMessage(message);
 
+        // Also save it, so users who were not connected still find it in the app. Older
+        // clients keep reading the "adminMessage" event above and ignore this.
+        var stored = new ServerMessage
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Body = message,
+            Severity = ServerMessage.SeverityInfo,
+            Delivery = ServerMessage.DeliveryPopup,
+            Audience = ServerMessage.AudienceAll,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedByUserId = this.GetUserIdFromClaims()?.ToString("N")
+        };
+
+        config.Messages.Add(stored);
+        ServerMessage.Prune(config.Messages);
+        MoonfinPlugin.Instance?.SaveConfiguration();
+        _settingsService.BroadcastSystemEvent("messagesChanged");
+
         // SSE only reaches clients that are open right now, so push covers
-        // backgrounded and killed apps. The route is left blank because the
-        // client ignores blank routes and just opens the app on a tap.
+        // backgrounded and killed apps. The route opens the messages window on tap.
         var pushTargets = 0;
         foreach (var userId in _notificationStore.GetUsersWithDevices())
         {
-            _pushDelivery.QueueToUser(userId, "Message from your server", message, route: "");
+            _pushDelivery.QueueToUser(userId, "Message from your server", message, route: "messages");
             pushTargets++;
         }
 
@@ -1524,6 +1542,13 @@ public class MoonfinPingResponse
 
     [JsonPropertyName("tmdbAvailable")]
     public bool? TmdbAvailable { get; set; }
+
+    /// <summary>
+    /// True when this plugin has the admin messages endpoints. Older plugins leave it out, so
+    /// the app reads a missing value as false and hides the button.
+    /// </summary>
+    [JsonPropertyName("messagesSupported")]
+    public bool? MessagesSupported { get; set; }
 
     [JsonPropertyName("defaultSettings")]
     public MoonfinSettingsProfile? DefaultSettings { get; set; }

--- a/Jellyfin/backend/Api/MoonfinController.cs
+++ b/Jellyfin/backend/Api/MoonfinController.cs
@@ -513,7 +513,7 @@ public class MoonfinController : ControllerBase
         {
             Id = Guid.NewGuid().ToString("N"),
             Body = message,
-            Severity = ServerMessage.SeverityInfo,
+            Color = ServerMessage.ColorWhite,
             Delivery = ServerMessage.DeliveryPopup,
             Audience = ServerMessage.AudienceAll,
             CreatedUtc = DateTime.UtcNow,

--- a/Jellyfin/backend/Api/MoonfinMessagesController.cs
+++ b/Jellyfin/backend/Api/MoonfinMessagesController.cs
@@ -1,0 +1,202 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moonfin.Server.Services;
+
+namespace Moonfin.Server.Api;
+
+/// <summary>
+/// API controller for admin messages shown to users in the Moonfin app.
+/// </summary>
+[ApiController]
+[Route("Moonfin")]
+[Produces(MediaTypeNames.Application.Json)]
+public class MoonfinMessagesController : ControllerBase
+{
+    private readonly MoonfinSettingsService _settingsService;
+    private readonly NotificationStore _notificationStore;
+    private readonly PushDeliveryService _pushDelivery;
+
+    public MoonfinMessagesController(
+        MoonfinSettingsService settingsService,
+        NotificationStore notificationStore,
+        PushDeliveryService pushDelivery)
+    {
+        _settingsService = settingsService;
+        _notificationStore = notificationStore;
+        _pushDelivery = pushDelivery;
+    }
+
+    /// <summary>
+    /// Returns the messages the calling user should see right now.
+    /// </summary>
+    [HttpGet("Messages")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public ActionResult GetMessages()
+    {
+        var config = MoonfinPlugin.Instance?.Configuration;
+        if (config?.EnableSettingsSync != true)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Settings sync is disabled" });
+        }
+
+        var userId = this.GetUserIdFromClaims();
+        if (userId == null)
+        {
+            return Unauthorized(new { error = "A valid user token is required" });
+        }
+
+        // Filtering happens here, not on the client. Sending everything and hiding it in the
+        // app would let any user read messages meant for someone else.
+        var isAdmin = this.IsAdminFromClaims();
+        var now = DateTime.UtcNow;
+        var items = config.Messages
+            .Where(m => m.IsVisibleTo(userId.Value, isAdmin, now))
+            .OrderByDescending(m => m.Pinned)
+            .ThenByDescending(m => m.CreatedUtc)
+            .ToList();
+
+        return Ok(new { items });
+    }
+
+    /// <summary>
+    /// Returns every message, including scheduled and expired ones, for the admin panel.
+    /// </summary>
+    [HttpGet("Admin/Messages")]
+    [Authorize(Policy = "RequiresElevation")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult GetAdminMessages()
+    {
+        var messages = MoonfinPlugin.Instance?.Configuration.Messages ?? new List<ServerMessage>();
+
+        return Ok(new
+        {
+            items = messages
+                .OrderByDescending(m => m.Pinned)
+                .ThenByDescending(m => m.CreatedUtc)
+                .ToList()
+        });
+    }
+
+    /// <summary>
+    /// Creates a message, or replaces one when the ID already exists.
+    /// </summary>
+    [HttpPost("Admin/Messages")]
+    [Authorize(Policy = "RequiresElevation")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult SaveMessage([FromBody] ServerMessage message)
+    {
+        var plugin = MoonfinPlugin.Instance;
+        if (plugin == null)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Plugin is not ready" });
+        }
+
+        if (message == null)
+        {
+            return BadRequest(new { error = "A message body is required" });
+        }
+
+        message.Sanitize();
+
+        if (message.Title.Length == 0 && message.Body.Length == 0)
+        {
+            return BadRequest(new { error = "A title or a body is required" });
+        }
+
+        var messages = plugin.Configuration.Messages;
+        var existing = messages.FirstOrDefault(m =>
+            string.Equals(m.Id, message.Id, StringComparison.OrdinalIgnoreCase));
+
+        if (existing != null)
+        {
+            message.CreatedUtc = existing.CreatedUtc;
+            message.CreatedByUserId = existing.CreatedByUserId;
+            messages.Remove(existing);
+        }
+        else
+        {
+            message.Id = Guid.NewGuid().ToString("N");
+            message.CreatedUtc = DateTime.UtcNow;
+            message.CreatedByUserId = this.GetUserIdFromClaims()?.ToString("N");
+        }
+
+        messages.Add(message);
+        ServerMessage.Prune(messages);
+        plugin.SaveConfiguration();
+
+        _settingsService.BroadcastSystemEvent("messagesChanged");
+
+        // Only push for messages meant to interrupt. An inbox message can wait until the user
+        // opens the app.
+        if (existing == null && message.Delivery != ServerMessage.DeliveryInbox)
+        {
+            SendPush(message);
+        }
+
+        return Ok(new { success = true, item = message });
+    }
+
+    /// <summary>
+    /// Deletes one message by ID.
+    /// </summary>
+    [HttpDelete("Admin/Messages/{messageId}")]
+    [Authorize(Policy = "RequiresElevation")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult DeleteMessage([FromRoute] string messageId)
+    {
+        var plugin = MoonfinPlugin.Instance;
+        if (plugin == null)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Plugin is not ready" });
+        }
+
+        var removed = plugin.Configuration.Messages
+            .RemoveAll(m => string.Equals(m.Id, messageId, StringComparison.OrdinalIgnoreCase));
+
+        if (removed == 0)
+        {
+            return NotFound(new { error = "Message not found" });
+        }
+
+        plugin.SaveConfiguration();
+        _settingsService.BroadcastSystemEvent("messagesChanged");
+
+        return Ok(new { success = true });
+    }
+
+    /// <summary>
+    /// Queues a push so the message also reaches users who do not have the app open.
+    /// The route tells the app to open the messages window on tap.
+    /// </summary>
+    private void SendPush(ServerMessage message)
+    {
+        // Admin-only messages get no push: we cannot tell who is an admin without the user
+        // manager, and admins still see them next time they open the app.
+        if (message.Audience == ServerMessage.AudienceAdmins)
+        {
+            return;
+        }
+
+        var title = message.Title.Length > 0 ? message.Title : "Message from your server";
+        var body = message.Body;
+
+        foreach (var userId in _notificationStore.GetUsersWithDevices())
+        {
+            if (message.Audience == ServerMessage.AudienceUsers &&
+                !message.TargetUserIds.Any(id =>
+                    Guid.TryParse(id, out var target) && target == userId))
+            {
+                continue;
+            }
+
+            _pushDelivery.QueueToUser(userId, title, body, route: "messages");
+        }
+    }
+}

--- a/Jellyfin/backend/Api/MoonfinMessagesController.cs
+++ b/Jellyfin/backend/Api/MoonfinMessagesController.cs
@@ -56,8 +56,6 @@ public class MoonfinMessagesController : ControllerBase
         var now = DateTime.UtcNow;
         var items = config.Messages
             .Where(m => m.IsVisibleTo(userId.Value, isAdmin, now))
-            .OrderByDescending(m => m.Pinned)
-            .ThenByDescending(m => m.CreatedUtc)
             .ToList();
 
         return Ok(new { items });
@@ -76,8 +74,6 @@ public class MoonfinMessagesController : ControllerBase
         return Ok(new
         {
             items = messages
-                .OrderByDescending(m => m.Pinned)
-                .ThenByDescending(m => m.CreatedUtc)
                 .ToList()
         });
     }
@@ -117,16 +113,18 @@ public class MoonfinMessagesController : ControllerBase
         {
             message.CreatedUtc = existing.CreatedUtc;
             message.CreatedByUserId = existing.CreatedByUserId;
-            messages.Remove(existing);
+            // Replaced in place, so editing a message does not move it in the list.
+            messages[messages.IndexOf(existing)] = message;
         }
         else
         {
             message.Id = Guid.NewGuid().ToString("N");
             message.CreatedUtc = DateTime.UtcNow;
             message.CreatedByUserId = this.GetUserIdFromClaims()?.ToString("N");
+            // Newest first by default. The admin can move it with the arrows.
+            messages.Insert(0, message);
         }
 
-        messages.Add(message);
         ServerMessage.Prune(messages);
         plugin.SaveConfiguration();
 
@@ -140,6 +138,52 @@ public class MoonfinMessagesController : ControllerBase
         }
 
         return Ok(new { success = true, item = message });
+    }
+
+    /// <summary>
+    /// Reorders the stored messages to match the IDs given. The app shows them in this
+    /// order, so this is what the up and down arrows in the config page drive.
+    /// </summary>
+    [HttpPost("Admin/Messages/Order")]
+    [Authorize(Policy = "RequiresElevation")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult ReorderMessages([FromBody] MoonfinMessageOrderRequest request)
+    {
+        var plugin = MoonfinPlugin.Instance;
+        if (plugin == null)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Plugin is not ready" });
+        }
+
+        var ids = request?.Ids;
+        if (ids == null || ids.Count == 0)
+        {
+            return BadRequest(new { error = "ids is required" });
+        }
+
+        var messages = plugin.Configuration.Messages;
+        var reordered = new List<ServerMessage>(messages.Count);
+
+        foreach (var id in ids)
+        {
+            var match = messages.FirstOrDefault(m =>
+                string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase));
+            if (match != null && !reordered.Contains(match))
+            {
+                reordered.Add(match);
+            }
+        }
+
+        // Anything the caller left out keeps its place at the end, so a stale list from
+        // the config page cannot delete messages.
+        reordered.AddRange(messages.Where(m => !reordered.Contains(m)));
+
+        plugin.Configuration.Messages = reordered;
+        plugin.SaveConfiguration();
+        _settingsService.BroadcastSystemEvent("messagesChanged");
+
+        return Ok(new { success = true });
     }
 
     /// <summary>
@@ -199,4 +243,13 @@ public class MoonfinMessagesController : ControllerBase
             _pushDelivery.QueueToUser(userId, title, body, route: "messages");
         }
     }
+}
+
+/// <summary>
+/// Body for the message reorder endpoint.
+/// </summary>
+public class MoonfinMessageOrderRequest
+{
+    /// <summary>Message IDs in the order they should be shown.</summary>
+    public List<string> Ids { get; set; } = new();
 }

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -848,6 +848,9 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("crashReportsEnabled")]
     public bool? CrashReportsEnabled { get; set; }
 
+    [JsonPropertyName("showServerMessagesButton")]
+    public bool? ShowServerMessagesButton { get; set; }
+
     [JsonPropertyName("diagnosticLoggingEnabled")]
     public bool? DiagnosticLoggingEnabled { get; set; }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1716,7 +1716,7 @@
                         </div>
 
                         <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="MessageBody">Message</label>
+                            <label class="inputLabel inputLabelUnfocused" for="MessageBody" style="display:block;">Message</label>
                             <textarea id="MessageBody" is="emby-textarea" rows="12" maxlength="2000" style="width:100%;box-sizing:border-box;font-family:inherit;" placeholder="Write your message here."></textarea>
                             <div class="fieldDescription">
                                 Formatting uses Markdown. Only CommonMark is supported:

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1752,9 +1752,9 @@
                                 <option value="popup">Open the message in the app</option>
                             </select>
                             <div class="fieldDescription">
-                                Notify adds the message to the unread count on the menu button. Open shows it
-                                the next time the user opens the app, and also sends a phone notification to
-                                users who turned them on.
+                                Notify adds the message to the unread count on the menu button. Open makes the
+                                message window come up on its own, once. Open also sends a phone notification, if
+                                this server has push set up.
                             </div>
                         </div>
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1738,14 +1738,15 @@
                         </div>
 
                         <div class="selectContainer">
-                            <label class="selectLabel" for="MessageDelivery">How loud</label>
+                            <label class="selectLabel" for="MessageDelivery">How to show it</label>
                             <select is="emby-select" id="MessageDelivery">
-                                <option value="inbox">Quiet: only a dot on the button</option>
-                                <option value="toast">Small popup in the corner</option>
-                                <option value="popup">Open the message window once</option>
+                                <option value="inbox">Notify on the menu button</option>
+                                <option value="popup">Open the message in the app</option>
                             </select>
                             <div class="fieldDescription">
-                                The last two also send a phone notification to users who turned them on.
+                                Notify adds the message to the unread count on the menu button. Open shows it
+                                the next time the user opens the app, and also sends a phone notification to
+                                users who turned them on.
                             </div>
                         </div>
 
@@ -1792,12 +1793,6 @@
                             </div>
                         </div>
 
-                        <div class="checkboxContainer">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" id="MessagePinned" is="emby-checkbox" />
-                                <span>Keep this message at the top of the list</span>
-                            </label>
-                        </div>
 
                         <div style="display:flex; flex-wrap:wrap; align-items:center; gap:0.6em; margin-top:0.8em;">
                             <button is="emby-button" type="button" id="MessageSaveBtn" class="raised">
@@ -1813,7 +1808,7 @@
                     <div class="verticalSection">
                         <h3 class="sectionTitle">Saved Messages</h3>
                         <div class="fieldDescription" style="margin-bottom: 0.8em;">
-                            Up to 50 messages are kept. Past that, the oldest unpinned ones are dropped.
+                            Shown in this order in the app. Up to 50 are kept, then the oldest are dropped.
                         </div>
                         <div id="MessagesList" style="max-height:340px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;"></div>
                     </div>
@@ -3716,9 +3711,8 @@
             };
 
             var moonfinDeliveryLabels = {
-                inbox: 'Quiet',
-                toast: 'Corner popup',
-                popup: 'Opens the window'
+                inbox: 'Notify',
+                popup: 'Opens in app'
             };
 
             function setMessageResult(text, color) {
@@ -3811,7 +3805,6 @@
                 document.querySelector('#MessageEnd').value = '';
                 document.querySelector('#MessageActionLabel').value = '';
                 document.querySelector('#MessageActionUrl').value = '';
-                document.querySelector('#MessagePinned').checked = false;
 
                 var targets = document.querySelector('#MessageTargets');
                 if (targets) {
@@ -3846,7 +3839,6 @@
                 document.querySelector('#MessageEnd').value = messageDateToInput(item.endUtc || item.EndUtc);
                 document.querySelector('#MessageActionLabel').value = item.actionLabel || item.ActionLabel || '';
                 document.querySelector('#MessageActionUrl').value = item.actionUrl || item.ActionUrl || '';
-                document.querySelector('#MessagePinned').checked = !!(item.pinned || item.Pinned);
 
                 var selected = item.targetUserIds || item.TargetUserIds || [];
                 var targets = document.querySelector('#MessageTargets');
@@ -3891,14 +3883,13 @@
                 var now = new Date();
                 var html = '';
 
-                items.forEach(function(item) {
+                items.forEach(function(item, index) {
                     var id = item.id || item.Id || '';
                     var title = item.title || item.Title || '';
                     var body = item.body || item.Body || '';
                     var pick = item.color || item.Color || 'white';
                     var delivery = item.delivery || item.Delivery || 'inbox';
                     var audience = item.audience || item.Audience || 'all';
-                    var pinned = !!(item.pinned || item.Pinned);
                     var start = item.startUtc || item.StartUtc;
                     var end = item.endUtc || item.EndUtc;
                     var targets = item.targetUserIds || item.TargetUserIds || [];
@@ -3923,12 +3914,15 @@
                         + '<div style="flex:1;min-width:0;">'
                         + '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">'
                         + '<strong style="font-size:0.95em;color:' + color + ';">' + esc(title || '(no title)') + '</strong>'
-                        + (pinned ? '<span style="font-size:0.72em;color:rgba(255,255,255,0.6);border:1px solid rgba(255,255,255,0.2);border-radius:3px;padding:0 4px;">PINNED</span>' : '')
                         + '</div>'
                         + '<div style="font-size:0.82em;color:rgba(255,255,255,0.7);margin-top:4px;white-space:pre-wrap;">' + esc(body.length > 160 ? body.slice(0, 160) + '…' : body) + '</div>'
                         + '<div style="font-size:0.78em;color:rgba(255,255,255,0.52);margin-top:4px;">'
                         + esc(state) + ' • ' + esc(who) + ' • ' + esc(moonfinDeliveryLabels[delivery] || delivery)
                         + '</div>'
+                        + '</div>'
+                        + '<div style="display:flex;flex-direction:column;gap:2px;">'
+                        + '<button type="button" class="moonfinMessageUpBtn" data-message-id="' + esc(id) + '" title="Move up"' + (index === 0 ? ' disabled' : '') + ' style="background:none;border:1px solid rgba(255,255,255,0.3);color:rgba(255,255,255,0.8);border-radius:4px;padding:0 6px;cursor:pointer;line-height:1.3;">&#9650;</button>'
+                        + '<button type="button" class="moonfinMessageDownBtn" data-message-id="' + esc(id) + '" title="Move down"' + (index === items.length - 1 ? ' disabled' : '') + ' style="background:none;border:1px solid rgba(255,255,255,0.3);color:rgba(255,255,255,0.8);border-radius:4px;padding:0 6px;cursor:pointer;line-height:1.3;">&#9660;</button>'
                         + '</div>'
                         + '<button type="button" class="moonfinMessageEditBtn" data-message-id="' + esc(id) + '" title="Edit message" style="background:none;border:1px solid rgba(255,255,255,0.3);color:rgba(255,255,255,0.8);border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">Edit</button>'
                         + '<button type="button" class="moonfinMessageDeleteBtn" data-message-id="' + esc(id) + '" title="Delete message" style="background:none;border:1px solid rgba(239,68,68,0.6);color:#ef4444;border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">&#x2715;</button>'
@@ -3960,6 +3954,43 @@
                     .catch(function(error) {
                         container.innerHTML = '<div style="padding:8px;color:#d9534f;font-size:0.9em;">'
                             + esc((error && error.message) ? error.message : 'Failed to load messages.') + '</div>';
+                    });
+            }
+
+            // Moves one message up or down and saves the whole order, so the app shows
+            // them in the same sequence as this list.
+            function moveMessage(messageId, delta) {
+                var items = (window.moonfinMessagesCache || []).slice();
+                var from = -1;
+                for (var i = 0; i < items.length; i++) {
+                    if ((items[i].id || items[i].Id) === messageId) { from = i; break; }
+                }
+
+                var to = from + delta;
+                if (from < 0 || to < 0 || to >= items.length) return;
+
+                var moved = items.splice(from, 1)[0];
+                items.splice(to, 0, moved);
+
+                // Redrawn straight away so the arrows feel instant, then saved.
+                window.moonfinMessagesCache = items;
+                renderMessagesList(items);
+
+                var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+                fetch(serverUrl + '/Moonfin/Admin/Messages/Order', {
+                    method: 'POST',
+                    headers: getMoonfinAuthHeaders(),
+                    body: JSON.stringify({
+                        ids: items.map(function (item) { return item.id || item.Id; })
+                    })
+                })
+                    .then(parseJsonResponse)
+                    .catch(function (error) {
+                        setMessageResult(
+                            (error && error.message) ? error.message : 'Could not save the new order.',
+                            '#d9534f'
+                        );
+                        loadMessagesList();
                     });
             }
 
@@ -3997,7 +4028,6 @@
                     delivery: document.querySelector('#MessageDelivery').value,
                     audience: audience,
                     targetUserIds: targetUserIds,
-                    pinned: document.querySelector('#MessagePinned').checked,
                     actionLabel: (document.querySelector('#MessageActionLabel').value || '').trim(),
                     actionUrl: (document.querySelector('#MessageActionUrl').value || '').trim(),
                     startUtc: messageDateFromInput(document.querySelector('#MessageStart').value),
@@ -4246,6 +4276,18 @@
                 if (messagesListContainer && !messagesListContainer.dataset.bound) {
                     messagesListContainer.dataset.bound = 'true';
                     messagesListContainer.addEventListener('click', function(event) {
+                        var upButton = event.target.closest('.moonfinMessageUpBtn');
+                        if (upButton) {
+                            moveMessage(upButton.getAttribute('data-message-id') || '', -1);
+                            return;
+                        }
+
+                        var downButton = event.target.closest('.moonfinMessageDownBtn');
+                        if (downButton) {
+                            moveMessage(downButton.getAttribute('data-message-id') || '', 1);
+                            return;
+                        }
+
                         var editButton = event.target.closest('.moonfinMessageEditBtn');
                         if (editButton) {
                             var editId = editButton.getAttribute('data-message-id') || '';

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -374,6 +374,10 @@
                             <span class="material-icons moonfinNavIcon" aria-hidden="true">palette</span>
                             <span class="moonfinNavText"><span class="moonfinNavLabel">Themes</span><span class="moonfinNavSub">Upload &amp; catalog</span></span>
                         </button>
+                        <button type="button" class="moonfinNavItem" data-tab="messages">
+                            <span class="material-icons moonfinNavIcon" aria-hidden="true">notifications</span>
+                            <span class="moonfinNavText"><span class="moonfinNavLabel">Messages</span><span class="moonfinNavSub">News for your users</span></span>
+                        </button>
                         <button type="button" class="moonfinNavItem" data-tab="actions">
                             <span class="material-icons moonfinNavIcon" aria-hidden="true">campaign</span>
                             <span class="moonfinNavText"><span class="moonfinNavLabel">Actions</span><span class="moonfinNavSub">Apply Defaults &amp; Broadcast</span></span>
@@ -1697,6 +1701,117 @@
                     </div>
 
                     </section>
+                    <section class="moonfinTabPanel" data-tab="messages">
+                    <div class="verticalSection">
+                        <h3 class="sectionTitle">Messages</h3>
+                        <div class="fieldDescription" style="margin-bottom: 0.8em;">
+                            Write news, updates or warnings for your users. They read them from the messages
+                            button in the app menu. Messages are saved, so users still see them if the app was
+                            closed when you posted.
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageTitle">Title</label>
+                            <input type="text" id="MessageTitle" is="emby-input" maxlength="120" placeholder="Server maintenance on Saturday" />
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageBody">Message</label>
+                            <textarea id="MessageBody" is="emby-textarea" rows="4" maxlength="2000" placeholder="Plain text only. Links and formatting are not shown."></textarea>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="MessageSeverity">Importance</label>
+                            <select is="emby-select" id="MessageSeverity">
+                                <option value="info">Info (green)</option>
+                                <option value="warning">Warning (yellow)</option>
+                                <option value="critical">Critical (red)</option>
+                            </select>
+                            <div class="fieldDescription">Sets the colour of the message and of the button in the app menu.</div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="MessageDelivery">How loud</label>
+                            <select is="emby-select" id="MessageDelivery">
+                                <option value="inbox">Quiet: only a dot on the button</option>
+                                <option value="toast">Small popup in the corner</option>
+                                <option value="popup">Open the message window once</option>
+                            </select>
+                            <div class="fieldDescription">
+                                The last two also send a phone notification to users who turned them on.
+                            </div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="MessageAudience">Who sees it</label>
+                            <select is="emby-select" id="MessageAudience">
+                                <option value="all">Everyone</option>
+                                <option value="users">Only the users I pick</option>
+                                <option value="admins">Only admins</option>
+                            </select>
+                        </div>
+
+                        <div class="selectContainer" id="MessageTargetsRow" style="display:none;">
+                            <label class="selectLabel" for="MessageTargets">Users</label>
+                            <select is="emby-select" id="MessageTargets" multiple size="6"></select>
+                            <div class="fieldDescription">Hold Ctrl or Cmd to pick more than one.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageStart">Show from (optional)</label>
+                            <input type="datetime-local" id="MessageStart" is="emby-input" />
+                            <div class="fieldDescription">Leave empty to show it right away.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageEnd">Hide after (optional)</label>
+                            <input type="datetime-local" id="MessageEnd" is="emby-input" />
+                            <div class="fieldDescription">
+                                Leave empty to keep it forever. Messages past this date are deleted on the next save.
+                            </div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageActionLabel">Button text (optional)</label>
+                            <input type="text" id="MessageActionLabel" is="emby-input" maxlength="40" placeholder="Read more" />
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MessageActionUrl">Button link (optional)</label>
+                            <input type="text" id="MessageActionUrl" is="emby-input" placeholder="https://example.com/news" />
+                            <div class="fieldDescription">
+                                Must start with http:// or https://. On TV the app shows it as a QR code.
+                                A link needs a button text, and a button text needs a link.
+                            </div>
+                        </div>
+
+                        <div class="checkboxContainer">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" id="MessagePinned" is="emby-checkbox" />
+                                <span>Keep this message at the top of the list</span>
+                            </label>
+                        </div>
+
+                        <div style="display:flex; flex-wrap:wrap; align-items:center; gap:0.6em; margin-top:0.8em;">
+                            <button is="emby-button" type="button" id="MessageSaveBtn" class="raised">
+                                <span>Save Message</span>
+                            </button>
+                            <button is="emby-button" type="button" id="MessageResetBtn" class="raised" style="display:none;">
+                                <span>Cancel Edit</span>
+                            </button>
+                        </div>
+                        <div id="MessageSaveResult" class="fieldDescription" style="display:none; margin-top:0.8em;"></div>
+                    </div>
+
+                    <div class="verticalSection">
+                        <h3 class="sectionTitle">Saved Messages</h3>
+                        <div class="fieldDescription" style="margin-bottom: 0.8em;">
+                            Up to 50 messages are kept. Past that, the oldest unpinned ones are dropped.
+                        </div>
+                        <div id="MessagesList" style="max-height:340px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;"></div>
+                    </div>
+
+                    </section>
                     <section class="moonfinTabPanel" data-tab="actions">
                     <div class="verticalSection">
                         <h3 class="sectionTitle">Apply Defaults To Users</h3>
@@ -1744,8 +1859,9 @@
                     <div class="verticalSection">
                         <h3 class="sectionTitle">Broadcast Message</h3>
                         <div class="fieldDescription" style="margin-bottom: 0.8em;">
-                            Send a live message to all currently connected Moonfin clients.
-                            This message is not saved and only appears for users with an active connection.
+                            Send a message to all connected Moonfin clients right now. It is also saved to
+                            the Messages tab, so users who were offline still see it later.
+                            For anything you want to write properly, use the Messages tab instead.
                         </div>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="BroadcastMessageText">Message</label>
@@ -3582,6 +3698,374 @@
                     });
             }
 
+            var moonfinEditingMessageId = null;
+
+            var moonfinSeverityColors = {
+                info: '#52b54b',
+                warning: '#f0ad4e',
+                critical: '#d9534f'
+            };
+
+            var moonfinDeliveryLabels = {
+                inbox: 'Quiet',
+                toast: 'Corner popup',
+                popup: 'Opens the window'
+            };
+
+            function setMessageResult(text, color) {
+                var result = document.querySelector('#MessageSaveResult');
+                if (!result) {
+                    return;
+                }
+
+                if (!text) {
+                    result.style.display = 'none';
+                    result.textContent = '';
+                    return;
+                }
+
+                result.style.display = '';
+                result.style.color = color || 'rgba(255,255,255,0.75)';
+                result.textContent = text;
+            }
+
+            // The date inputs work in the admin's own time zone, but the server stores UTC.
+            function messageDateToInput(utcValue) {
+                if (!utcValue) {
+                    return '';
+                }
+
+                var date = new Date(utcValue);
+                if (isNaN(date.getTime())) {
+                    return '';
+                }
+
+                var pad = function(n) { return (n < 10 ? '0' : '') + n; };
+                return date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate())
+                    + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+            }
+
+            function messageDateFromInput(value) {
+                if (!value) {
+                    return null;
+                }
+
+                var date = new Date(value);
+                return isNaN(date.getTime()) ? null : date.toISOString();
+            }
+
+            function formatMessageDate(utcValue) {
+                if (!utcValue) {
+                    return '';
+                }
+
+                var date = new Date(utcValue);
+                return isNaN(date.getTime()) ? '' : date.toLocaleString();
+            }
+
+            function toggleMessageTargets() {
+                var audience = document.querySelector('#MessageAudience');
+                var row = document.querySelector('#MessageTargetsRow');
+                if (!audience || !row) {
+                    return;
+                }
+
+                row.style.display = audience.value === 'users' ? '' : 'none';
+            }
+
+            function loadMessageTargetUsers() {
+                var select = document.querySelector('#MessageTargets');
+                if (!select || !ApiClient.getUsers) {
+                    return Promise.resolve();
+                }
+
+                return ApiClient.getUsers().then(function(users) {
+                    select.innerHTML = '';
+                    (users || []).forEach(function(user) {
+                        var option = document.createElement('option');
+                        option.value = user.Id;
+                        option.textContent = user.Name;
+                        select.appendChild(option);
+                    });
+                });
+            }
+
+            function resetMessageForm() {
+                moonfinEditingMessageId = null;
+
+                document.querySelector('#MessageTitle').value = '';
+                document.querySelector('#MessageBody').value = '';
+                document.querySelector('#MessageSeverity').value = 'info';
+                document.querySelector('#MessageDelivery').value = 'inbox';
+                document.querySelector('#MessageAudience').value = 'all';
+                document.querySelector('#MessageStart').value = '';
+                document.querySelector('#MessageEnd').value = '';
+                document.querySelector('#MessageActionLabel').value = '';
+                document.querySelector('#MessageActionUrl').value = '';
+                document.querySelector('#MessagePinned').checked = false;
+
+                var targets = document.querySelector('#MessageTargets');
+                if (targets) {
+                    Array.prototype.forEach.call(targets.options, function(option) {
+                        option.selected = false;
+                    });
+                }
+
+                var saveBtn = document.querySelector('#MessageSaveBtn');
+                if (saveBtn) {
+                    saveBtn.querySelector('span').textContent = 'Save Message';
+                }
+
+                var resetBtn = document.querySelector('#MessageResetBtn');
+                if (resetBtn) {
+                    resetBtn.style.display = 'none';
+                }
+
+                toggleMessageTargets();
+                setMessageResult('', '');
+            }
+
+            function editMessage(item) {
+                moonfinEditingMessageId = item.id || item.Id || null;
+
+                document.querySelector('#MessageTitle').value = item.title || item.Title || '';
+                document.querySelector('#MessageBody').value = item.body || item.Body || '';
+                document.querySelector('#MessageSeverity').value = item.severity || item.Severity || 'info';
+                document.querySelector('#MessageDelivery').value = item.delivery || item.Delivery || 'inbox';
+                document.querySelector('#MessageAudience').value = item.audience || item.Audience || 'all';
+                document.querySelector('#MessageStart').value = messageDateToInput(item.startUtc || item.StartUtc);
+                document.querySelector('#MessageEnd').value = messageDateToInput(item.endUtc || item.EndUtc);
+                document.querySelector('#MessageActionLabel').value = item.actionLabel || item.ActionLabel || '';
+                document.querySelector('#MessageActionUrl').value = item.actionUrl || item.ActionUrl || '';
+                document.querySelector('#MessagePinned').checked = !!(item.pinned || item.Pinned);
+
+                var selected = item.targetUserIds || item.TargetUserIds || [];
+                var targets = document.querySelector('#MessageTargets');
+                if (targets) {
+                    Array.prototype.forEach.call(targets.options, function(option) {
+                        option.selected = selected.some(function(id) {
+                            return String(id).toLowerCase() === String(option.value).toLowerCase();
+                        });
+                    });
+                }
+
+                var saveBtn = document.querySelector('#MessageSaveBtn');
+                if (saveBtn) {
+                    saveBtn.querySelector('span').textContent = 'Update Message';
+                }
+
+                var resetBtn = document.querySelector('#MessageResetBtn');
+                if (resetBtn) {
+                    resetBtn.style.display = '';
+                }
+
+                toggleMessageTargets();
+                setMessageResult('', '');
+
+                var titleInput = document.querySelector('#MessageTitle');
+                if (titleInput) {
+                    titleInput.focus();
+                }
+            }
+
+            function renderMessagesList(items) {
+                var container = document.querySelector('#MessagesList');
+                if (!container) {
+                    return;
+                }
+
+                if (!items || items.length === 0) {
+                    container.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.55);font-size:0.9em;">No messages yet.</div>';
+                    return;
+                }
+
+                var now = new Date();
+                var html = '';
+
+                items.forEach(function(item) {
+                    var id = item.id || item.Id || '';
+                    var title = item.title || item.Title || '';
+                    var body = item.body || item.Body || '';
+                    var severity = item.severity || item.Severity || 'info';
+                    var delivery = item.delivery || item.Delivery || 'inbox';
+                    var audience = item.audience || item.Audience || 'all';
+                    var pinned = !!(item.pinned || item.Pinned);
+                    var start = item.startUtc || item.StartUtc;
+                    var end = item.endUtc || item.EndUtc;
+                    var targets = item.targetUserIds || item.TargetUserIds || [];
+                    var color = moonfinSeverityColors[severity] || moonfinSeverityColors.info;
+
+                    var state = 'Showing now';
+                    if (start && new Date(start) > now) {
+                        state = 'Starts ' + formatMessageDate(start);
+                    } else if (end && new Date(end) <= now) {
+                        state = 'Expired';
+                    } else if (end) {
+                        state = 'Until ' + formatMessageDate(end);
+                    }
+
+                    var who = audience === 'admins'
+                        ? 'Admins only'
+                        : audience === 'users'
+                            ? targets.length + (targets.length === 1 ? ' user' : ' users')
+                            : 'Everyone';
+
+                    html += '<div style="display:flex;align-items:flex-start;gap:10px;padding:8px;border:1px solid rgba(255,255,255,0.08);border-left:3px solid ' + color + ';border-radius:4px;margin-bottom:6px;background:rgba(255,255,255,0.02);">'
+                        + '<div style="flex:1;min-width:0;">'
+                        + '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">'
+                        + '<strong style="font-size:0.95em;color:' + color + ';">' + esc(title || '(no title)') + '</strong>'
+                        + (pinned ? '<span style="font-size:0.72em;color:rgba(255,255,255,0.6);border:1px solid rgba(255,255,255,0.2);border-radius:3px;padding:0 4px;">PINNED</span>' : '')
+                        + '</div>'
+                        + '<div style="font-size:0.82em;color:rgba(255,255,255,0.7);margin-top:4px;white-space:pre-wrap;">' + esc(body.length > 160 ? body.slice(0, 160) + '…' : body) + '</div>'
+                        + '<div style="font-size:0.78em;color:rgba(255,255,255,0.52);margin-top:4px;">'
+                        + esc(state) + ' • ' + esc(who) + ' • ' + esc(moonfinDeliveryLabels[delivery] || delivery)
+                        + '</div>'
+                        + '</div>'
+                        + '<button type="button" class="moonfinMessageEditBtn" data-message-id="' + esc(id) + '" title="Edit message" style="background:none;border:1px solid rgba(255,255,255,0.3);color:rgba(255,255,255,0.8);border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">Edit</button>'
+                        + '<button type="button" class="moonfinMessageDeleteBtn" data-message-id="' + esc(id) + '" title="Delete message" style="background:none;border:1px solid rgba(239,68,68,0.6);color:#ef4444;border-radius:4px;padding:2px 8px;cursor:pointer;line-height:1.1;">&#x2715;</button>'
+                        + '</div>';
+                });
+
+                container.innerHTML = html;
+            }
+
+            function loadMessagesList() {
+                var container = document.querySelector('#MessagesList');
+                if (!container) {
+                    return;
+                }
+
+                var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+                container.innerHTML = '<div style="padding:8px;color:rgba(255,255,255,0.55);font-size:0.9em;">Loading messages...</div>';
+
+                fetch(serverUrl + '/Moonfin/Admin/Messages', {
+                    method: 'GET',
+                    headers: getMoonfinAuthHeaders()
+                })
+                    .then(parseJsonResponse)
+                    .then(function(payload) {
+                        var items = payload.items || payload.Items || [];
+                        window.moonfinMessagesCache = items;
+                        renderMessagesList(items);
+                    })
+                    .catch(function(error) {
+                        container.innerHTML = '<div style="padding:8px;color:#d9534f;font-size:0.9em;">'
+                            + esc((error && error.message) ? error.message : 'Failed to load messages.') + '</div>';
+                    });
+            }
+
+            function saveMessage() {
+                var saveBtn = document.querySelector('#MessageSaveBtn');
+                var title = (document.querySelector('#MessageTitle').value || '').trim();
+                var body = (document.querySelector('#MessageBody').value || '').trim();
+
+                if (!title && !body) {
+                    setMessageResult('Enter a title or a message.', '#d9534f');
+                    return;
+                }
+
+                var audience = document.querySelector('#MessageAudience').value;
+                var targetSelect = document.querySelector('#MessageTargets');
+                var targetUserIds = [];
+                if (audience === 'users' && targetSelect) {
+                    targetUserIds = Array.prototype.filter.call(targetSelect.options, function(option) {
+                        return option.selected;
+                    }).map(function(option) {
+                        return option.value;
+                    });
+
+                    if (targetUserIds.length === 0) {
+                        setMessageResult('Pick at least one user, or change who sees it.', '#d9534f');
+                        return;
+                    }
+                }
+
+                var payload = {
+                    id: moonfinEditingMessageId || '',
+                    title: title,
+                    body: body,
+                    severity: document.querySelector('#MessageSeverity').value,
+                    delivery: document.querySelector('#MessageDelivery').value,
+                    audience: audience,
+                    targetUserIds: targetUserIds,
+                    pinned: document.querySelector('#MessagePinned').checked,
+                    actionLabel: (document.querySelector('#MessageActionLabel').value || '').trim(),
+                    actionUrl: (document.querySelector('#MessageActionUrl').value || '').trim(),
+                    startUtc: messageDateFromInput(document.querySelector('#MessageStart').value),
+                    endUtc: messageDateFromInput(document.querySelector('#MessageEnd').value)
+                };
+
+                var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+                var wasEditing = !!moonfinEditingMessageId;
+
+                saveBtn.disabled = true;
+                setMessageResult('', '');
+                Dashboard.showLoadingMsg();
+
+                fetch(serverUrl + '/Moonfin/Admin/Messages', {
+                    method: 'POST',
+                    headers: getMoonfinAuthHeaders(),
+                    body: JSON.stringify(payload)
+                })
+                    .then(parseJsonResponse)
+                    .then(function(response) {
+                        var saved = response.item || response.Item || {};
+                        var warnings = [];
+
+                        if (payload.actionUrl && !(saved.actionUrl || saved.ActionUrl)) {
+                            warnings.push('the link was dropped, it must start with http:// or https://');
+                        }
+                        if (payload.endUtc && !(saved.endUtc || saved.EndUtc)) {
+                            warnings.push('the end date was dropped, it was before the start date');
+                        }
+
+                        var message = wasEditing ? 'Message updated.' : 'Message saved.';
+                        if (warnings.length) {
+                            message += ' Note: ' + warnings.join(', ') + '.';
+                        }
+
+                        // resetMessageForm clears the result line, so set it afterwards.
+                        resetMessageForm();
+                        setMessageResult(message, warnings.length ? '#f0ad4e' : '#52b54b');
+                        loadMessagesList();
+                    })
+                    .catch(function(error) {
+                        setMessageResult((error && error.message) ? error.message : 'Save failed.', '#d9534f');
+                    })
+                    .finally(function() {
+                        saveBtn.disabled = false;
+                        Dashboard.hideLoadingMsg();
+                    });
+            }
+
+            function deleteMessage(messageId) {
+                if (!messageId) {
+                    return;
+                }
+
+                if (!window.confirm('Delete this message?')) {
+                    return;
+                }
+
+                var serverUrl = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+
+                fetch(serverUrl + '/Moonfin/Admin/Messages/' + encodeURIComponent(messageId), {
+                    method: 'DELETE',
+                    headers: getMoonfinAuthHeaders()
+                })
+                    .then(parseJsonResponse)
+                    .then(function() {
+                        if (moonfinEditingMessageId === messageId) {
+                            resetMessageForm();
+                        }
+                        setMessageResult('Message deleted.', '#52b54b');
+                        loadMessagesList();
+                    })
+                    .catch(function(error) {
+                        setMessageResult((error && error.message) ? error.message : 'Delete failed.', '#d9534f');
+                    });
+            }
+
             function ensureMoonfinAdminRuntimeStyles() {
                 var source = document.getElementById('MoonfinAdminRuntimeStyleSource');
                 if (!source || !source.textContent) {
@@ -3730,6 +4214,54 @@
                 clearSelectedThemeFile();
                 setThemeUploadResult('', '');
                 loadAdminThemesList();
+
+                var messageAudience = document.querySelector('#MessageAudience');
+                if (messageAudience && !messageAudience.dataset.bound) {
+                    messageAudience.dataset.bound = 'true';
+                    messageAudience.addEventListener('change', toggleMessageTargets);
+                }
+
+                var messageSaveBtn = document.querySelector('#MessageSaveBtn');
+                if (messageSaveBtn && !messageSaveBtn.dataset.bound) {
+                    messageSaveBtn.dataset.bound = 'true';
+                    messageSaveBtn.addEventListener('click', saveMessage);
+                }
+
+                var messageResetBtn = document.querySelector('#MessageResetBtn');
+                if (messageResetBtn && !messageResetBtn.dataset.bound) {
+                    messageResetBtn.dataset.bound = 'true';
+                    messageResetBtn.addEventListener('click', resetMessageForm);
+                }
+
+                var messagesListContainer = document.querySelector('#MessagesList');
+                if (messagesListContainer && !messagesListContainer.dataset.bound) {
+                    messagesListContainer.dataset.bound = 'true';
+                    messagesListContainer.addEventListener('click', function(event) {
+                        var editButton = event.target.closest('.moonfinMessageEditBtn');
+                        if (editButton) {
+                            var editId = editButton.getAttribute('data-message-id') || '';
+                            var cached = window.moonfinMessagesCache || [];
+                            var found = cached.filter(function(item) {
+                                return (item.id || item.Id) === editId;
+                            })[0];
+                            if (found) {
+                                editMessage(found);
+                            }
+                            return;
+                        }
+
+                        var deleteButton = event.target.closest('.moonfinMessageDeleteBtn');
+                        if (deleteButton) {
+                            deleteMessage(deleteButton.getAttribute('data-message-id') || '');
+                        }
+                    });
+                }
+
+                // The user list must be there before the form can preselect targets on edit.
+                loadMessageTargetUsers().then(function() {
+                    resetMessageForm();
+                    loadMessagesList();
+                });
 
                 Dashboard.showLoadingMsg();
                 ApiClient.getPluginConfiguration(MoonfinConfig.pluginUniqueId).then(function(config) {

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1020,6 +1020,14 @@
                                     <option value="false">No</option>
                                 </select>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowServerMessagesButton">Show Messages Button</label>
+                                <select id="DefaultShowServerMessagesButton" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
                         </div>
 
                         <!-- 4. Home Screen -->
@@ -4377,6 +4385,7 @@
                     setNullableBoolSelect('#DefaultNavbarAlwaysExpanded', defaults.navbarAlwaysExpanded);
                     setNullableBoolSelect('#DefaultEnableFolderView', defaults.enableFolderView);
                     setNullableBoolSelect('#DefaultShowSeerrButton', defaults.showSeerrButton);
+                    setNullableBoolSelect('#DefaultShowServerMessagesButton', defaults.showServerMessagesButton);
 
                     setSelectValue('#DefaultMediaBarSourceType', defaults.mediaBarSourceType, 'Configured source');
                     loadAdminGenrePicker(defaults.mediaBarExcludedGenres || []);
@@ -4758,6 +4767,7 @@
                         config.DefaultUserSettings.navbarAlwaysExpanded = getNullableBoolSelect('#DefaultNavbarAlwaysExpanded');
                         config.DefaultUserSettings.enableFolderView = getNullableBoolSelect('#DefaultEnableFolderView');
                         config.DefaultUserSettings.showSeerrButton = getNullableBoolSelect('#DefaultShowSeerrButton');
+                        config.DefaultUserSettings.showServerMessagesButton = getNullableBoolSelect('#DefaultShowServerMessagesButton');
 
                         config.DefaultUserSettings.mediaBarSourceType = document.querySelector('#DefaultMediaBarSourceType').value || null;
                         var genreIds = [];

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1717,17 +1717,24 @@
 
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="MessageBody">Message</label>
-                            <textarea id="MessageBody" is="emby-textarea" rows="4" maxlength="2000" placeholder="Plain text only. Links and formatting are not shown."></textarea>
+                            <textarea id="MessageBody" is="emby-textarea" rows="12" maxlength="2000" style="width:100%;box-sizing:border-box;font-family:inherit;" placeholder="Write your message here."></textarea>
+                            <div class="fieldDescription">
+                                Formatting uses Markdown. Only CommonMark is supported:
+                                <a href="https://commonmark.org/help/" target="_blank">syntax reference</a>.
+                                Images are not shown, even though that page lists them.
+                            </div>
                         </div>
 
                         <div class="selectContainer">
-                            <label class="selectLabel" for="MessageSeverity">Importance</label>
-                            <select is="emby-select" id="MessageSeverity">
-                                <option value="info">Info (green)</option>
-                                <option value="warning">Warning (yellow)</option>
-                                <option value="critical">Critical (red)</option>
+                            <label class="selectLabel" for="MessageColor">Colour</label>
+                            <select is="emby-select" id="MessageColor">
+                                <option value="white">White</option>
+                                <option value="green">Green</option>
+                                <option value="blue">Blue</option>
+                                <option value="yellow">Yellow</option>
+                                <option value="red">Red</option>
                             </select>
-                            <div class="fieldDescription">Sets the colour of the message and of the button in the app menu.</div>
+                            <div class="fieldDescription">Colours the message in the app. The menu button stays neutral.</div>
                         </div>
 
                         <div class="selectContainer">
@@ -3700,10 +3707,12 @@
 
             var moonfinEditingMessageId = null;
 
-            var moonfinSeverityColors = {
-                info: '#52b54b',
-                warning: '#f0ad4e',
-                critical: '#d9534f'
+            var moonfinMessageColors = {
+                white: '#e8eaed',
+                green: '#4caf6d',
+                blue: '#4a9ee0',
+                yellow: '#e0b040',
+                red: '#e05260'
             };
 
             var moonfinDeliveryLabels = {
@@ -3795,7 +3804,7 @@
 
                 document.querySelector('#MessageTitle').value = '';
                 document.querySelector('#MessageBody').value = '';
-                document.querySelector('#MessageSeverity').value = 'info';
+                document.querySelector('#MessageColor').value = 'white';
                 document.querySelector('#MessageDelivery').value = 'inbox';
                 document.querySelector('#MessageAudience').value = 'all';
                 document.querySelector('#MessageStart').value = '';
@@ -3830,7 +3839,7 @@
 
                 document.querySelector('#MessageTitle').value = item.title || item.Title || '';
                 document.querySelector('#MessageBody').value = item.body || item.Body || '';
-                document.querySelector('#MessageSeverity').value = item.severity || item.Severity || 'info';
+                document.querySelector('#MessageColor').value = item.color || item.Color || 'white';
                 document.querySelector('#MessageDelivery').value = item.delivery || item.Delivery || 'inbox';
                 document.querySelector('#MessageAudience').value = item.audience || item.Audience || 'all';
                 document.querySelector('#MessageStart').value = messageDateToInput(item.startUtc || item.StartUtc);
@@ -3886,14 +3895,14 @@
                     var id = item.id || item.Id || '';
                     var title = item.title || item.Title || '';
                     var body = item.body || item.Body || '';
-                    var severity = item.severity || item.Severity || 'info';
+                    var pick = item.color || item.Color || 'white';
                     var delivery = item.delivery || item.Delivery || 'inbox';
                     var audience = item.audience || item.Audience || 'all';
                     var pinned = !!(item.pinned || item.Pinned);
                     var start = item.startUtc || item.StartUtc;
                     var end = item.endUtc || item.EndUtc;
                     var targets = item.targetUserIds || item.TargetUserIds || [];
-                    var color = moonfinSeverityColors[severity] || moonfinSeverityColors.info;
+                    var color = moonfinMessageColors[pick] || moonfinMessageColors.white;
 
                     var state = 'Showing now';
                     if (start && new Date(start) > now) {
@@ -3984,7 +3993,7 @@
                     id: moonfinEditingMessageId || '',
                     title: title,
                     body: body,
-                    severity: document.querySelector('#MessageSeverity').value,
+                    color: document.querySelector('#MessageColor').value,
                     delivery: document.querySelector('#MessageDelivery').value,
                     audience: audience,
                     targetUserIds: targetUserIds,

--- a/Jellyfin/backend/PluginConfiguration.cs
+++ b/Jellyfin/backend/PluginConfiguration.cs
@@ -395,11 +395,8 @@ public class ServerMessage
     public const string ColorBlue = "blue";
     public const string ColorWhite = "white";
 
-    /// <summary>Shows in the list only.</summary>
+    /// <summary>Only marks the menu button as unread.</summary>
     public const string DeliveryInbox = "inbox";
-
-    /// <summary>Shows a small toast when it arrives.</summary>
-    public const string DeliveryToast = "toast";
 
     /// <summary>Opens the message window once, until the user reads it.</summary>
     public const string DeliveryPopup = "popup";
@@ -413,7 +410,6 @@ public class ServerMessage
     public string Body { get; set; } = string.Empty;
     public string Color { get; set; } = ColorWhite;
     public string Delivery { get; set; } = DeliveryInbox;
-    public bool Pinned { get; set; }
     public string? ActionLabel { get; set; }
     public string? ActionUrl { get; set; }
 
@@ -478,12 +474,7 @@ public class ServerMessage
             _ => ColorWhite
         };
 
-        Delivery = Delivery switch
-        {
-            DeliveryToast => DeliveryToast,
-            DeliveryPopup => DeliveryPopup,
-            _ => DeliveryInbox
-        };
+        Delivery = Delivery == DeliveryPopup ? DeliveryPopup : DeliveryInbox;
 
         Audience = Audience switch
         {
@@ -561,8 +552,7 @@ public class ServerMessage
         }
 
         var extra = messages
-            .OrderBy(m => m.Pinned)
-            .ThenBy(m => m.CreatedUtc)
+            .OrderBy(m => m.CreatedUtc)
             .Take(messages.Count - MaxStored)
             .ToList();
 

--- a/Jellyfin/backend/PluginConfiguration.cs
+++ b/Jellyfin/backend/PluginConfiguration.cs
@@ -205,6 +205,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public List<UploadedThemeEntry> UploadedThemes { get; set; } = new();
 
+    /// <summary>
+    /// Admin messages shown to users in the app. They are only a few KB of text, so they live
+    /// in the config instead of the data folder.
+    /// </summary>
+    public List<ServerMessage> Messages { get; set; } = new();
+
     // ---------------------------------------------------------------------
     // Retro games (EmulatorJS) configuration
     // ---------------------------------------------------------------------
@@ -370,4 +376,195 @@ public class UploadedThemeEntry
     public DateTimeOffset UploadedAtUtc { get; set; }
     public string? UploadedByUserId { get; set; }
     public string ChecksumSha256 { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// One message the admin wrote for users to read in the app.
+/// </summary>
+public class ServerMessage
+{
+    /// <summary>Highest number of messages kept. Older ones are dropped on save.</summary>
+    public const int MaxStored = 50;
+
+    /// <summary>Body length cap, so a huge paste cannot break the app layout.</summary>
+    public const int MaxBodyLength = 2000;
+
+    public const string SeverityInfo = "info";
+    public const string SeverityWarning = "warning";
+    public const string SeverityCritical = "critical";
+
+    /// <summary>Shows in the list only.</summary>
+    public const string DeliveryInbox = "inbox";
+
+    /// <summary>Shows a small toast when it arrives.</summary>
+    public const string DeliveryToast = "toast";
+
+    /// <summary>Opens the message window once, until the user reads it.</summary>
+    public const string DeliveryPopup = "popup";
+
+    public const string AudienceAll = "all";
+    public const string AudienceUsers = "users";
+    public const string AudienceAdmins = "admins";
+
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public string Severity { get; set; } = SeverityInfo;
+    public string Delivery { get; set; } = DeliveryInbox;
+    public bool Pinned { get; set; }
+    public string? ActionLabel { get; set; }
+    public string? ActionUrl { get; set; }
+
+    /// <summary>When the message starts showing. Null means right away.</summary>
+    public DateTime? StartUtc { get; set; }
+
+    /// <summary>When the message stops showing. Null means never.</summary>
+    public DateTime? EndUtc { get; set; }
+
+    public string Audience { get; set; } = AudienceAll;
+
+    /// <summary>User IDs to show this to. Only used when <see cref="Audience"/> is "users".</summary>
+    public List<string> TargetUserIds { get; set; } = new();
+
+    public DateTime CreatedUtc { get; set; }
+    public string? CreatedByUserId { get; set; }
+
+    /// <summary>
+    /// True when this message should show right now, for this user.
+    /// </summary>
+    public bool IsVisibleTo(Guid userId, bool isAdmin, DateTime nowUtc)
+    {
+        if (StartUtc.HasValue && nowUtc < StartUtc.Value)
+        {
+            return false;
+        }
+
+        if (EndUtc.HasValue && nowUtc >= EndUtc.Value)
+        {
+            return false;
+        }
+
+        return Audience switch
+        {
+            AudienceAdmins => isAdmin,
+            AudienceUsers => TargetUserIds.Any(id =>
+                Guid.TryParse(id, out var target) && target == userId),
+            _ => true
+        };
+    }
+
+    /// <summary>
+    /// Cleans admin input before it is saved. Bad values fall back to the default instead of
+    /// being rejected, except the action URL which is dropped when it is not http or https.
+    /// </summary>
+    public void Sanitize()
+    {
+        Title = (Title ?? string.Empty).Trim();
+        Body = (Body ?? string.Empty).Trim();
+
+        if (Body.Length > MaxBodyLength)
+        {
+            Body = Body.Substring(0, MaxBodyLength);
+        }
+
+        Severity = Severity switch
+        {
+            SeverityWarning => SeverityWarning,
+            SeverityCritical => SeverityCritical,
+            _ => SeverityInfo
+        };
+
+        Delivery = Delivery switch
+        {
+            DeliveryToast => DeliveryToast,
+            DeliveryPopup => DeliveryPopup,
+            _ => DeliveryInbox
+        };
+
+        Audience = Audience switch
+        {
+            AudienceUsers => AudienceUsers,
+            AudienceAdmins => AudienceAdmins,
+            _ => AudienceAll
+        };
+
+        if (Audience != AudienceUsers)
+        {
+            TargetUserIds = new List<string>();
+        }
+        else
+        {
+            TargetUserIds = TargetUserIds
+                .Where(id => Guid.TryParse(id, out _))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        ActionLabel = string.IsNullOrWhiteSpace(ActionLabel) ? null : ActionLabel.Trim();
+        ActionUrl = SanitizeActionUrl(ActionUrl);
+
+        // A link with no label is useless to the user, and a label with no link does nothing.
+        if (ActionUrl == null)
+        {
+            ActionLabel = null;
+        }
+        else if (ActionLabel == null)
+        {
+            ActionUrl = null;
+        }
+
+        // An end date before the start date would hide the message forever.
+        if (StartUtc.HasValue && EndUtc.HasValue && EndUtc.Value <= StartUtc.Value)
+        {
+            EndUtc = null;
+        }
+    }
+
+    /// <summary>
+    /// Keeps only real http and https links. Anything else is dropped, since this URL gets
+    /// opened on the user's device.
+    /// </summary>
+    private static string? SanitizeActionUrl(string? rawUrl)
+    {
+        if (string.IsNullOrWhiteSpace(rawUrl))
+        {
+            return null;
+        }
+
+        var value = rawUrl.Trim().Trim('"', '\'').Trim();
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return null;
+        }
+
+        return uri.ToString();
+    }
+
+    /// <summary>
+    /// Drops expired messages, then the oldest ones if the list is still too long. Keeps the
+    /// config file from growing forever without needing a scheduled task.
+    /// </summary>
+    public static void Prune(List<ServerMessage> messages)
+    {
+        var now = DateTime.UtcNow;
+        messages.RemoveAll(m => m.EndUtc.HasValue && m.EndUtc.Value < now);
+
+        if (messages.Count <= MaxStored)
+        {
+            return;
+        }
+
+        var extra = messages
+            .OrderBy(m => m.Pinned)
+            .ThenBy(m => m.CreatedUtc)
+            .Take(messages.Count - MaxStored)
+            .ToList();
+
+        foreach (var message in extra)
+        {
+            messages.Remove(message);
+        }
+    }
 }

--- a/Jellyfin/backend/PluginConfiguration.cs
+++ b/Jellyfin/backend/PluginConfiguration.cs
@@ -389,6 +389,9 @@ public class ServerMessage
     /// <summary>Body length cap, so a huge paste cannot break the app layout.</summary>
     public const int MaxBodyLength = 2000;
 
+    /// <summary>Title length cap, the same limit the config page puts on its field.</summary>
+    public const int MaxTitleLength = 120;
+
     public const string ColorGreen = "green";
     public const string ColorRed = "red";
     public const string ColorYellow = "yellow";
@@ -465,6 +468,11 @@ public class ServerMessage
             Body = Body.Substring(0, MaxBodyLength);
         }
 
+        if (Title.Length > MaxTitleLength)
+        {
+            Title = Title.Substring(0, MaxTitleLength);
+        }
+
         Color = Color switch
         {
             ColorGreen => ColorGreen,
@@ -534,7 +542,8 @@ public class ServerMessage
             return null;
         }
 
-        return uri.ToString();
+        // AbsoluteUri keeps the escaping the admin typed, where ToString would decode it.
+        return uri.AbsoluteUri;
     }
 
     /// <summary>

--- a/Jellyfin/backend/PluginConfiguration.cs
+++ b/Jellyfin/backend/PluginConfiguration.cs
@@ -389,9 +389,11 @@ public class ServerMessage
     /// <summary>Body length cap, so a huge paste cannot break the app layout.</summary>
     public const int MaxBodyLength = 2000;
 
-    public const string SeverityInfo = "info";
-    public const string SeverityWarning = "warning";
-    public const string SeverityCritical = "critical";
+    public const string ColorGreen = "green";
+    public const string ColorRed = "red";
+    public const string ColorYellow = "yellow";
+    public const string ColorBlue = "blue";
+    public const string ColorWhite = "white";
 
     /// <summary>Shows in the list only.</summary>
     public const string DeliveryInbox = "inbox";
@@ -409,7 +411,7 @@ public class ServerMessage
     public string Id { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string Body { get; set; } = string.Empty;
-    public string Severity { get; set; } = SeverityInfo;
+    public string Color { get; set; } = ColorWhite;
     public string Delivery { get; set; } = DeliveryInbox;
     public bool Pinned { get; set; }
     public string? ActionLabel { get; set; }
@@ -467,11 +469,13 @@ public class ServerMessage
             Body = Body.Substring(0, MaxBodyLength);
         }
 
-        Severity = Severity switch
+        Color = Color switch
         {
-            SeverityWarning => SeverityWarning,
-            SeverityCritical => SeverityCritical,
-            _ => SeverityInfo
+            ColorGreen => ColorGreen,
+            ColorRed => ColorRed,
+            ColorYellow => ColorYellow,
+            ColorBlue => ColorBlue,
+            _ => ColorWhite
         };
 
         Delivery = Delivery switch

--- a/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
@@ -159,6 +159,29 @@ public class ServerMessageTests
     }
 
     [Fact]
+    public void Sanitize_CutsTitleToTheCap()
+    {
+        var message = Message();
+        message.Title = new string('x', ServerMessage.MaxTitleLength + 50);
+
+        message.Sanitize();
+
+        Assert.Equal(ServerMessage.MaxTitleLength, message.Title.Length);
+    }
+
+    [Fact]
+    public void Sanitize_KeepsTheEscapingInALink()
+    {
+        var message = Message();
+        message.ActionLabel = "Open";
+        message.ActionUrl = "https://example.com/a%20b?q=caf%C3%A9";
+
+        message.Sanitize();
+
+        Assert.Equal("https://example.com/a%20b?q=caf%C3%A9", message.ActionUrl);
+    }
+
+    [Fact]
     public void Sanitize_ClearsTargetsWhenAudienceIsNotUsers()
     {
         var message = Message();

--- a/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
@@ -1,0 +1,220 @@
+using Moonfin.Server;
+using Moonfin.Server.Api;
+using Xunit;
+
+namespace Moonfin.Server.Tests;
+
+public class ServerMessageTests
+{
+    private static readonly DateTime Now = new(2026, 8, 24, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly Guid Alice = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Bob = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static ServerMessage Message() => new()
+    {
+        Id = "m1",
+        Title = "Hello",
+        Body = "Body",
+        CreatedUtc = Now
+    };
+
+    [Fact]
+    public void IsVisibleTo_ShowsPlainMessageToEveryone()
+    {
+        var message = Message();
+
+        Assert.True(message.IsVisibleTo(Alice, isAdmin: false, Now));
+        Assert.True(message.IsVisibleTo(Bob, isAdmin: true, Now));
+    }
+
+    [Fact]
+    public void IsVisibleTo_HidesMessageBeforeItStarts()
+    {
+        var message = Message();
+        message.StartUtc = Now.AddHours(1);
+
+        Assert.False(message.IsVisibleTo(Alice, isAdmin: false, Now));
+        Assert.True(message.IsVisibleTo(Alice, isAdmin: false, Now.AddHours(2)));
+    }
+
+    [Fact]
+    public void IsVisibleTo_HidesMessageOnceItEnds()
+    {
+        var message = Message();
+        message.EndUtc = Now.AddHours(1);
+
+        Assert.True(message.IsVisibleTo(Alice, isAdmin: false, Now));
+        Assert.False(message.IsVisibleTo(Alice, isAdmin: false, Now.AddHours(1)));
+        Assert.False(message.IsVisibleTo(Alice, isAdmin: false, Now.AddHours(2)));
+    }
+
+    [Fact]
+    public void IsVisibleTo_AdminsOnlyMessageStaysHiddenFromUsers()
+    {
+        var message = Message();
+        message.Audience = ServerMessage.AudienceAdmins;
+
+        Assert.False(message.IsVisibleTo(Alice, isAdmin: false, Now));
+        Assert.True(message.IsVisibleTo(Alice, isAdmin: true, Now));
+    }
+
+    [Fact]
+    public void IsVisibleTo_TargetedMessageReachesOnlyItsTargets()
+    {
+        var message = Message();
+        message.Audience = ServerMessage.AudienceUsers;
+        message.TargetUserIds = new List<string> { Alice.ToString() };
+
+        Assert.True(message.IsVisibleTo(Alice, isAdmin: false, Now));
+        Assert.False(message.IsVisibleTo(Bob, isAdmin: false, Now));
+
+        // Being an admin does not grant access to someone else's message.
+        Assert.False(message.IsVisibleTo(Bob, isAdmin: true, Now));
+    }
+
+    [Fact]
+    public void Sanitize_FallsBackToDefaultsOnUnknownValues()
+    {
+        var message = Message();
+        message.Severity = "catastrophic";
+        message.Delivery = "carrier-pigeon";
+        message.Audience = "nobody";
+
+        message.Sanitize();
+
+        Assert.Equal(ServerMessage.SeverityInfo, message.Severity);
+        Assert.Equal(ServerMessage.DeliveryInbox, message.Delivery);
+        Assert.Equal(ServerMessage.AudienceAll, message.Audience);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("moonfin://open")]
+    [InlineData("not a url")]
+    public void Sanitize_DropsLinksThatAreNotHttp(string url)
+    {
+        var message = Message();
+        message.ActionLabel = "Open";
+        message.ActionUrl = url;
+
+        message.Sanitize();
+
+        Assert.Null(message.ActionUrl);
+        Assert.Null(message.ActionLabel);
+    }
+
+    [Fact]
+    public void Sanitize_KeepsHttpAndHttpsLinks()
+    {
+        var message = Message();
+        message.ActionLabel = "Open";
+        message.ActionUrl = "https://example.com/news";
+
+        message.Sanitize();
+
+        Assert.Equal("https://example.com/news", message.ActionUrl);
+        Assert.Equal("Open", message.ActionLabel);
+    }
+
+    [Fact]
+    public void Sanitize_DropsLabelWithoutLinkAndLinkWithoutLabel()
+    {
+        var labelOnly = Message();
+        labelOnly.ActionLabel = "Open";
+        labelOnly.Sanitize();
+        Assert.Null(labelOnly.ActionLabel);
+
+        var linkOnly = Message();
+        linkOnly.ActionUrl = "https://example.com";
+        linkOnly.Sanitize();
+        Assert.Null(linkOnly.ActionUrl);
+    }
+
+    [Fact]
+    public void Sanitize_CutsBodyToTheCap()
+    {
+        var message = Message();
+        message.Body = new string('x', ServerMessage.MaxBodyLength + 500);
+
+        message.Sanitize();
+
+        Assert.Equal(ServerMessage.MaxBodyLength, message.Body.Length);
+    }
+
+    [Fact]
+    public void Sanitize_ClearsTargetsWhenAudienceIsNotUsers()
+    {
+        var message = Message();
+        message.Audience = ServerMessage.AudienceAll;
+        message.TargetUserIds = new List<string> { Alice.ToString() };
+
+        message.Sanitize();
+
+        Assert.Empty(message.TargetUserIds);
+    }
+
+    [Fact]
+    public void Sanitize_DropsTargetsThatAreNotUserIds()
+    {
+        var message = Message();
+        message.Audience = ServerMessage.AudienceUsers;
+        message.TargetUserIds = new List<string> { Alice.ToString(), "everyone" };
+
+        message.Sanitize();
+
+        Assert.Equal(new[] { Alice.ToString() }, message.TargetUserIds);
+    }
+
+    [Fact]
+    public void Sanitize_ClearsEndDateThatWouldHideTheMessageForever()
+    {
+        var message = Message();
+        message.StartUtc = Now;
+        message.EndUtc = Now.AddHours(-1);
+
+        message.Sanitize();
+
+        Assert.Null(message.EndUtc);
+    }
+
+    [Fact]
+    public void PruneMessages_RemovesExpiredMessages()
+    {
+        var fresh = Message();
+        var expired = Message();
+        expired.Id = "old";
+        expired.EndUtc = DateTime.UtcNow.AddDays(-1);
+
+        var messages = new List<ServerMessage> { fresh, expired };
+        ServerMessage.Prune(messages);
+
+        Assert.Equal(new[] { "m1" }, messages.Select(m => m.Id));
+    }
+
+    [Fact]
+    public void PruneMessages_DropsOldestFirstAndKeepsPinned()
+    {
+        var messages = new List<ServerMessage>();
+
+        var pinned = Message();
+        pinned.Id = "pinned";
+        pinned.Pinned = true;
+        pinned.CreatedUtc = Now.AddYears(-5);
+        messages.Add(pinned);
+
+        for (var i = 0; i < ServerMessage.MaxStored + 5; i++)
+        {
+            var message = Message();
+            message.Id = $"m{i}";
+            message.CreatedUtc = Now.AddMinutes(i);
+            messages.Add(message);
+        }
+
+        ServerMessage.Prune(messages);
+
+        Assert.Equal(ServerMessage.MaxStored, messages.Count);
+        Assert.Contains(messages, m => m.Id == "pinned");
+        Assert.DoesNotContain(messages, m => m.Id == "m0");
+    }
+}

--- a/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
@@ -76,15 +76,31 @@ public class ServerMessageTests
     public void Sanitize_FallsBackToDefaultsOnUnknownValues()
     {
         var message = Message();
-        message.Severity = "catastrophic";
+        message.Color = "chartreuse";
         message.Delivery = "carrier-pigeon";
         message.Audience = "nobody";
 
         message.Sanitize();
 
-        Assert.Equal(ServerMessage.SeverityInfo, message.Severity);
+        Assert.Equal(ServerMessage.ColorWhite, message.Color);
         Assert.Equal(ServerMessage.DeliveryInbox, message.Delivery);
         Assert.Equal(ServerMessage.AudienceAll, message.Audience);
+    }
+
+    [Theory]
+    [InlineData(ServerMessage.ColorGreen)]
+    [InlineData(ServerMessage.ColorRed)]
+    [InlineData(ServerMessage.ColorYellow)]
+    [InlineData(ServerMessage.ColorBlue)]
+    [InlineData(ServerMessage.ColorWhite)]
+    public void Sanitize_KeepsEveryColourTheAdminCanPick(string colour)
+    {
+        var message = Message();
+        message.Color = colour;
+
+        message.Sanitize();
+
+        Assert.Equal(colour, message.Color);
     }
 
     [Theory]

--- a/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/ServerMessageTests.cs
@@ -209,15 +209,9 @@ public class ServerMessageTests
     }
 
     [Fact]
-    public void PruneMessages_DropsOldestFirstAndKeepsPinned()
+    public void PruneMessages_DropsTheOldestFirst()
     {
         var messages = new List<ServerMessage>();
-
-        var pinned = Message();
-        pinned.Id = "pinned";
-        pinned.Pinned = true;
-        pinned.CreatedUtc = Now.AddYears(-5);
-        messages.Add(pinned);
 
         for (var i = 0; i < ServerMessage.MaxStored + 5; i++)
         {
@@ -230,7 +224,8 @@ public class ServerMessageTests
         ServerMessage.Prune(messages);
 
         Assert.Equal(ServerMessage.MaxStored, messages.Count);
-        Assert.Contains(messages, m => m.Id == "pinned");
         Assert.DoesNotContain(messages, m => m.Id == "m0");
+        Assert.DoesNotContain(messages, m => m.Id == "m4");
+        Assert.Contains(messages, m => m.Id == "m5");
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary
`POST /Moonfin/Broadcast` was the only way to tell users anything, and the message was not saved and only reached clients that were connected at that moment. This adds a Messages tab where an admin writes messages that are stored, scheduled and aimed at people they choose, plus the endpoints the app reads them from. Broadcast still works and is now saved too, so a message no longer disappears the moment it is sent.

## Related Issues
- Closes #
- Fixes #
- Related to [Moonfin-Core `feat/server-messages`](https://github.com/Moonfin-Client/Moonfin-Core/pull/1274)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] API / endpoint change
- [x] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [x] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [x] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## What an admin can do

- Write a message with a title and a body. The body takes Markdown, so headings, bold, italic, lists and links all work.
- Pick a colour: white, green, blue, yellow or red.
- Pick how it shows up: a count on the menu button, or the message window opening on its own once.
- Pick who sees it: everyone, some selected users, or admins only.
- Set a start date, so a message appears on its own, and an end date, so it goes away without anyone having to remember to delete it.
- Add a button with a link at the end of a message.
- Order the list with up and down arrows. The app shows them in the same order.
- Edit or delete any saved message.

## Changes Made
- New `ServerMessage` in `PluginConfiguration`. It lives in the config next to `UploadedThemes` rather than in the data folder. Up to 50 are kept, and expired ones are dropped on the next save, so nothing has to run on a schedule.
- New endpoints, following `MoonfinThemesController`: `GET Moonfin/Messages` for users, and `GET`, `POST`, `DELETE` under `Moonfin/Admin/Messages` behind `RequiresElevation`. `POST Moonfin/Admin/Messages/Order` saves the order, the same thing as `Moonfin/Collections/{id}/Order`.
- Who sees what is decided on the server, in `GET Moonfin/Messages`. Sending everything and hiding it in the app would let any user read a message meant for someone else. Scheduled and expired messages are left out of the payload too.
- Input is cleaned before it is stored: the body is capped, unknown colours fall back to white, and a link that is not http or https is dropped rather than passed to a client to open.
- `POST Moonfin/Broadcast` keeps working and now saves what it sends, so users who were offline still find it.
- Push already existed and is reused.
- `Ping` gains `messagesSupported`, so an older plugin simply reads as false and the client hides the button.
- New Messages tab in both config pages, and `showServerMessagesButton` in the Navigation part of the default user settings.
- ⚠️ Mirrored on the Emby plugin but not tested at all as I don't have an Emby server.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [x] Companion client PR(s) required, linked here: [Moonfin-Core `feat/server-messages`](https://github.com/Moonfin-Client/Moonfin-Core/pull/1274)
- [x] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `showServerMessagesButton` matches the Dart `SyncedField('showServerMessagesButton',)` in `lib/data/services/synced_fields.dart` exactly, including casing.

## Compatibility
- [x] Change to the settings profile is additive only, no renamed or removed properties
- [x] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [x] Migration added for any renamed or removed settings
- [ ] Older clients still work, unknown fields are ignored and no keys were removed

`MoonfinSettingsProfile` only gains `ShowServerMessagesButton` as a `bool?`, so it is additive. No migration is needed: `ServerMessage` is new in this PR, so nothing has ever been stored under an older shape. Older clients never call the new endpoints and ignore `messagesSupported`.

**One ordering dependency, which is why the last box is unticked.** A message push carries `route: "messages"`, and only a client with the matching [Moongin-Core PR ](https://github.com/Moonfin-Client/Moonfin-Core/pull/1274) knows what to do with it.

## Testing
- [x] Built the plugin and deployed to a Jellyfin server
- [x] Verified against a live client, Moonfin-Core on:
   - macOS (physical device)
   - Android TV (emulator)
   - Android phone (emulator)
   - Web
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. With no messages on the server, the button is absent. Post one and it appears with a red cicle with 1 inside. ("Show messages button" setting needs to be enabled)
2. Open a message: the count drops and the circle goes away.
3. Post a message set to open the window, with the app closed. Open the app and the window comes up on its own, once.
4. Write a message with a heading, bold text, a list and a link. The closed card shows a plain sentence, the open one shows the formatting.
5. Kill the app and reopen it: the messages are still listed.
6. Move a message in Moonbase with the arrows. The app follows the same order.
7. On a TV, walk the list with the D-pad. Down from an open message reaches its link button, up goes back to the card, and the link shows a QR code.
8. Sign in as another user. You only see the messages meant for you.

## Screenshots (if applicable)
<img width="3456" height="4307" alt="FireShot Capture 002 - bientavu-jellyfin -  jellyfin bientavu dev" src="https://github.com/user-attachments/assets/6771bef6-3018-4ae6-a3ef-c370cfdccef4" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
- [x] Any new setting keys match the client-side keys exactly
