### PR TITLE
Update wording in settings

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -595,10 +595,10 @@
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input type="checkbox" id="EnableSettingsSync" is="emby-checkbox" />
-                                <span>Enable Settings Sync</span>
+                                <span>Enable Moonbase Sync</span>
                             </label>
                             <div class="fieldDescription">
-                                Allow Moonfin clients to sync their settings across devices via this server.
+                                Allow Moonfin clients to sync their settings across devices via this server. Enabling this is required for seerr/ratings integrations. 
                             </div>
                         </div>
                     </div>

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -402,10 +402,10 @@
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input type="checkbox" id="EnableSettingsSync" is="emby-checkbox" />
-                                <span>Enable Settings Sync</span>
+                                <span>Enable Moonbase Sync</span>
                             </label>
                             <div class="fieldDescription">
-                                Allow Moonfin clients to sync their settings across devices via this server.
+                                Allow Moonfin clients to sync their settings across devices via this server. Enabling this is required for seerr/ratings integrations. 
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
# Pull Request

## Summary
Make it crystal clear for users that "settings sync" is required for advanced moonbase features like seerr/ratings/etc. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #214
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [X] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- rename "enable settings sync" to "enable moonbase sync" so users know it applies to more than just user settings
- clarify the toggle is required for seerr/ratings features
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [ ] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
