### PR TITLE
(fix) Refactor/redesign of game artwork services

### DIFF
--- a/Jellyfin/backend/Services/DerivedThumbnailService.cs
+++ b/Jellyfin/backend/Services/DerivedThumbnailService.cs
@@ -11,6 +11,12 @@ namespace Moonfin.Server.Services;
 /// </summary>
 internal sealed class DerivedThumbnailService
 {
+    /// <summary>
+    /// Concurrent encodes allowed, and therefore the number of background thumbnail workers worth
+    /// running: fewer leaves cores idle behind the downloaders, more only queues on this gate.
+    /// </summary>
+    internal static int DefaultEncodeConcurrency => Math.Max(1, Environment.ProcessorCount / 2);
+
     private const int MaxThumbDimension = 512;
     private const int ThumbQuality = 85;
 
@@ -45,10 +51,17 @@ internal sealed class DerivedThumbnailService
         int? encodeConcurrencyForTests,
         TimeSpan? derivedThumbBudgetForTests)
     {
+        if (encodeConcurrencyForTests is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(encodeConcurrencyForTests),
+                "Encode concurrency must be at least one.");
+        }
+
         _logger = logger;
         _cacheDir = cacheDir;
         _imageEncoder = imageEncoder;
-        _encodeSemaphore = new SemaphoreSlim(encodeConcurrencyForTests ?? Math.Max(1, Environment.ProcessorCount / 2));
+        _encodeSemaphore = new SemaphoreSlim(encodeConcurrencyForTests ?? DefaultEncodeConcurrency);
         _derivedThumbBudget = derivedThumbBudgetForTests ?? DerivedThumbBudget;
     }
 

--- a/Jellyfin/backend/Services/GameArtworkCatalog.cs
+++ b/Jellyfin/backend/Services/GameArtworkCatalog.cs
@@ -153,6 +153,12 @@ public sealed record ArtworkCatalogSystemSnapshot(
     /// from <see cref="PreviewGameIds"/>: a remote miss must not consume one of the four panels.
     /// </summary>
     public IReadOnlyList<string> PreviewCandidateGameIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>The inventory generation whose preview panels are stable and final.</summary>
+    public string? PreviewSelectionGeneration { get; init; }
+
+    /// <summary>The next candidate whose artwork state can still change the final panels.</summary>
+    public string? NextUnresolvedGameId { get; init; }
 }
 
 /// <summary>An item workers must reconstruct after a process restart.</summary>
@@ -195,6 +201,7 @@ public sealed class GameArtworkCatalog
     private readonly TimeSpan _persistDebounce;
     private readonly ConcurrentDictionary<string, Lazy<Task<LibraryCatalog>>> _libraries = new(StringComparer.Ordinal);
     private long _documentWrites;
+    private long _previewScanLookups;
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -212,6 +219,9 @@ public sealed class GameArtworkCatalog
 
     /// <summary>Whole-document writes performed so far; the debounce's only observable effect.</summary>
     internal long DocumentWriteCount => Interlocked.Read(ref _documentWrites);
+
+    /// <summary>Boxart lookups performed by preview-selection scans; the resumable scan's observable cost.</summary>
+    internal long PreviewScanLookupCount => Interlocked.Read(ref _previewScanLookups);
 
     /// <summary>
     /// Plugin-owned catalog directory. The reconciliation service uses its sibling artwork cache
@@ -259,7 +269,10 @@ public sealed class GameArtworkCatalog
                 .ToArray();
             foreach (var staleKey in staleKeys)
             {
+                // A re-fingerprinted ROM drops an entry a preview scan may already have counted as
+                // terminal, so the resume index can no longer be trusted for this system.
                 library.RemoveEntry(staleKey);
+                ResetPreviewScanProgress(library.Document, systemId);
                 changed = true;
             }
 
@@ -274,6 +287,9 @@ public sealed class GameArtworkCatalog
                 entry.State == ArtworkCatalogState.MetadataDeferred &&
                 !string.Equals(entry.MetadataDeferredProviderVersion, providerVersion, StringComparison.Ordinal))
             {
+                // A durable miss/defer reopens to Pending -- a preview scan may have already
+                // counted this candidate as terminal.
+                ResetPreviewScanProgress(library.Document, entry.SystemId);
                 entry = NewPending(key, systemId, entry.Revision, gameId);
                 library.SetEntry(key.StorageKey, entry);
                 changed = true;
@@ -489,11 +505,22 @@ public sealed class GameArtworkCatalog
         await library.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (!library.RemoveEntry(key.StorageKey))
+            if (!library.Entries.TryGetValue(key.StorageKey, out var removed) || !library.RemoveEntry(key.StorageKey))
             {
                 return false;
             }
 
+            // Mirrors PruneAsync's preview repair for the single-entry path: drop the game from any
+            // published selection and from the resumable scan's trusted prefix, then reset the
+            // checkpoint. Without this the panels keep advertising a game that has no entry left.
+            if (!string.IsNullOrWhiteSpace(removed.GameId) &&
+                library.Document.Systems.TryGetValue(systemId, out var system))
+            {
+                system.PreviewGameIds = system.PreviewGameIds
+                    .Where(id => !string.Equals(id, removed.GameId, StringComparison.Ordinal)).ToList();
+            }
+
+            ResetPreviewScanProgress(library.Document, systemId);
             BumpSystemGeneration(library.Document, systemId);
             await MarkDirtyUnsafeAsync(library, cancellationToken).ConfigureAwait(false);
             return true;
@@ -692,6 +719,7 @@ public sealed class GameArtworkCatalog
                 {
                     system.PreviewGameIds = previewIds;
                     system.PreviewCandidateGameIds = candidateIds;
+                    system.PreviewSelectionGeneration = null;
                     affectedSystems.Add(systemId);
                     changed = true;
                 }
@@ -707,6 +735,10 @@ public sealed class GameArtworkCatalog
                 if (library.Document.Systems.ContainsKey(systemId))
                 {
                     BumpSystemGeneration(library.Document, systemId);
+
+                    // A removed entry or a reindexed candidate list can silently un-confirm or
+                    // shift a candidate the scan already counted; always rescan from zero.
+                    ResetPreviewScanProgress(library.Document, systemId);
                 }
             }
 
@@ -727,6 +759,60 @@ public sealed class GameArtworkCatalog
             // one write per library rather than one per entry.
             await WriteUnsafeAsync(library, cancellationToken).ConfigureAwait(false);
             return orphaned;
+        }
+        finally
+        {
+            library.Gate.Release();
+        }
+    }
+
+    /// <summary>Reopens ready entries whose cached files were removed outside the catalog.</summary>
+    public async Task<int> RepairMissingArtifactsAsync(
+        string libraryId,
+        CancellationToken cancellationToken = default)
+    {
+        var library = await GetLibraryAsync(NormalizeLibraryId(libraryId), cancellationToken).ConfigureAwait(false);
+        await library.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var repaired = 0;
+            var affectedSystems = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var (storageKey, entry) in library.Entries.ToArray())
+            {
+                var updated = RepairMissingArtifact(entry);
+                if (updated == entry)
+                {
+                    continue;
+                }
+
+                library.SetEntry(storageKey, updated);
+                InvalidatePreviewScanIfReopened(library.Document, entry.SystemId, entry, updated);
+                if (entry.Key.Role == "boxart" &&
+                    !string.IsNullOrWhiteSpace(entry.GameId) &&
+                    ClassifyForPreviewScan(updated) == PreviewCandidateOutcome.NonTerminal &&
+                    library.Document.Systems.TryGetValue(entry.SystemId, out var system))
+                {
+                    system.PreviewGameIds = system.PreviewGameIds
+                        .Where(id => !string.Equals(id, entry.GameId, StringComparison.Ordinal)).ToList();
+                    system.PreviewSelectionGeneration = null;
+                }
+
+                affectedSystems.Add(entry.SystemId);
+                repaired++;
+            }
+
+            if (repaired == 0)
+            {
+                return 0;
+            }
+
+            foreach (var systemId in affectedSystems)
+            {
+                BumpSystemGeneration(library.Document, systemId);
+            }
+
+            await MarkDirtyUnsafeAsync(library, cancellationToken).ConfigureAwait(false);
+            return repaired;
         }
         finally
         {
@@ -808,6 +894,7 @@ public sealed class GameArtworkCatalog
                     library.SetEntry(item.Key.StorageKey, updated);
                     affectedSystems.Add(existing.SystemId);
                     affectedSystems.Add(item.SystemId);
+                    InvalidatePreviewScanIfReopened(library.Document, existing.SystemId, existing, updated);
                 }
             }
 
@@ -831,9 +918,8 @@ public sealed class GameArtworkCatalog
 
     /// <summary>
     /// Persists the complete deterministic preview-discovery permutation for an inventory
-    /// generation without prematurely publishing any panel. Workers walk this list until they
-    /// have confirmed up to four artwork-bearing games, then call
-    /// <see cref="CommitPreviewSelectionAsync"/>.
+    /// generation without prematurely publishing any panel. Preview selection is derived later
+    /// from this order and the catalog's terminal artwork states.
     /// </summary>
     public async Task<ArtworkCatalogSystemSnapshot> GetOrCreatePreviewDiscoveryAsync(
         string libraryId,
@@ -863,10 +949,18 @@ public sealed class GameArtworkCatalog
             var system = new PersistedSystem
             {
                 SystemId = systemId,
+                Name = existing?.Name ?? string.Empty,
+                Core = existing?.Core ?? string.Empty,
+                GameCount = existing?.GameCount ?? 0,
                 Generation = (existing?.Generation ?? 0) + 1,
                 InventoryGeneration = inventoryGeneration,
                 PreviewCandidateGameIds = candidates,
                 PreviewGameIds = new List<string>(),
+                PreviewSelectionGeneration = null,
+                // A new candidate order invalidates any prior scan checkpoint (indices no longer
+                // line up); explicit here even though a fresh PersistedSystem defaults to this.
+                PreviewScanStartIndex = 0,
+                PreviewScanConfirmedGameIds = new List<string>(),
             };
             library.Document.Systems[systemId] = system;
             await MarkDirtyUnsafeAsync(library, cancellationToken).ConfigureAwait(false);
@@ -879,19 +973,16 @@ public sealed class GameArtworkCatalog
     }
 
     /// <summary>
-    /// Publishes only artwork-bearing preview panels already confirmed by a worker. The set is
-    /// locked to the stored inventory generation and must be an ordered subset of its discovery
-    /// permutation.
+    /// Recomputes one system's stable preview selection from its persisted candidate order and
+    /// current box-art states. No filesystem work is performed.
     /// </summary>
-    public async Task<ArtworkCatalogSystemSnapshot> CommitPreviewSelectionAsync(
+    public async Task<ArtworkCatalogSystemSnapshot> RecomputePreviewSelectionAsync(
         string libraryId,
         string systemId,
         string inventoryGeneration,
-        IEnumerable<string> confirmedGameIds,
         CancellationToken cancellationToken = default)
     {
         systemId = NormalizeSystemId(systemId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(inventoryGeneration);
         var library = await GetLibraryAsync(NormalizeLibraryId(libraryId), cancellationToken).ConfigureAwait(false);
         await library.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -899,28 +990,68 @@ public sealed class GameArtworkCatalog
             if (!library.Document.Systems.TryGetValue(systemId, out var system) ||
                 !string.Equals(system.InventoryGeneration, inventoryGeneration, StringComparison.Ordinal))
             {
-                throw new InvalidOperationException("Preview discovery must be initialized before its selection is committed.");
+                return Snapshot(system ?? new PersistedSystem { SystemId = systemId });
             }
 
-            var confirmed = confirmedGameIds
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Select(id => id.Trim())
-                .Distinct(StringComparer.Ordinal)
-                .Take(4)
-                .ToList();
-            if (confirmed.Any(id => !system.PreviewCandidateGameIds.Contains(id, StringComparer.Ordinal)))
+            var candidates = system.PreviewCandidateGameIds;
+
+            // Resuming trusts that every candidate before this index is still terminal (confirmed
+            // or a durable skip); every mutation that can reopen one resets it back to 0 (see
+            // ResetPreviewScanProgress and its callers).
+            var scanIndex = Math.Clamp(system.PreviewScanStartIndex, 0, candidates.Count);
+            var previousScanIndex = scanIndex;
+            var previousConfirmedPrefix = system.PreviewScanConfirmedGameIds;
+            var confirmed = scanIndex > 0 ? new List<string>(previousConfirmedPrefix) : new List<string>(4);
+            var complete = true;
+            string? nextUnresolvedGameId = null;
+
+            while (scanIndex < candidates.Count && confirmed.Count < 4)
             {
-                throw new ArgumentException("Preview panels must come from the persisted discovery order.", nameof(confirmedGameIds));
+                var gameId = candidates[scanIndex];
+                var outcome = ClassifyForPreviewScan(library.FindByGameRole(gameId, "boxart"));
+                Interlocked.Increment(ref _previewScanLookups);
+                if (outcome == PreviewCandidateOutcome.Confirmed)
+                {
+                    confirmed.Add(gameId);
+                    scanIndex++;
+                    continue;
+                }
+
+                if (outcome == PreviewCandidateOutcome.TerminalSkip)
+                {
+                    scanIndex++;
+                    continue;
+                }
+
+                complete = false;
+                nextUnresolvedGameId = gameId;
+                break;
             }
 
-            if (!system.PreviewGameIds.SequenceEqual(confirmed, StringComparer.Ordinal))
+            var scanProgressed = previousScanIndex != scanIndex || !previousConfirmedPrefix.SequenceEqual(confirmed, StringComparer.Ordinal);
+            system.PreviewScanStartIndex = scanIndex;
+            system.PreviewScanConfirmedGameIds = new List<string>(confirmed);
+
+            // An incomplete walk keeps whatever was last published: a candidate reopening mid-walk
+            // must not blank a system's panels until its replacement selection is known. A new
+            // inventory generation still clears them, in GetOrCreatePreviewDiscoveryAsync.
+            var selection = complete ? confirmed : system.PreviewGameIds;
+            var completedGeneration = complete ? inventoryGeneration : null;
+            var selectionChanged = !system.PreviewGameIds.SequenceEqual(selection, StringComparer.Ordinal) ||
+                !string.Equals(system.PreviewSelectionGeneration, completedGeneration, StringComparison.Ordinal);
+            if (selectionChanged)
             {
-                system.PreviewGameIds = confirmed;
+                system.PreviewGameIds = selection;
+                system.PreviewSelectionGeneration = completedGeneration;
                 system.Generation++;
+            }
+
+            if (scanProgressed || selectionChanged)
+            {
                 await MarkDirtyUnsafeAsync(library, cancellationToken).ConfigureAwait(false);
             }
 
-            return Snapshot(system);
+            return Snapshot(system) with { NextUnresolvedGameId = nextUnresolvedGameId };
         }
         finally
         {
@@ -995,9 +1126,11 @@ public sealed class GameArtworkCatalog
                 entry = NewPending(key, systemId);
             }
 
+            var before = entry;
             entry = update(entry);
             library.SetEntry(key.StorageKey, entry);
             BumpSystemGeneration(library.Document, systemId);
+            InvalidatePreviewScanIfReopened(library.Document, before.SystemId, before, entry);
             await MarkDirtyUnsafeAsync(library, cancellationToken).ConfigureAwait(false);
             return entry;
         }
@@ -1245,10 +1378,94 @@ public sealed class GameArtworkCatalog
         system.Generation++;
     }
 
+    /// <summary>How the preview scan treats one candidate's current boxart entry.</summary>
+    private enum PreviewCandidateOutcome
+    {
+        NonTerminal,
+        Confirmed,
+        TerminalSkip,
+    }
+
+    /// <summary>Mirrors the classification the preview scan loop applies to a boxart entry.</summary>
+    private static PreviewCandidateOutcome ClassifyForPreviewScan(ArtworkCatalogEntry? entry)
+    {
+        if (entry == null)
+        {
+            return PreviewCandidateOutcome.NonTerminal;
+        }
+
+        return entry.State switch
+        {
+            ArtworkCatalogState.ThumbnailReady => PreviewCandidateOutcome.Confirmed,
+            ArtworkCatalogState.OriginalReady when !string.IsNullOrWhiteSpace(entry.OriginalPath) => PreviewCandidateOutcome.Confirmed,
+            ArtworkCatalogState.Missing or ArtworkCatalogState.MetadataDeferred => PreviewCandidateOutcome.TerminalSkip,
+            _ => PreviewCandidateOutcome.NonTerminal,
+        };
+    }
+
+    private static ArtworkCatalogEntry RepairMissingArtifact(ArtworkCatalogEntry entry)
+    {
+        var originalExists = !string.IsNullOrWhiteSpace(entry.OriginalPath) && File.Exists(entry.OriginalPath);
+        if (entry.State == ArtworkCatalogState.OriginalReady)
+        {
+            return originalExists
+                ? entry
+                : NewPending(entry.Key, entry.SystemId, entry.Revision, entry.GameId);
+        }
+
+        var thumbnailExists = !string.IsNullOrWhiteSpace(entry.ThumbnailPath) && File.Exists(entry.ThumbnailPath);
+        if (entry.State != ArtworkCatalogState.ThumbnailReady || thumbnailExists)
+        {
+            return entry;
+        }
+
+        return originalExists
+            ? entry with
+            {
+                State = ArtworkCatalogState.OriginalReady,
+                ThumbnailPath = null,
+                RetryAfterUtc = null,
+                Revision = entry.Revision + 1,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            }
+            : NewPending(entry.Key, entry.SystemId, entry.Revision, entry.GameId);
+    }
+
+    /// <summary>
+    /// Resets a resumable preview scan back to the start. Called wherever an entry mutation can
+    /// change a candidate the scan already classified as terminal -- a stale resume index would
+    /// then skip a candidate the panel selection needs to re-examine.
+    /// </summary>
+    private static void ResetPreviewScanProgress(PersistedCatalog document, string systemId)
+    {
+        if (document.Systems.TryGetValue(systemId, out var system))
+        {
+            system.PreviewScanStartIndex = 0;
+            system.PreviewScanConfirmedGameIds = new List<string>();
+        }
+    }
+
+    /// <summary>
+    /// Resets the scan only when a transition actually reopens a previously terminal entry: the
+    /// old state was terminal (confirmed or a durable skip) and its classification changed. A
+    /// non-terminal entry could never have been in a previously scanned prefix, and a terminal
+    /// entry keeping the same classification (e.g. OriginalReady -&gt; ThumbnailReady) is not a
+    /// reopening, so both are left alone to keep the common paths cheap.
+    /// </summary>
+    private static void InvalidatePreviewScanIfReopened(PersistedCatalog document, string systemId, ArtworkCatalogEntry before, ArtworkCatalogEntry after)
+    {
+        var previousOutcome = ClassifyForPreviewScan(before);
+        if (previousOutcome != PreviewCandidateOutcome.NonTerminal && previousOutcome != ClassifyForPreviewScan(after))
+        {
+            ResetPreviewScanProgress(document, systemId);
+        }
+    }
+
     private static ArtworkCatalogSystemSnapshot Snapshot(PersistedSystem system) =>
         new(system.SystemId, system.Generation, system.InventoryGeneration, system.PreviewGameIds.ToArray())
         {
             PreviewCandidateGameIds = system.PreviewCandidateGameIds.ToArray(),
+            PreviewSelectionGeneration = system.PreviewSelectionGeneration,
         };
 
     private static string NormalizeLibraryId(string libraryId) =>
@@ -1491,5 +1708,18 @@ public sealed class GameArtworkCatalog
         public List<string> PreviewGameIds { get; set; } = new();
 
         public List<string> PreviewCandidateGameIds { get; set; } = new();
+
+        public string? PreviewSelectionGeneration { get; set; }
+
+        /// <summary>
+        /// How far into <see cref="PreviewCandidateGameIds"/> every entry is proven terminal
+        /// (confirmed or a durable skip). Defaults to 0 -- an older catalog file without this field
+        /// simply scans from the start, which is still correct. See
+        /// <see cref="ResetPreviewScanProgress"/> for what invalidates it.
+        /// </summary>
+        public int PreviewScanStartIndex { get; set; }
+
+        /// <summary>Confirmed candidates found strictly before <see cref="PreviewScanStartIndex"/>.</summary>
+        public List<string> PreviewScanConfirmedGameIds { get; set; } = new();
     }
 }

--- a/Jellyfin/backend/Services/GameArtworkCatalog.cs
+++ b/Jellyfin/backend/Services/GameArtworkCatalog.cs
@@ -196,6 +196,8 @@ public sealed class GameArtworkCatalog
     /// </summary>
     private static readonly TimeSpan DefaultPersistDebounce = TimeSpan.FromSeconds(2);
 
+    private const string BoxartRole = "boxart";
+
     private readonly string _root;
     private readonly ILogger<GameArtworkCatalog>? _logger;
     private readonly TimeSpan _persistDebounce;
@@ -220,8 +222,27 @@ public sealed class GameArtworkCatalog
     /// <summary>Whole-document writes performed so far; the debounce's only observable effect.</summary>
     internal long DocumentWriteCount => Interlocked.Read(ref _documentWrites);
 
-    /// <summary>Boxart lookups performed by preview-selection scans; the resumable scan's observable cost.</summary>
+    /// <summary>Boxart lookups performed by preview-selection scans, the resumable scan's observable cost.</summary>
     internal long PreviewScanLookupCount => Interlocked.Read(ref _previewScanLookups);
+
+    /// <summary>Reads one system's persisted preview-scan checkpoint. Test seam.</summary>
+    internal async Task<int> PreviewScanStartIndexForTestsAsync(
+        string libraryId,
+        string systemId,
+        CancellationToken cancellationToken = default)
+    {
+        systemId = NormalizeSystemId(systemId);
+        var library = await GetLibraryAsync(NormalizeLibraryId(libraryId), cancellationToken).ConfigureAwait(false);
+        await library.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return library.Document.Systems.TryGetValue(systemId, out var system) ? system.PreviewScanStartIndex : -1;
+        }
+        finally
+        {
+            library.Gate.Release();
+        }
+    }
 
     /// <summary>
     /// Plugin-owned catalog directory. The reconciliation service uses its sibling artwork cache
@@ -287,9 +308,11 @@ public sealed class GameArtworkCatalog
                 entry.State == ArtworkCatalogState.MetadataDeferred &&
                 !string.Equals(entry.MetadataDeferredProviderVersion, providerVersion, StringComparison.Ordinal))
             {
-                // A durable miss/defer reopens to Pending -- a preview scan may have already
-                // counted this candidate as terminal.
+                // A durable miss or defer reopens to Pending, and a preview scan may have already
+                // counted this candidate as terminal. It reopens under the caller's systemId, which
+                // isn't always the one it was filed under, so both sides reset.
                 ResetPreviewScanProgress(library.Document, entry.SystemId);
+                ResetPreviewScanProgress(library.Document, systemId);
                 entry = NewPending(key, systemId, entry.Revision, gameId);
                 library.SetEntry(key.StorageKey, entry);
                 changed = true;
@@ -297,6 +320,10 @@ public sealed class GameArtworkCatalog
             else if ((gameId != null && !string.Equals(entry.GameId, gameId, StringComparison.Ordinal)) ||
                 !string.Equals(entry.SystemId, systemId, StringComparison.Ordinal))
             {
+                // The entry leaves one candidate list and joins another, so no resume index that
+                // counted it still lines up.
+                ResetPreviewScanProgress(library.Document, entry.SystemId);
+                ResetPreviewScanProgress(library.Document, systemId);
                 entry = entry with { GameId = gameId ?? entry.GameId, SystemId = systemId };
                 library.SetEntry(key.StorageKey, entry);
                 changed = true;
@@ -516,8 +543,15 @@ public sealed class GameArtworkCatalog
             if (!string.IsNullOrWhiteSpace(removed.GameId) &&
                 library.Document.Systems.TryGetValue(systemId, out var system))
             {
-                system.PreviewGameIds = system.PreviewGameIds
+                var remaining = system.PreviewGameIds
                     .Where(id => !string.Equals(id, removed.GameId, StringComparison.Ordinal)).ToList();
+                if (remaining.Count != system.PreviewGameIds.Count)
+                {
+                    // The published selection is a panel short now, so it isn't the final answer
+                    // for its generation any more.
+                    system.PreviewGameIds = remaining;
+                    system.PreviewSelectionGeneration = null;
+                }
             }
 
             ResetPreviewScanProgress(library.Document, systemId);
@@ -787,7 +821,7 @@ public sealed class GameArtworkCatalog
 
                 library.SetEntry(storageKey, updated);
                 InvalidatePreviewScanIfReopened(library.Document, entry.SystemId, entry, updated);
-                if (entry.Key.Role == "boxart" &&
+                if (entry.Key.Role == BoxartRole &&
                     !string.IsNullOrWhiteSpace(entry.GameId) &&
                     ClassifyForPreviewScan(updated) == PreviewCandidateOutcome.NonTerminal &&
                     library.Document.Systems.TryGetValue(entry.SystemId, out var system))
@@ -894,7 +928,18 @@ public sealed class GameArtworkCatalog
                     library.SetEntry(item.Key.StorageKey, updated);
                     affectedSystems.Add(existing.SystemId);
                     affectedSystems.Add(item.SystemId);
-                    InvalidatePreviewScanIfReopened(library.Document, existing.SystemId, existing, updated);
+                    if (!string.Equals(existing.GameId, updated.GameId, StringComparison.Ordinal) ||
+                        !string.Equals(existing.SystemId, updated.SystemId, StringComparison.Ordinal))
+                    {
+                        // An identity move is invisible to a state comparison, and it leaves one
+                        // candidate list and joins another, so both sides reset.
+                        ResetPreviewScanProgress(library.Document, existing.SystemId);
+                        ResetPreviewScanProgress(library.Document, updated.SystemId);
+                    }
+                    else
+                    {
+                        InvalidatePreviewScanIfReopened(library.Document, existing.SystemId, existing, updated);
+                    }
                 }
             }
 
@@ -1008,7 +1053,7 @@ public sealed class GameArtworkCatalog
             while (scanIndex < candidates.Count && confirmed.Count < 4)
             {
                 var gameId = candidates[scanIndex];
-                var outcome = ClassifyForPreviewScan(library.FindByGameRole(gameId, "boxart"));
+                var outcome = ClassifyForPreviewScan(library.FindByGameRole(gameId, BoxartRole));
                 Interlocked.Increment(ref _previewScanLookups);
                 if (outcome == PreviewCandidateOutcome.Confirmed)
                 {
@@ -1433,8 +1478,8 @@ public sealed class GameArtworkCatalog
 
     /// <summary>
     /// Resets a resumable preview scan back to the start. Called wherever an entry mutation can
-    /// change a candidate the scan already classified as terminal -- a stale resume index would
-    /// then skip a candidate the panel selection needs to re-examine.
+    /// change a candidate the scan already classified as terminal, since a stale resume index
+    /// would then skip a candidate the panel selection needs to re-examine.
     /// </summary>
     private static void ResetPreviewScanProgress(PersistedCatalog document, string systemId)
     {
@@ -1713,7 +1758,7 @@ public sealed class GameArtworkCatalog
 
         /// <summary>
         /// How far into <see cref="PreviewCandidateGameIds"/> every entry is proven terminal
-        /// (confirmed or a durable skip). Defaults to 0 -- an older catalog file without this field
+        /// (confirmed or a durable skip). Defaults to 0, so an older catalog file without this field
         /// simply scans from the start, which is still correct. See
         /// <see cref="ResetPreviewScanProgress"/> for what invalidates it.
         /// </summary>

--- a/Jellyfin/backend/Services/GameArtworkReconciliationService.cs
+++ b/Jellyfin/backend/Services/GameArtworkReconciliationService.cs
@@ -17,6 +17,7 @@ namespace Moonfin.Server.Services;
 public sealed class GameArtworkReconciliationService : IHostedService
 {
     private static readonly TimeSpan LibraryFileSystemQuietPeriod = TimeSpan.FromSeconds(5);
+    private long _lastWatcherOverflowWarningTicks = long.MinValue / 2;
 
     // v3 repairs false terminal misses caused by RDB and thumbnail alternate-title separators.
     private const string ProviderVersion = "libretro-thumbnails-v3";
@@ -30,25 +31,40 @@ public sealed class GameArtworkReconciliationService : IHostedService
     private static readonly TimeSpan MetadataFirstRetryDelay = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan MetadataRepeatRetryDelay = TimeSpan.FromHours(3);
     private static readonly TimeSpan MetadataRetryWindow = TimeSpan.FromHours(24);
-    private const int MaxQueuedRemoteWork = 20_000;
+    // Bulk and interactive acquisition are best-effort at this threshold. One unresolved preview
+    // per incomplete system may exceed it so preview discovery can never be stranded by admission.
+    private const int MaxQueuedBestEffortRemoteWork = 20_000;
     private const int MaxQueuedThumbnailWork = 20_000;
+
+    // Bounded well below the encode gate on large hosts: artwork backfill is background work
+    // sharing a box with playback and transcoding, and only two downloaders feed it, so more
+    // encoders buy nothing. On the NAS-class hardware Jellyfin often runs on this resolves to
+    // 1-2 -- i.e. unchanged from the single worker it replaces.
+    private const int MaxThumbnailWorkers = 4;
+
+    private static readonly TimeSpan WorkerStopGrace = TimeSpan.FromSeconds(10);
+
+    private static int ThumbnailWorkerCount =>
+        Math.Clamp(DerivedThumbnailService.DefaultEncodeConcurrency, 1, MaxThumbnailWorkers);
     private readonly GamesService _games;
     private readonly GameThumbService _thumbs;
     private readonly GameArtworkCatalog _catalog;
     private readonly ILogger<GameArtworkReconciliationService> _logger;
     private readonly ITaskManager? _taskManager;
     private readonly bool _watchLibraryFileSystem;
+    private readonly TimeSpan _workerStopGrace;
     private readonly ArtworkWorkScheduler _remote = new();
     private readonly ConcurrentQueue<ArtworkWork> _thumbnail = new();
     private readonly SemaphoreSlim _thumbnailAvailable = new(0);
     private readonly object _remoteQueueGate = new();
+    private readonly object _thumbnailQueueGate = new();
+    private readonly object _lifecycleGate = new();
     private readonly Dictionary<string, QueuedRemoteWork> _queued = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, byte> _thumbnailQueued = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, PreviewPlan> _previewPlans = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _thumbnailQueued = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _reconciliationAvailable = new(0, 1);
     private CancellationTokenSource? _stop;
     private Task[] _remoteWorkers = Array.Empty<Task>();
-    private Task? _thumbnailWorker;
+    private Task[] _thumbnailWorkers = Array.Empty<Task>();
     private Task? _reconciliationWorker;
     private readonly Dictionary<string, FileSystemWatcher> _libraryWatchers = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _libraryWatcherLock = new();
@@ -56,6 +72,9 @@ public sealed class GameArtworkReconciliationService : IHostedService
     private Timer? _libraryWatcherDebounce;
     private bool _startupRecoveryDone;
     private int _reopenMetadataDeferred;
+    private int _nextRemoteQueueVersion;
+    private int _nextThumbnailQueueVersion;
+    private Task _shutdownCleanup = Task.CompletedTask;
 
     /// <param name="games">Resolves game libraries/systems/games from the filesystem.</param>
     /// <param name="thumbs">Looks up and derives artwork thumbnails.</param>
@@ -83,7 +102,10 @@ public sealed class GameArtworkReconciliationService : IHostedService
         GameArtworkCatalog catalog,
         ILogger<GameArtworkReconciliationService> logger,
         ITaskManager? taskManager,
-        bool watchLibraryFileSystem)
+        bool watchLibraryFileSystem,
+        // The grace exists so a wedged worker cannot strand restart; a test drives it with
+        // milliseconds rather than waiting out the production value.
+        TimeSpan? workerStopGraceForTests = null)
     {
         _games = games;
         _thumbs = thumbs;
@@ -91,6 +113,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
         _logger = logger;
         _taskManager = taskManager;
         _watchLibraryFileSystem = watchLibraryFileSystem;
+        _workerStopGrace = workerStopGraceForTests ?? WorkerStopGrace;
     }
 
     /// <summary>
@@ -110,7 +133,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
         }
 
         await _catalog.RequestRefreshAsync(candidate.Key, candidate.SystemId, candidate.GameId, cancellationToken).ConfigureAwait(false);
-        QueueRemote(candidate, ArtworkLane.Interactive, null, null);
+        QueueRemote(candidate, ArtworkLane.Interactive, null);
         return true;
     }
 
@@ -156,7 +179,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
         }
         else if (entry.State is ArtworkCatalogState.Pending or ArtworkCatalogState.Retryable)
         {
-            QueueRemote(candidate, ArtworkLane.Interactive, null, entry.RetryAfterUtc);
+            QueueRemote(candidate, ArtworkLane.Interactive, entry.RetryAfterUtc);
         }
 
         return true;
@@ -332,88 +355,212 @@ public sealed class GameArtworkReconciliationService : IHostedService
     /// <see cref="RequestRefreshAsync"/>, one of the <c>PromoteAsync</c> overloads, or
     /// <see cref="ReconcileAsync"/>.
     /// </summary>
-    internal void EnqueueRemoteForTest(ArtworkCandidate candidate) => QueueRemote(candidate, ArtworkLane.Interactive, null, null);
+    internal bool EnqueueRemoteForTest(
+        ArtworkCandidate candidate,
+        ArtworkLane lane = ArtworkLane.Interactive,
+        DateTimeOffset? notBefore = null) =>
+        QueueRemote(candidate, lane, notBefore);
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _stop = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var token = _stop.Token;
-        // Do not call ILibraryManager.AddParts here, and do not implement ILibraryPostScanTask to
-        // register a post-scan hook through it. AddParts assigns wholesale rather than appending
-        // (see Emby.Server.Implementations.Library.LibraryManager.AddParts) -- Jellyfin calls it
-        // exactly once at startup with every discovered resolver/rule/comparer export, and a plugin
-        // calling it again afterwards replaces that with only what the plugin itself passed in,
-        // wiping every other library's ability to resolve files into items. Reconciliation is
-        // therefore driven by the startup queue below plus a subscription to
-        // ITaskManager.TaskCompleted (see OnTaskCompleted): that is a plain event handler `+=` on a
-        // DI singleton, not a library-manager mutation, so it carries none of the AddParts risk.
-        //
-        // Per-library scans bypass TaskCompleted; ROM-root watchers cover their raw-file changes.
-        _remoteWorkers = Enumerable.Range(0, 2).Select(_ => Task.Run(() => RemoteWorkerAsync(token), token)).ToArray();
-        _thumbnailWorker = Task.Run(() => ThumbnailWorkerAsync(token), token);
-        _reconciliationWorker = Task.Run(() => ReconciliationWorkerAsync(token), token);
-        _thumbs.MetadataIndexAvailable += OnMetadataIndexAvailable;
-        if (_taskManager != null)
+        while (true)
         {
-            _taskManager.TaskCompleted += OnTaskCompleted;
-        }
-        else
-        {
-            // File-system events still cover ROM changes, but scheduled refreshes will not.
-            _logger.LogWarning(
-                "No task manager was supplied to game artwork reconciliation; scheduled library refreshes will not signal artwork reconciliation");
-        }
+            Task priorCleanup;
+            var started = false;
+            lock (_lifecycleGate)
+            {
+                if (_stop is { IsCancellationRequested: false })
+                {
+                    return;
+                }
 
-        QueueReconciliation("plugin startup");
-        return Task.CompletedTask;
+                priorCleanup = _shutdownCleanup;
+                if (_stop == null && priorCleanup.IsCompleted)
+                {
+                    // Do not call ILibraryManager.AddParts here. It replaces Jellyfin's complete
+                    // resolver set instead of appending, so reconciliation is driven by the task
+                    // completion event and ROM-root watchers without mutating library parts.
+                    _stop = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    var token = _stop.Token;
+                    _remoteWorkers = Enumerable.Range(0, 2).Select(_ => Task.Run(() => RemoteWorkerAsync(token), token)).ToArray();
+                    // One worker could never reach the concurrency the encode gate already
+                    // allows, so downloads outran encoding and left a backlog in OriginalReady.
+                    _thumbnailWorkers = Enumerable.Range(0, ThumbnailWorkerCount)
+                        .Select(_ => Task.Run(() => ThumbnailWorkerAsync(token), token)).ToArray();
+                    _reconciliationWorker = Task.Run(() => ReconciliationWorkerAsync(token), token);
+                    _thumbs.MetadataIndexAvailable += OnMetadataIndexAvailable;
+                    if (_taskManager != null)
+                    {
+                        _taskManager.TaskCompleted += OnTaskCompleted;
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "No task manager was supplied to game artwork reconciliation; scheduled library refreshes will not signal artwork reconciliation");
+                    }
+
+                    started = true;
+                }
+            }
+
+            if (started)
+            {
+                QueueReconciliation("plugin startup");
+                return;
+            }
+
+            await priorCleanup.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        _thumbs.MetadataIndexAvailable -= OnMetadataIndexAvailable;
-        if (_taskManager != null)
+        Task cleanup;
+        CancellationTokenSource? stop = null;
+        TaskCompletionSource? cleanupCompletion = null;
+        lock (_lifecycleGate)
         {
-            _taskManager.TaskCompleted -= OnTaskCompleted;
+            if (_stop is { IsCancellationRequested: false } activeStop)
+            {
+                stop = activeStop;
+                cleanupCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                cleanup = cleanupCompletion.Task;
+                _shutdownCleanup = cleanup;
+                stop.Cancel();
+            }
+            else
+            {
+                cleanup = _shutdownCleanup;
+            }
         }
 
-        if (_stop == null)
+        if (stop != null)
         {
-            return;
+            _thumbs.MetadataIndexAvailable -= OnMetadataIndexAvailable;
+            if (_taskManager != null)
+            {
+                _taskManager.TaskCompleted -= OnTaskCompleted;
+            }
+
+            CancelLibraryWatcherDebounce();
+            StopLibraryWatchers();
+            if (_remoteWorkers.Length > 0)
+            {
+                _remote.Available.Release(_remoteWorkers.Length);
+            }
+
+            if (_thumbnailWorkers.Length > 0)
+            {
+                _thumbnailAvailable.Release(_thumbnailWorkers.Length);
+            }
+
+            TrySignalReconciliation();
+            var workers = _remoteWorkers.Concat(_thumbnailWorkers).Concat(new[] { _reconciliationWorker }.OfType<Task>());
+            _ = CompleteStopAsync(stop, Task.WhenAll(workers), cleanupCompletion!);
         }
 
-        _stop.Cancel();
-        CancelLibraryWatcherDebounce();
-        StopLibraryWatchers();
-        _remote.Available.Release(_remoteWorkers.Length);
-        _thumbnailAvailable.Release();
-        TrySignalReconciliation();
-        var workers = _remoteWorkers.Concat(new[] { _thumbnailWorker, _reconciliationWorker }.OfType<Task>());
         try
         {
-            await Task.WhenAll(workers).WaitAsync(cancellationToken).ConfigureAwait(false);
+            await cleanup.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Expected: _stop.Cancel() above is exactly how these workers are asked to exit. Each
-            // worker loop now catches its own cancellation and returns cleanly, but this stays as a
-            // safety net for the WaitAsync(cancellationToken) call itself.
+            // Cleanup continues independently; StartAsync waits for it before creating new workers.
+        }
+    }
+
+    private async Task CompleteStopAsync(
+        CancellationTokenSource stop,
+        Task workersStopped,
+        TaskCompletionSource completion)
+    {
+        try
+        {
+            await FinishStopAsync(stop, workersStopped).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Completed rather than faulted: every later StartAsync awaits this same task, so a
+            // faulted cleanup would leave the service permanently unstartable.
+            _logger.LogWarning(ex, "Cleaning up after game artwork reconciliation shutdown failed");
         }
         finally
         {
-            _stop.Dispose();
-            _stop = null;
+            completion.TrySetResult();
+        }
+    }
 
-            // The workers have stopped, so nothing can dirty the catalog after this point. Catalog
-            // writes are debounced; paying one write per library here is what keeps a clean
-            // shutdown from discarding the last window of state transitions.
-            try
+    private async Task FinishStopAsync(CancellationTokenSource stop, Task workersStopped)
+    {
+        var workersQuiesced = false;
+        try
+        {
+            // Bounded: a worker parked in a non-cancelable call (a filesystem operation on a dead
+            // NAS mount) would otherwise never complete, and every later StartAsync waits on this
+            // cleanup -- so an unbounded wait here makes one wedged worker permanently unstartable.
+            // A straggler keeps its canceled lifetime token; queue versions and lifetime checks
+            // prevent it from publishing into the replacement lifetime.
+            await workersStopped.WaitAsync(_workerStopGrace).ConfigureAwait(false);
+            workersQuiesced = true;
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning(
+                "A game artwork worker did not stop within {Seconds}s; cleaning up without it",
+                _workerStopGrace.TotalSeconds);
+        }
+        catch (OperationCanceledException)
+        {
+            // A canceled worker is stopped and therefore safe to clean up.
+            workersQuiesced = true;
+        }
+        catch (Exception ex)
+        {
+            // Task.WhenAll only faults after every worker has finished.
+            workersQuiesced = true;
+            _logger.LogWarning(ex, "A game artwork worker failed while stopping");
+        }
+        finally
+        {
+            lock (_remoteQueueGate)
             {
-                await _catalog.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                _queued.Clear();
+                _remote.Clear();
             }
-            catch (Exception ex)
+
+            lock (_thumbnailQueueGate)
             {
-                // Shutdown must not fault: the lost state is re-derivable by startup recovery.
-                _logger.LogWarning(ex, "Flushing the game artwork catalog during shutdown failed");
+                _thumbnail.Clear();
+                _thumbnailQueued.Clear();
+                while (_thumbnailAvailable.Wait(0))
+                {
+                    // Late delayed work rechecks this cleared identity before publishing a permit.
+                }
+            }
+
+            _startupRecoveryDone = false;
+            stop.Dispose();
+            lock (_lifecycleGate)
+            {
+                if (ReferenceEquals(_stop, stop))
+                {
+                    _stop = null;
+                }
+            }
+
+            // Never wait on a catalog gate that an abandoned worker may still hold. Its state is
+            // re-derived by startup recovery and the next reconciliation pass.
+            if (workersQuiesced)
+            {
+                try
+                {
+                    await _catalog.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Shutdown must not fault: the lost state is re-derivable by startup recovery.
+                    _logger.LogWarning(ex, "Flushing the game artwork catalog during shutdown failed");
+                }
             }
         }
     }
@@ -461,9 +608,9 @@ public sealed class GameArtworkReconciliationService : IHostedService
     /// startup, a library location changed outside Moonfin's own configuration page, or a watcher
     /// whose construction threw.
     /// </summary>
-    private void SyncLibraryWatchers()
+    private void SyncLibraryWatchers(CancellationToken lifetimeToken)
     {
-        if (!_watchLibraryFileSystem || _stop is not { IsCancellationRequested: false })
+        if (!_watchLibraryFileSystem || lifetimeToken.IsCancellationRequested)
         {
             return;
         }
@@ -485,9 +632,9 @@ public sealed class GameArtworkReconciliationService : IHostedService
 
         lock (_libraryWatcherLock)
         {
-            // Root resolution above can block in Jellyfin's library manager. StopAsync may cancel
-            // the service and dispose every watcher while that work is in progress.
-            if (_stop is not { IsCancellationRequested: false })
+            // Root resolution can outlive shutdown. Check this worker's token rather than _stop,
+            // which may already belong to a replacement lifetime.
+            if (lifetimeToken.IsCancellationRequested)
             {
                 return;
             }
@@ -512,6 +659,10 @@ public sealed class GameArtworkReconciliationService : IHostedService
                     {
                         IncludeSubdirectories = true,
                         NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+
+                        // The 8 KB default overflows within a second of a romset copy. 64 KB is the
+                        // documented maximum; overflow is still handled, just made rarer.
+                        InternalBufferSize = 64 * 1024,
                         EnableRaisingEvents = true,
                     };
                     watcher.Created += OnLibraryFileSystemChanged;
@@ -608,8 +759,64 @@ public sealed class GameArtworkReconciliationService : IHostedService
 
     private void OnLibraryWatcherError(object sender, ErrorEventArgs e)
     {
-        _logger.LogWarning(e.GetException(), "Game-library watcher overflowed; reconciling artwork catalog");
-        QueueReconciliation("game-library watcher error");
+        var error = e.GetException();
+        var watcher = sender as FileSystemWatcher;
+
+        if (error is InternalBufferOverflowException && watcher is { EnableRaisingEvents: true })
+        {
+            // Only events were lost; the watcher itself keeps working. A romset copy raises this
+            // many times a second, so one warning per quiet period explains the reconcile without
+            // burying the rest of the log.
+            if (ShouldWarnAboutWatcherOverflow())
+            {
+                _logger.LogWarning(error, "Game-library watcher overflowed; reconciling artwork catalog");
+            }
+        }
+        else
+        {
+            // Unlike overflow this leaves a watcher that never reports again, and SyncLibraryWatchers
+            // skips any root it still holds, so the root would go unwatched until a restart.
+            _logger.LogWarning(error, "Game-library watcher failed; recreating it and reconciling artwork catalog");
+            RecycleLibraryWatcher(watcher);
+        }
+
+        // Debounced like an ordinary change: queueing directly ran a full library enumeration back
+        // to back for the length of an import. The pass is still guaranteed, because this call arms
+        // the timer itself.
+        DebounceLibraryFileSystemReconciliation();
+    }
+
+    private bool ShouldWarnAboutWatcherOverflow()
+    {
+        var now = DateTime.UtcNow.Ticks;
+        var previous = Interlocked.Read(ref _lastWatcherOverflowWarningTicks);
+        return now - previous >= LibraryFileSystemQuietPeriod.Ticks
+            && Interlocked.CompareExchange(ref _lastWatcherOverflowWarningTicks, now, previous) == previous;
+    }
+
+    /// <summary>
+    /// Drops a watcher that can no longer report, so the next <see cref="SyncLibraryWatchers"/>
+    /// treats its root as unwatched and builds a replacement.
+    /// </summary>
+    private void RecycleLibraryWatcher(FileSystemWatcher? watcher)
+    {
+        if (watcher == null)
+        {
+            return;
+        }
+
+        lock (_libraryWatcherLock)
+        {
+            foreach (var root in _libraryWatchers
+                .Where(entry => ReferenceEquals(entry.Value, watcher))
+                .Select(entry => entry.Key)
+                .ToList())
+            {
+                _libraryWatchers.Remove(root);
+            }
+        }
+
+        watcher.Dispose();
     }
 
     private void TrySignalReconciliation()
@@ -635,7 +842,8 @@ public sealed class GameArtworkReconciliationService : IHostedService
 
                 // Before scanning, not after: a root added since the last pass must be watched and
                 // scanned in the same pass, or its ROMs wait for the pass after next.
-                SyncLibraryWatchers();
+                SyncLibraryWatchers(cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
                 var reopenMetadataDeferred = Interlocked.Exchange(ref _reopenMetadataDeferred, 0) != 0;
                 await ReconcileAsync(cancellationToken, reopenMetadataDeferred).ConfigureAwait(false);
             }
@@ -660,6 +868,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
             if (!_startupRecoveryDone)
             {
                 recovery = await _catalog.GetStartupRecoveryWorkAsync(cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
 
                 // Latched only after the read succeeds. Latching first would let one failed or
                 // cancelled startup pass strand the recoverable jobs until the next process start,
@@ -691,9 +900,31 @@ public sealed class GameArtworkReconciliationService : IHostedService
                     library.Id,
                     reconciledSystems.SelectMany(item => item.All).Select(candidate => candidate.Key),
                     cancellationToken).ConfigureAwait(false);
-                foreach (var path in orphaned.Where(IsManagedArtworkPath))
+                var deletable = orphaned.Where(IsManagedArtworkPath).ToList();
+                if (deletable.Count > 0)
+                {
+                    // Deleting cached artwork is the one destructive thing reconciliation does and
+                    // it was previously silent, which made a mass loss impossible to attribute.
+                    _logger.LogWarning(
+                        "Deleting {Count} orphaned game artwork files for library {LibraryId} (of {Orphaned} reported); first: {Sample}",
+                        deletable.Count,
+                        library.Id,
+                        orphaned.Count,
+                        string.Join(", ", deletable.Take(3)));
+                }
+
+                foreach (var path in deletable)
                 {
                     try { File.Delete(path); } catch (Exception ex) { _logger.LogDebug(ex, "Removing orphaned game artwork {Path} failed", path); }
+                }
+
+                var repaired = await _catalog.RepairMissingArtifactsAsync(library.Id, cancellationToken).ConfigureAwait(false);
+                if (repaired > 0)
+                {
+                    _logger.LogWarning(
+                        "Reopened {Count} game artwork entries whose cached files were missing for library {LibraryId}",
+                        repaired,
+                        library.Id);
                 }
 
                 foreach (var (system, allCandidates, candidates) in reconciledSystems)
@@ -727,23 +958,23 @@ public sealed class GameArtworkReconciliationService : IHostedService
                         .Cast<ArtworkCandidate>()
                         .ToArray();
 
-                    if (discovery.PreviewGameIds.Count == 0)
+                    discovery = await _catalog.RecomputePreviewSelectionAsync(
+                        library.Id,
+                        candidates[0].SystemId,
+                        inventoryGeneration,
+                        cancellationToken).ConfigureAwait(false);
+                    var selectionComplete = string.Equals(
+                        discovery.PreviewSelectionGeneration,
+                        inventoryGeneration,
+                        StringComparison.Ordinal);
+                    var previewQueued = selectionComplete;
+                    foreach (var candidate in ordered)
                     {
-                        var plan = new PreviewPlan(library.Id, candidates[0].SystemId, inventoryGeneration, ordered);
-                        if (_previewPlans.TryAdd(plan.Identity, plan))
+                        var lane = previewQueued ? ArtworkLane.Bulk : ArtworkLane.Preview;
+                        if (await QueueCandidateAsync(candidate, lane, cancellationToken, reopenMetadataDeferred).ConfigureAwait(false) &&
+                            lane == ArtworkLane.Preview)
                         {
-                            var first = plan.TakeNext();
-                            if (first != null)
-                            {
-                                await QueueCandidateAsync(first, ArtworkLane.Preview, plan, cancellationToken, reopenMetadataDeferred).ConfigureAwait(false);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        foreach (var candidate in ordered)
-                        {
-                            await QueueCandidateAsync(candidate, ArtworkLane.Bulk, null, cancellationToken, reopenMetadataDeferred).ConfigureAwait(false);
+                            previewQueued = true;
                         }
                     }
                 }
@@ -752,10 +983,9 @@ public sealed class GameArtworkReconciliationService : IHostedService
             await EnqueueRecoveryAsync(recovery, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task QueueCandidateAsync(
+    private async Task<bool> QueueCandidateAsync(
         ArtworkCandidate candidate,
         ArtworkLane lane,
-        PreviewPlan? preview,
         CancellationToken cancellationToken,
         bool reopenMetadataDeferred = false)
     {
@@ -768,15 +998,12 @@ public sealed class GameArtworkReconciliationService : IHostedService
         switch (entry.State)
         {
             case ArtworkCatalogState.ThumbnailReady:
-                await AdvancePreviewAsync(preview, candidate, true, cancellationToken).ConfigureAwait(false);
-                break;
+                return false;
             case ArtworkCatalogState.OriginalReady when !string.IsNullOrWhiteSpace(entry.OriginalPath):
                 QueueThumbnail(candidate with { OriginalPath = entry.OriginalPath }, entry.RetryAfterUtc);
-                await AdvancePreviewAsync(preview, candidate, true, cancellationToken).ConfigureAwait(false);
-                break;
+                return false;
             case ArtworkCatalogState.Missing:
-                await AdvancePreviewAsync(preview, candidate, false, cancellationToken).ConfigureAwait(false);
-                break;
+                return false;
             case ArtworkCatalogState.MetadataDeferred:
                 if (reopenMetadataDeferred)
                 {
@@ -785,16 +1012,11 @@ public sealed class GameArtworkReconciliationService : IHostedService
                         candidate.SystemId,
                         candidate.GameId,
                         cancellationToken).ConfigureAwait(false);
-                    QueueRemote(candidate, lane, preview, null);
+                    return QueueRemote(candidate, lane, null);
                 }
-                else
-                {
-                    await AdvancePreviewAsync(preview, candidate, false, cancellationToken).ConfigureAwait(false);
-                }
-                break;
+                return false;
             default:
-                QueueRemote(candidate, lane, preview, entry.RetryAfterUtc);
-                break;
+                return QueueRemote(candidate, lane, entry.RetryAfterUtc);
         }
     }
 
@@ -823,7 +1045,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
             }
             else if (item.Stage == ArtworkCatalogWorkStage.AcquireOriginal)
             {
-                QueueRemote(candidate, ArtworkLane.Bulk, null, item.NotBeforeUtc);
+                QueueRemote(candidate, ArtworkLane.Bulk, item.NotBeforeUtc);
             }
         }
 
@@ -889,13 +1111,13 @@ public sealed class GameArtworkReconciliationService : IHostedService
                         }
 
                         await _catalog.MarkMissingAsync(work.Candidate.Key, work.Candidate.SystemId, ProviderVersion, cancellationToken).ConfigureAwait(false);
-                        await AdvancePreviewAsync(work.Preview, work.Candidate, false, cancellationToken).ConfigureAwait(false);
+                        await RefreshPreviewSelectionAsync(work.Candidate, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     await _catalog.MarkOriginalReadyAsync(work.Candidate.Key, work.Candidate.SystemId, original, cancellationToken).ConfigureAwait(false);
                     QueueThumbnail(work.Candidate with { OriginalPath = original });
-                    await AdvancePreviewAsync(work.Preview, work.Candidate, true, cancellationToken).ConfigureAwait(false);
+                    await RefreshPreviewSelectionAsync(work.Candidate, cancellationToken).ConfigureAwait(false);
                 }
                 catch (ThumbLookupTimedOutException)
                 {
@@ -946,7 +1168,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
         var retryAfter = DateTimeOffset.UtcNow.Add(delay);
         await _catalog.MarkRetryableAsync(work.Candidate.Key, work.Candidate.SystemId, ArtworkCatalogWorkStage.AcquireOriginal, retryAfter, cancellationToken).ConfigureAwait(false);
         CompleteRemote(work);
-        QueueRemote(work.Candidate, work.Lane, work.Preview, retryAfter);
+        QueueRemote(work.Candidate, work.Lane, retryAfter);
     }
 
     private async Task DeferMetadataAsync(ArtworkWork work, CancellationToken cancellationToken)
@@ -967,7 +1189,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
                 "Deferring artwork for {GameId} until {RetryAfterUtc} while its metadata index is pending",
                 work.Candidate.GameId,
                 scheduled);
-            QueueRemote(work.Candidate, work.Lane, work.Preview, scheduled);
+            QueueRemote(work.Candidate, work.Lane, scheduled);
         }
         else
         {
@@ -975,7 +1197,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
                 "Stopped automatic metadata retries for {GameId} after the {Hours}-hour retry window",
                 work.Candidate.GameId,
                 MetadataRetryWindow.TotalHours);
-            await AdvancePreviewAsync(work.Preview, work.Candidate, false, cancellationToken).ConfigureAwait(false);
+            await RefreshPreviewSelectionAsync(work.Candidate, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -987,6 +1209,11 @@ public sealed class GameArtworkReconciliationService : IHostedService
             {
                 await _thumbnailAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
                 if (!_thumbnail.TryDequeue(out var work))
+                {
+                    continue;
+                }
+
+                if (!IsCurrentThumbnailWork(work))
                 {
                     continue;
                 }
@@ -1003,7 +1230,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
                         // original forever.
                         var retryAfter = DateTimeOffset.UtcNow.Add(RetryDelay);
                         await _catalog.MarkRetryableAsync(work.Candidate.Key, work.Candidate.SystemId, ArtworkCatalogWorkStage.DeriveThumbnail, retryAfter, cancellationToken).ConfigureAwait(false);
-                        _thumbnailQueued.TryRemove(work.Identity, out _);
+                        CompleteThumbnail(work);
                         QueueThumbnail(work.Candidate, retryAfter);
                         retryQueued = true;
                     }
@@ -1021,7 +1248,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
                     _logger.LogDebug(ex, "Artwork thumbnail generation failed for {GameId}", work.Candidate.GameId);
                     var retryAfter = DateTimeOffset.UtcNow.Add(RetryDelay);
                     await _catalog.MarkRetryableAsync(work.Candidate.Key, work.Candidate.SystemId, ArtworkCatalogWorkStage.DeriveThumbnail, retryAfter, cancellationToken).ConfigureAwait(false);
-                    _thumbnailQueued.TryRemove(work.Identity, out _);
+                    CompleteThumbnail(work);
                     QueueThumbnail(work.Candidate, retryAfter);
                     retryQueued = true;
                 }
@@ -1029,7 +1256,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
                 {
                     if (!retryQueued)
                     {
-                        _thumbnailQueued.TryRemove(work.Identity, out _);
+                        CompleteThumbnail(work);
                     }
                 }
             }
@@ -1053,56 +1280,79 @@ public sealed class GameArtworkReconciliationService : IHostedService
         }
     }
 
-    private async Task AdvancePreviewAsync(PreviewPlan? plan, ArtworkCandidate candidate, bool artworkFound, CancellationToken cancellationToken)
+    private async Task RefreshPreviewSelectionAsync(ArtworkCandidate candidate, CancellationToken cancellationToken)
     {
-        if (plan == null)
+        if (candidate.Kind != GameThumbService.ThumbKind.Boxart)
         {
             return;
         }
 
-        var next = plan.Complete(candidate, artworkFound, out var confirmed, out var bulkRemainder);
-        if (confirmed != null)
+        var system = await _catalog.GetSystemAsync(
+            candidate.Key.LibraryId,
+            candidate.SystemId,
+            cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(system.InventoryGeneration))
         {
-            await _catalog.CommitPreviewSelectionAsync(plan.LibraryId, plan.SystemId, plan.InventoryGeneration, confirmed, cancellationToken).ConfigureAwait(false);
-            _previewPlans.TryRemove(plan.Identity, out _);
-            foreach (var bulk in bulkRemainder!)
+            return;
+        }
+
+        var selection = await _catalog.RecomputePreviewSelectionAsync(
+            candidate.Key.LibraryId,
+            candidate.SystemId,
+            system.InventoryGeneration,
+            cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(selection.NextUnresolvedGameId))
+        {
+            var expected = await _catalog.GetByGameIdAsync(
+                candidate.Key.LibraryId,
+                selection.NextUnresolvedGameId,
+                "boxart",
+                cancellationToken).ConfigureAwait(false);
+            var nextUnresolved = expected == null
+                ? null
+                : TryCreatePersistedCandidate(
+                    candidate.Key.LibraryId,
+                    selection.NextUnresolvedGameId,
+                    GameThumbService.ThumbKind.Boxart,
+                    expected.Key.StorageKey);
+            if (nextUnresolved != null)
             {
-                await QueueCandidateAsync(bulk, ArtworkLane.Bulk, null, cancellationToken).ConfigureAwait(false);
+                await QueueCandidateAsync(nextUnresolved, ArtworkLane.Preview, cancellationToken).ConfigureAwait(false);
+                return;
             }
 
-            return;
-        }
-
-        if (next != null)
-        {
-            await QueueCandidateAsync(next, ArtworkLane.Preview, plan, cancellationToken).ConfigureAwait(false);
+            // A missing source or changed fingerprint means the persisted inventory is stale; only
+            // a normal reconciliation should replace that inventory and its deterministic order.
+            DebounceLibraryFileSystemReconciliation();
         }
     }
 
-    private void QueueRemote(ArtworkCandidate candidate, ArtworkLane lane, PreviewPlan? preview, DateTimeOffset? notBefore)
+    private bool QueueRemote(ArtworkCandidate candidate, ArtworkLane lane, DateTimeOffset? notBefore)
     {
-        var work = ArtworkWork.Remote(candidate, lane, preview);
+        var work = ArtworkWork.Remote(candidate, lane);
         lock (_remoteQueueGate)
         {
             if (_queued.TryGetValue(work.Identity, out var existing))
             {
                 if (existing.Started || !IsHigherPriority(lane, existing.Lane))
                 {
-                    return;
+                    return true;
                 }
 
-                existing = existing with { Lane = lane, Version = existing.Version + 1 };
+                existing = existing with { Lane = lane, Version = NextRemoteQueueVersion() };
                 _queued[work.Identity] = existing;
                 work = work with { QueueVersion = existing.Version };
             }
             else
             {
-                if (_queued.Count >= MaxQueuedRemoteWork && !MakeRoomForRemoteUnsafe(lane))
+                if (_queued.Count >= MaxQueuedBestEffortRemoteWork &&
+                    !MakeRoomForRemoteUnsafe(lane) &&
+                    lane != ArtworkLane.Preview)
                 {
-                    return;
+                    return false;
                 }
 
-                var queued = new QueuedRemoteWork(lane, 1, false);
+                var queued = new QueuedRemoteWork(lane, NextRemoteQueueVersion(), false);
                 _queued.Add(work.Identity, queued);
                 work = work with { QueueVersion = queued.Version };
             }
@@ -1111,10 +1361,11 @@ public sealed class GameArtworkReconciliationService : IHostedService
         if (notBefore is { } retryAfter && retryAfter > DateTimeOffset.UtcNow)
         {
             _ = DelayQueueRemoteAsync(work, retryAfter, _stop?.Token ?? CancellationToken.None);
-            return;
+            return true;
         }
 
-        _remote.Enqueue(work);
+        EnqueueRemoteIfCurrent(work);
+        return true;
     }
 
     private async Task DelayQueueRemoteAsync(ArtworkWork work, DateTimeOffset notBefore, CancellationToken cancellationToken)
@@ -1122,7 +1373,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
         try
         {
             await Task.Delay(notBefore - DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
-            _remote.Enqueue(work);
+            EnqueueRemoteIfCurrent(work);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -1130,16 +1381,33 @@ public sealed class GameArtworkReconciliationService : IHostedService
         }
     }
 
+    private void EnqueueRemoteIfCurrent(ArtworkWork work)
+    {
+        lock (_remoteQueueGate)
+        {
+            if (_queued.TryGetValue(work.Identity, out var queued) &&
+                queued.Version == work.QueueVersion &&
+                !queued.Started)
+            {
+                _remote.Enqueue(work);
+            }
+        }
+    }
+
     private void QueueThumbnail(ArtworkCandidate candidate, DateTimeOffset? notBefore = null)
     {
-        var work = ArtworkWork.Thumbnail(candidate);
-        if (_thumbnailQueued.Count >= MaxQueuedThumbnailWork)
+        lock (_thumbnailQueueGate)
         {
-            return;
-        }
+            var work = ArtworkWork.Thumbnail(candidate) with
+            {
+                QueueVersion = Interlocked.Increment(ref _nextThumbnailQueueVersion),
+            };
+            if (_thumbnailQueued.Count >= MaxQueuedThumbnailWork ||
+                !_thumbnailQueued.TryAdd(work.Identity, work.QueueVersion))
+            {
+                return;
+            }
 
-        if (_thumbnailQueued.TryAdd(work.Identity, 0))
-        {
             if (notBefore is { } retryAfter && retryAfter > DateTimeOffset.UtcNow)
             {
                 _ = DelayQueueThumbnailAsync(work, retryAfter, _stop?.Token ?? CancellationToken.None);
@@ -1156,12 +1424,40 @@ public sealed class GameArtworkReconciliationService : IHostedService
         try
         {
             await Task.Delay(notBefore - DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
-            _thumbnail.Enqueue(work);
-            _thumbnailAvailable.Release();
+            lock (_thumbnailQueueGate)
+            {
+                if (_thumbnailQueued.TryGetValue(work.Identity, out var version) &&
+                    version == work.QueueVersion)
+                {
+                    _thumbnail.Enqueue(work);
+                    _thumbnailAvailable.Release();
+                }
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            _thumbnailQueued.TryRemove(work.Identity, out _);
+            // Stop cleanup owns removal; a late continuation must not remove a restarted lifetime's work.
+        }
+    }
+
+    private bool IsCurrentThumbnailWork(ArtworkWork work)
+    {
+        lock (_thumbnailQueueGate)
+        {
+            return _thumbnailQueued.TryGetValue(work.Identity, out var version) &&
+                version == work.QueueVersion;
+        }
+    }
+
+    private void CompleteThumbnail(ArtworkWork work)
+    {
+        lock (_thumbnailQueueGate)
+        {
+            if (_thumbnailQueued.TryGetValue(work.Identity, out var version) &&
+                version == work.QueueVersion)
+            {
+                _thumbnailQueued.TryRemove(work.Identity, out _);
+            }
         }
     }
 
@@ -1197,7 +1493,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
             return false;
         }
 
-        var evictable = _queued.FirstOrDefault(pair => !pair.Value.Started && pair.Value.Lane != ArtworkLane.Interactive);
+        var evictable = _queued.FirstOrDefault(pair => !pair.Value.Started && pair.Value.Lane == ArtworkLane.Bulk);
         if (string.IsNullOrEmpty(evictable.Key))
         {
             return false;
@@ -1208,6 +1504,8 @@ public sealed class GameArtworkReconciliationService : IHostedService
     }
 
     private static bool IsHigherPriority(ArtworkLane candidate, ArtworkLane existing) => candidate < existing;
+
+    private int NextRemoteQueueVersion() => Interlocked.Increment(ref _nextRemoteQueueVersion);
 
     private ArtworkCandidate? TryCreateCandidate(
         string libraryId,
@@ -1225,18 +1523,28 @@ public sealed class GameArtworkReconciliationService : IHostedService
         }
 
         var library = _games.GetGameLibraries().FirstOrDefault(item => string.Equals(item.Id, libraryId, StringComparison.OrdinalIgnoreCase));
-        var game = _games.GetGames(libraryId, null).FirstOrDefault(item => string.Equals(item.Id, gameId, StringComparison.Ordinal));
-        return library == null || game == null ? null : TryCreateCandidate(library, game, kind);
+        if (library == null)
+        {
+            return null;
+        }
+
+        var game = _games.GetGames(library.Id, null)
+            .FirstOrDefault(item => string.Equals(item.Id, gameId, StringComparison.Ordinal));
+        return game == null ? null : TryCreateCandidate(library, game, kind);
     }
 
     private ArtworkCandidate? TryCreateCandidate(GameLibrary library, GameSummary game, GameThumbService.ThumbKind kind)
     {
         var source = _games.ResolveThumbSource(library.Id, game.Id);
-        if (source == null)
-        {
-            return null;
-        }
+        return source == null ? null : TryCreateCandidate(library, game.Id, source, kind);
+    }
 
+    private static ArtworkCandidate? TryCreateCandidate(
+        GameLibrary library,
+        string gameId,
+        GameThumbSource source,
+        GameThumbService.ThumbKind kind)
+    {
         var root = library.Locations.Where(path => GamePathResolver.IsWithinRoot(path, source.RomPath)).OrderByDescending(path => path.Length).FirstOrDefault();
         if (root == null)
         {
@@ -1251,7 +1559,25 @@ public sealed class GameArtworkReconciliationService : IHostedService
         }
 
         var key = ArtworkCatalogKey.Create(library.Id, relativePath, $"{info.Length:x}-{info.LastWriteTimeUtc.Ticks:x}", KindName(kind));
-        return new ArtworkCandidate(game.Id, source.SystemName, kind, source, key, null);
+        return new ArtworkCandidate(gameId, source.SystemName, kind, source, key, null);
+    }
+
+    private ArtworkCandidate? TryCreatePersistedCandidate(
+        string libraryId,
+        string gameId,
+        GameThumbService.ThumbKind kind,
+        string expectedStorageKey)
+    {
+        var library = _games.GetGameLibraries().FirstOrDefault(item =>
+            string.Equals(item.Id, libraryId, StringComparison.OrdinalIgnoreCase));
+        var source = _games.ResolveThumbSource(libraryId, gameId);
+        var candidate = library == null || source == null
+            ? null
+            : TryCreateCandidate(library, gameId, source, kind);
+        return candidate != null &&
+            string.Equals(candidate.Key.StorageKey, expectedStorageKey, StringComparison.Ordinal)
+                ? candidate
+                : null;
     }
 
     private static GameThumbService.ThumbKind ParseKind(string? kind) => GameThumbService.ParseKind(kind);
@@ -1299,72 +1625,17 @@ public sealed class GameArtworkReconciliationService : IHostedService
 
     internal sealed record ArtworkCandidate(string GameId, string SystemId, GameThumbService.ThumbKind Kind, GameThumbSource Source, ArtworkCatalogKey Key, string? OriginalPath);
 
-    internal sealed record ArtworkWork(ArtworkCandidate Candidate, ArtworkLane Lane, PreviewPlan? Preview, bool IsThumbnail, int QueueVersion = 0)
+    internal sealed record ArtworkWork(ArtworkCandidate Candidate, ArtworkLane Lane, bool IsThumbnail, int QueueVersion = 0)
     {
-        public string Identity => (IsThumbnail ? "thumbnail:" : "remote:") + Candidate.Key.StorageKey;
-        public static ArtworkWork Remote(ArtworkCandidate candidate, ArtworkLane lane, PreviewPlan? preview) => new(candidate, lane, preview, false);
-        public static ArtworkWork Thumbnail(ArtworkCandidate candidate) => new(candidate, ArtworkLane.Interactive, null, true);
+        public string Identity => IsThumbnail
+            ? "thumbnail:" + Candidate.Key.StorageKey
+            : "remote:" + Candidate.Key.StorageKey;
+        public static ArtworkWork Remote(ArtworkCandidate candidate, ArtworkLane lane) => new(candidate, lane, false);
+        public static ArtworkWork Thumbnail(ArtworkCandidate candidate) => new(candidate, ArtworkLane.Interactive, true);
     }
 
     private sealed record QueuedRemoteWork(ArtworkLane Lane, int Version, bool Started);
 
-    internal sealed class PreviewPlan
-    {
-        private readonly object _gate = new();
-        private readonly IReadOnlyList<ArtworkCandidate> _candidates;
-        private readonly List<string> _confirmed = new(4);
-        private int _next;
-        private bool _finished;
-
-        public PreviewPlan(string libraryId, string systemId, string inventoryGeneration, IReadOnlyList<ArtworkCandidate> candidates)
-        {
-            LibraryId = libraryId;
-            SystemId = systemId;
-            InventoryGeneration = inventoryGeneration;
-            _candidates = candidates;
-        }
-
-        public string LibraryId { get; }
-        public string SystemId { get; }
-        public string InventoryGeneration { get; }
-        public string Identity => LibraryId + "/" + SystemId + "/" + InventoryGeneration;
-
-        public ArtworkCandidate? TakeNext()
-        {
-            lock (_gate)
-            {
-                return _next < _candidates.Count ? _candidates[_next++] : null;
-            }
-        }
-
-        public ArtworkCandidate? Complete(ArtworkCandidate candidate, bool found, out IReadOnlyList<string>? confirmed, out IReadOnlyList<ArtworkCandidate>? bulkRemainder)
-        {
-            lock (_gate)
-            {
-                confirmed = null;
-                bulkRemainder = null;
-                if (_finished)
-                {
-                    return null;
-                }
-
-                if (found && !_confirmed.Contains(candidate.GameId, StringComparer.Ordinal))
-                {
-                    _confirmed.Add(candidate.GameId);
-                }
-
-                if (_confirmed.Count == 4 || _next >= _candidates.Count)
-                {
-                    _finished = true;
-                    confirmed = _confirmed.ToArray();
-                    bulkRemainder = _candidates.Skip(_next).ToArray();
-                    return null;
-                }
-
-                return _candidates[_next++];
-            }
-        }
-    }
 }
 
 /// <summary>
@@ -1433,9 +1704,8 @@ internal sealed class ArtworkWorkScheduler
             {
                 _bulk.Enqueue(work);
             }
+            Available.Release();
         }
-
-        Available.Release();
     }
 
     public bool TryDequeue(out GameArtworkReconciliationService.ArtworkWork work)
@@ -1483,6 +1753,22 @@ internal sealed class ArtworkWorkScheduler
 
             work = null!;
             return false;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _interactive.Clear();
+            _bulk.Clear();
+            _preview.Clear();
+            _previewSystems.Clear();
+            _nonBulkSelections = 0;
+            while (Available.Wait(0))
+            {
+                // Cleared work must not leave stale permits for workers created by a later start.
+            }
         }
     }
 }

--- a/Jellyfin/backend/Services/GameArtworkReconciliationService.cs
+++ b/Jellyfin/backend/Services/GameArtworkReconciliationService.cs
@@ -17,7 +17,6 @@ namespace Moonfin.Server.Services;
 public sealed class GameArtworkReconciliationService : IHostedService
 {
     private static readonly TimeSpan LibraryFileSystemQuietPeriod = TimeSpan.FromSeconds(5);
-    private long _lastWatcherOverflowWarningTicks = long.MinValue / 2;
 
     // v3 repairs false terminal misses caused by RDB and thumbnail alternate-title separators.
     private const string ProviderVersion = "libretro-thumbnails-v3";
@@ -31,15 +30,17 @@ public sealed class GameArtworkReconciliationService : IHostedService
     private static readonly TimeSpan MetadataFirstRetryDelay = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan MetadataRepeatRetryDelay = TimeSpan.FromHours(3);
     private static readonly TimeSpan MetadataRetryWindow = TimeSpan.FromHours(24);
-    // Bulk and interactive acquisition are best-effort at this threshold. One unresolved preview
-    // per incomplete system may exceed it so preview discovery can never be stranded by admission.
+    // Bulk and interactive acquisition are best-effort at this threshold. Preview work admits past
+    // it so discovery is never stranded, but only into a bounded reserve. A pass queues at most one
+    // unresolved preview per system, so the reserve outlasts any real library's system count.
     private const int MaxQueuedBestEffortRemoteWork = 20_000;
+    private const int MaxQueuedPreviewReserve = 1_000;
     private const int MaxQueuedThumbnailWork = 20_000;
 
     // Bounded well below the encode gate on large hosts: artwork backfill is background work
     // sharing a box with playback and transcoding, and only two downloaders feed it, so more
     // encoders buy nothing. On the NAS-class hardware Jellyfin often runs on this resolves to
-    // 1-2 -- i.e. unchanged from the single worker it replaces.
+    // 1-2, unchanged from the single worker it replaces.
     private const int MaxThumbnailWorkers = 4;
 
     private static readonly TimeSpan WorkerStopGrace = TimeSpan.FromSeconds(10);
@@ -70,6 +71,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
     private readonly object _libraryWatcherLock = new();
     private readonly object _libraryWatcherDebounceLock = new();
     private Timer? _libraryWatcherDebounce;
+    private long _lastWatcherOverflowWarningTicks = long.MinValue / 2;
     private bool _startupRecoveryDone;
     private int _reopenMetadataDeferred;
     private int _nextRemoteQueueVersion;
@@ -497,7 +499,7 @@ public sealed class GameArtworkReconciliationService : IHostedService
         {
             // Bounded: a worker parked in a non-cancelable call (a filesystem operation on a dead
             // NAS mount) would otherwise never complete, and every later StartAsync waits on this
-            // cleanup -- so an unbounded wait here makes one wedged worker permanently unstartable.
+            // cleanup, so an unbounded wait here makes one wedged worker permanently unstartable.
             // A straggler keeps its canceled lifetime token; queue versions and lifetime checks
             // prevent it from publishing into the replacement lifetime.
             await workersStopped.WaitAsync(_workerStopGrace).ConfigureAwait(false);
@@ -816,7 +818,29 @@ public sealed class GameArtworkReconciliationService : IHostedService
             }
         }
 
-        watcher.Dispose();
+        // Clearing this is what silences the watcher, and it's safe from inside the watcher's own
+        // Error callback. Dispose isn't: it tears down the runner that raised the event we're
+        // standing on, so it goes to the thread pool rather than this stack.
+        try
+        {
+            watcher.EnableRaisingEvents = false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Silencing a failed game-library watcher failed");
+        }
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                watcher.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Disposing a failed game-library watcher failed");
+            }
+        });
     }
 
     private void TrySignalReconciliation()
@@ -952,11 +976,23 @@ public sealed class GameArtworkReconciliationService : IHostedService
                         inventoryGeneration,
                         candidates.Select(candidate => candidate.GameId),
                         cancellationToken).ConfigureAwait(false);
-                    var ordered = discovery.PreviewCandidateGameIds
-                        .Select(id => candidates.FirstOrDefault(candidate => string.Equals(candidate.GameId, id, StringComparison.Ordinal)))
-                        .Where(candidate => candidate != null)
-                        .Cast<ArtworkCandidate>()
-                        .ToArray();
+                    // One index rather than a FirstOrDefault per candidate, which cost systems
+                    // times candidates squared on every pass. TryAdd keeps the first match the
+                    // FirstOrDefault would have taken.
+                    var candidatesByGameId = new Dictionary<string, ArtworkCandidate>(candidates.Count, StringComparer.Ordinal);
+                    foreach (var candidate in candidates)
+                    {
+                        candidatesByGameId.TryAdd(candidate.GameId, candidate);
+                    }
+
+                    var ordered = new List<ArtworkCandidate>(discovery.PreviewCandidateGameIds.Count);
+                    foreach (var gameId in discovery.PreviewCandidateGameIds)
+                    {
+                        if (candidatesByGameId.TryGetValue(gameId, out var candidate))
+                        {
+                            ordered.Add(candidate);
+                        }
+                    }
 
                     discovery = await _catalog.RecomputePreviewSelectionAsync(
                         library.Id,
@@ -1345,9 +1381,10 @@ public sealed class GameArtworkReconciliationService : IHostedService
             }
             else
             {
-                if (_queued.Count >= MaxQueuedBestEffortRemoteWork &&
-                    !MakeRoomForRemoteUnsafe(lane) &&
-                    lane != ArtworkLane.Preview)
+                var admissionCap = lane == ArtworkLane.Preview
+                    ? MaxQueuedBestEffortRemoteWork + MaxQueuedPreviewReserve
+                    : MaxQueuedBestEffortRemoteWork;
+                if (_queued.Count >= admissionCap && !MakeRoomForRemoteUnsafe(lane))
                 {
                     return false;
                 }

--- a/Jellyfin/backend/Services/GameArtworkStore.cs
+++ b/Jellyfin/backend/Services/GameArtworkStore.cs
@@ -22,7 +22,16 @@ internal sealed class GameArtworkStore
     private const int MaxTotalProbesPerRequest = RdbService.MaxSiblingArtworkNamesPerRequest + 3;
     private static readonly TimeSpan MissTtl = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(6);
-    private static readonly TimeSpan OverallRequestBudget = TimeSpan.FromSeconds(3);
+
+    // A client is waiting on GetThumbPathAsync, so it gives up well inside one ProbeTimeout: a fast
+    // miss plus a background retry beats a long hang.
+    internal static readonly TimeSpan InteractiveRequestBudget = TimeSpan.FromSeconds(3);
+
+    // Nothing waits on a prewarm, and 3s cannot cover even one stalled probe of the ten a walk may
+    // make, so long arcade names expired every time and churned on the retry cycle forever. Still
+    // bounded, because a prewarm holds one of only two remote workers while it runs.
+    internal static readonly TimeSpan PrewarmRequestBudget = TimeSpan.FromSeconds(20);
+
     private static readonly char[] ReservedChars = { '&', '*', '/', ':', '`', '<', '>', '?', '\\', '|', '"' };
 
     // Ceiling on a single artwork response body, mirroring GamesService.MaxExtractedRomBytes and
@@ -77,7 +86,7 @@ internal sealed class GameArtworkStore
             .ConfigureAwait(false);
         if (result.TimedOut)
         {
-            throw new ThumbLookupTimedOutException(romPath, OverallRequestBudget);
+            throw new ThumbLookupTimedOutException(romPath, InteractiveRequestBudget);
         }
 
         return result.Path;
@@ -90,10 +99,12 @@ internal sealed class GameArtworkStore
         string romPath,
         string? title,
         GameThumbService.ThumbKind kind,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? budget = null)
     {
+        var effectiveBudget = budget ?? InteractiveRequestBudget;
         using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        budgetCts.CancelAfter(OverallRequestBudget);
+        budgetCts.CancelAfter(effectiveBudget);
 
         try
         {
@@ -105,8 +116,8 @@ internal sealed class GameArtworkStore
             _logger.LogDebug(
                 "Thumbnail lookup for {RomPath} exceeded its {BudgetSeconds}s overall budget; giving up",
                 romPath,
-                OverallRequestBudget.TotalSeconds);
-            return GameArtworkLookupResult.TransientFailure(OverallRequestBudget, timedOut: true);
+                effectiveBudget.TotalSeconds);
+            return GameArtworkLookupResult.TransientFailure(effectiveBudget, timedOut: true);
         }
     }
 

--- a/Jellyfin/backend/Services/GameArtworkStore.cs
+++ b/Jellyfin/backend/Services/GameArtworkStore.cs
@@ -27,7 +27,7 @@ internal sealed class GameArtworkStore
     // miss plus a background retry beats a long hang.
     internal static readonly TimeSpan InteractiveRequestBudget = TimeSpan.FromSeconds(3);
 
-    // Nothing waits on a prewarm, and 3s cannot cover even one stalled probe of the ten a walk may
+    // Nothing waits on a prewarm, and 3s can't cover even one stalled probe of the nine a walk may
     // make, so long arcade names expired every time and churned on the retry cycle forever. Still
     // bounded, because a prewarm holds one of only two remote workers while it runs.
     internal static readonly TimeSpan PrewarmRequestBudget = TimeSpan.FromSeconds(20);

--- a/Jellyfin/backend/Services/GameThumbService.cs
+++ b/Jellyfin/backend/Services/GameThumbService.cs
@@ -100,7 +100,8 @@ public class GameThumbService
 
     /// <summary>
     /// Performs a state-aware artwork lookup for background workers. Unlike <see cref="GetThumbPathAsync"/>,
-    /// this preserves the difference between confirmed absence and a retryable provider failure.
+    /// this preserves the difference between confirmed absence and a retryable provider failure,
+    /// and runs on the prewarm budget because no client is waiting on it.
     /// </summary>
     internal Task<GameArtworkLookupResult> LookupThumbAsync(
         string core,
@@ -110,7 +111,7 @@ public class GameThumbService
         string? title,
         ThumbKind kind,
         CancellationToken cancellationToken = default) =>
-        _artworkStore.LookupThumbAsync(core, coreWasDefaulted, systemName, romPath, title, kind, cancellationToken);
+        _artworkStore.LookupThumbAsync(core, coreWasDefaulted, systemName, romPath, title, kind, cancellationToken, GameArtworkStore.PrewarmRequestBudget);
 
     /// <summary>
     /// Gets the cached size/format-optimized thumbnail derived from an already-acquired original.

--- a/Jellyfin/tests/Moonfin.Server.Tests/ArtworkPriorityTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/ArtworkPriorityTests.cs
@@ -70,9 +70,25 @@ public sealed class ArtworkPriorityTests : IDisposable
     /// exactly what the per-call filesystem path resolves, including rejecting an unknown game id.
     /// </summary>
     [Fact]
-    public void GameLookup_MatchesTheUncachedMembershipDecision()
+    public async Task GameLookup_MatchesTheUncachedMembershipDecision()
     {
         var harness = CreateHarness(gameCount: 8);
+        var libraryRoot = Path.Combine(_root, "Games");
+        var systemRoot = Path.Combine(libraryRoot, "SNES");
+        var hiddenRoot = Path.Combine(libraryRoot, ".hidden");
+        Directory.CreateDirectory(hiddenRoot);
+        var invalidPaths = new[]
+        {
+            Path.Combine(libraryRoot, "readme.txt"),
+            Path.Combine(hiddenRoot, "Hidden.sfc"),
+            Path.Combine(systemRoot, "readme.txt"),
+            Path.Combine(systemRoot, "firmware.bin"),
+        };
+        foreach (var path in invalidPaths)
+        {
+            await File.WriteAllBytesAsync(path, [1, 2, 3]);
+        }
+
         var lookup = harness.Service.CreateGameLookup(harness.LibraryId);
 
         foreach (var game in harness.Games.GetGames(harness.LibraryId, null))
@@ -85,6 +101,13 @@ public sealed class ArtworkPriorityTests : IDisposable
         var unknown = GamePathResolver.EncodeToken(Path.Combine(_root, "Games", "SNES", "Not Installed.sfc"));
         Assert.False(harness.Service.IsCurrentGameMember(harness.LibraryId, unknown));
         Assert.False(harness.Service.IsCurrentGameMember(harness.LibraryId, unknown, lookup));
+        foreach (var path in invalidPaths)
+        {
+            var invalid = GamePathResolver.EncodeToken(path);
+            Assert.False(harness.Service.IsCurrentGameMember(harness.LibraryId, invalid));
+            Assert.False(harness.Service.IsCurrentGameMember(harness.LibraryId, invalid, lookup));
+            Assert.False(await harness.Service.RequestRefreshAsync(harness.LibraryId, invalid, "boxart"));
+        }
 
         // A snapshot taken against a different library must never answer for this one. It is
         // ignored and the uncached resolve runs instead, so the answer stays correct (true)

--- a/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkCatalogTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkCatalogTests.cs
@@ -95,6 +95,68 @@ public sealed class GameArtworkCatalogTests : IDisposable
         Assert.Null(service.ResolveLocalArtwork(thumbnail, thumbnail.Revision.ToString(System.Globalization.CultureInfo.InvariantCulture)));
     }
 
+    [Fact]
+    public async Task RepairMissingArtifacts_ReopensOnlyEntriesWhoseCacheFilesWereDeleted()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var artifacts = Path.Combine(_root, "artifacts");
+        Directory.CreateDirectory(artifacts);
+        var missingOriginal = Path.Combine(artifacts, "boxart.png");
+        var missingThumbnail = Path.Combine(artifacts, "boxart_thumb.jpg");
+        var retainedOriginal = Path.Combine(artifacts, "snap.png");
+        var removedThumbnail = Path.Combine(artifacts, "snap_thumb.jpg");
+        var healthyOriginal = Path.Combine(artifacts, "title.png");
+        var healthyThumbnail = Path.Combine(artifacts, "title_thumb.jpg");
+        foreach (var path in new[] { missingOriginal, missingThumbnail, retainedOriginal, removedThumbnail, healthyOriginal, healthyThumbnail })
+        {
+            await File.WriteAllBytesAsync(path, [1, 2, 3]);
+        }
+
+        var boxart = ArtworkCatalogKey.Create("library-a", "SNES/Game.sfc", "fingerprint", "boxart");
+        var snap = ArtworkCatalogKey.Create("library-a", "SNES/Game.sfc", "fingerprint", "snap");
+        var title = ArtworkCatalogKey.Create("library-a", "SNES/Game.sfc", "fingerprint", "title");
+        foreach (var key in new[] { boxart, snap, title })
+        {
+            await catalog.GetOrCreateAsync(key, "snes", "provider-v1", "game");
+        }
+
+        await catalog.MarkOriginalReadyAsync(boxart, "snes", missingOriginal);
+        await catalog.MarkThumbnailReadyAsync(boxart, "snes", missingThumbnail);
+        await catalog.MarkOriginalReadyAsync(snap, "snes", retainedOriginal);
+        var snapReady = await catalog.MarkThumbnailReadyAsync(snap, "snes", removedThumbnail);
+        await catalog.MarkOriginalReadyAsync(title, "snes", healthyOriginal);
+        await catalog.MarkThumbnailReadyAsync(title, "snes", healthyThumbnail);
+        await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", ["game"]);
+        var published = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        Assert.Single(published.PreviewGameIds);
+
+        File.Delete(missingOriginal);
+        File.Delete(missingThumbnail);
+        File.Delete(removedThumbnail);
+
+        Assert.Equal(2, await catalog.RepairMissingArtifactsAsync("library-a"));
+
+        var repairedBoxart = await catalog.GetAsync(boxart);
+        var repairedSnap = await catalog.GetAsync(snap);
+        var unchangedTitle = await catalog.GetAsync(title);
+        var repairedSystem = await catalog.GetSystemAsync("library-a", "snes");
+        Assert.Equal(ArtworkCatalogState.Pending, repairedBoxart?.State);
+        Assert.Null(repairedBoxart?.OriginalPath);
+        Assert.Null(repairedBoxart?.ThumbnailPath);
+        Assert.Equal(ArtworkCatalogState.OriginalReady, repairedSnap?.State);
+        Assert.Equal(retainedOriginal, repairedSnap?.OriginalPath);
+        Assert.Null(repairedSnap?.ThumbnailPath);
+        Assert.True(repairedSnap?.Revision > snapReady.Revision);
+        Assert.Equal(ArtworkCatalogState.ThumbnailReady, unchangedTitle?.State);
+        Assert.Empty(repairedSystem.PreviewGameIds);
+        Assert.Null(repairedSystem.PreviewSelectionGeneration);
+
+        var recovery = await catalog.GetStartupRecoveryWorkAsync();
+        Assert.Contains(recovery, item => item.Entry.Key == boxart && item.Stage == ArtworkCatalogWorkStage.AcquireOriginal);
+        Assert.Contains(recovery, item => item.Entry.Key == snap && item.Stage == ArtworkCatalogWorkStage.DeriveThumbnail);
+        Assert.DoesNotContain(recovery, item => item.Entry.Key == title);
+    }
+
     private static GameArtworkReconciliationService BuildReconciliationService(GameArtworkCatalog catalog)
     {
         var libraryManager = new FakeLibraryManager(new List<VirtualFolderInfo>());
@@ -110,28 +172,383 @@ public sealed class GameArtworkCatalogTests : IDisposable
     [Fact]
     public async Task PreviewSelection_IsStableForInventoryGenerationAndChangesWhenInventoryChanges()
     {
-        // GetOrCreatePreviewSelectionAsync was removed (dead: production only ever used the
-        // discovery/commit pair below). This exercises the same stability guarantee through the
-        // surviving two-step API: discovery fixes the deterministic candidate order for an
-        // inventory generation, and commit publishes the confirmed panels from that order.
         var catalog = new GameArtworkCatalog(_root);
         var candidates = new[] { "g1", "g2", "g3", "g4", "g5", "g6" };
+        await catalog.SynchronizeProjectionAsync(
+            "library-a",
+            Array.Empty<ArtworkCatalogProjectionEntry>(),
+            "provider-v1",
+            new ArtworkCatalogSystemMetadata("snes", "Super Nintendo", "snes9x", candidates.Length));
 
         var discoveryFirst = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
-        var confirmedFirst = discoveryFirst.PreviewCandidateGameIds.Take(4).ToList();
-        var first = await catalog.CommitPreviewSelectionAsync("library-a", "snes", "inventory-a", confirmedFirst);
+        foreach (var gameId in discoveryFirst.PreviewCandidateGameIds.Take(4))
+        {
+            var key = ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart");
+            await catalog.GetOrCreateAsync(key, "snes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(key, "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        var first = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
 
         var discoveryRepeated = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates.Reverse());
-        var repeated = await catalog.CommitPreviewSelectionAsync("library-a", "snes", "inventory-a", confirmedFirst);
+        var repeated = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        foreach (var gameId in discoveryFirst.PreviewCandidateGameIds.Skip(4))
+        {
+            var key = ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart");
+            await catalog.GetOrCreateAsync(key, "snes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(key, "snes", $"C:/catalog/{gameId}.png");
+        }
 
         var discoveryChanged = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-b", candidates);
-        var confirmedChanged = discoveryChanged.PreviewCandidateGameIds.Take(4).ToList();
-        var changed = await catalog.CommitPreviewSelectionAsync("library-a", "snes", "inventory-b", confirmedChanged);
+        var changed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-b");
 
         Assert.Equal(discoveryFirst.PreviewCandidateGameIds, discoveryRepeated.PreviewCandidateGameIds);
         Assert.Equal(first.PreviewGameIds, repeated.PreviewGameIds);
         Assert.Equal(4, first.PreviewGameIds.Count);
+        Assert.Equal("inventory-a", first.PreviewSelectionGeneration);
+        Assert.Equal("inventory-b", changed.PreviewSelectionGeneration);
         Assert.True(changed.Generation > first.Generation);
+        var metadata = Assert.Single(await catalog.GetSystemMetadataAsync("library-a"));
+        Assert.Equal(("Super Nintendo", "snes9x", candidates.Length), (metadata.Name, metadata.Core, metadata.GameCount));
+    }
+
+    [Fact]
+    public async Task PreviewSelection_NextUnresolvedCandidateBlocksPublicationUntilItBecomesTerminal()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = new[] { "g1", "g2", "g3", "g4", "g5" };
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+        var ordered = discovery.PreviewCandidateGameIds;
+        var keys = ordered.ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+
+        foreach (var gameId in ordered)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+        }
+
+        foreach (var gameId in ordered.Skip(1).Take(4))
+        {
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        var blocked = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        Assert.Empty(blocked.PreviewGameIds);
+        Assert.Null(blocked.PreviewSelectionGeneration);
+
+        await catalog.MarkMissingAsync(keys[ordered[0]], "snes", "provider-v1");
+        var complete = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        Assert.Equal(ordered.Skip(1).Take(4), complete.PreviewGameIds);
+        Assert.Equal("inventory-a", complete.PreviewSelectionGeneration);
+    }
+
+    // A completion elsewhere in the system recomputes the selection while a reopened candidate is
+    // still non-terminal. Publishing an empty list there would blank the panels mid-import.
+    [Fact]
+    public async Task PreviewSelection_KeepsPublishedPanelsWhileACandidateReopens()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = new[] { "g1", "g2", "g3", "g4", "g5" };
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+        var ordered = discovery.PreviewCandidateGameIds;
+        var keys = ordered.ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+        foreach (var gameId in ordered)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        var completed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        Assert.Equal(4, completed.PreviewGameIds.Count);
+
+        await catalog.RequestRefreshAsync(keys[ordered[0]], "snes", ordered[0]);
+        var reopened = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        Assert.Equal(completed.PreviewGameIds, reopened.PreviewGameIds);
+        Assert.Null(reopened.PreviewSelectionGeneration);
+        Assert.Equal(ordered[0], reopened.NextUnresolvedGameId);
+    }
+
+    // The resumable scan trusts its stored prefix. Removing a confirmed entry through the
+    // single-entry path must invalidate that checkpoint, or the selection keeps publishing a game
+    // whose catalog entry is gone.
+    [Fact]
+    public async Task PreviewSelection_RemovingAConfirmedEntryInvalidatesTheScanCheckpoint()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = new[] { "g1", "g2", "g3", "g4", "g5", "g6" };
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+        var ordered = discovery.PreviewCandidateGameIds;
+        var keys = ordered.ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+        foreach (var gameId in ordered)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        var completed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        var dropped = completed.PreviewGameIds[0];
+        Assert.True(await catalog.RemoveAsync(keys[dropped], "snes"));
+
+        var after = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        Assert.DoesNotContain(dropped, after.PreviewGameIds);
+
+        await catalog.GetOrCreateAsync(keys[dropped], "snes", "provider-v1", dropped);
+        await catalog.MarkOriginalReadyAsync(keys[dropped], "snes", $"C:/catalog/{dropped}.png");
+        var rediscovered = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            "library-a",
+            "snes",
+            "inventory-a",
+            candidates);
+        var restored = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        Assert.Contains(dropped, rediscovered.PreviewCandidateGameIds);
+        Assert.Contains(dropped, restored.PreviewGameIds);
+    }
+
+    [Fact]
+    public async Task PreviewSelection_EmptyCompletionPersistsAndANewInventoryResetsIt()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = new[] { "g1", "g2", "g3" };
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+
+        foreach (var gameId in discovery.PreviewCandidateGameIds)
+        {
+            var key = ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart");
+            await catalog.GetOrCreateAsync(key, "snes", "provider-v1", gameId);
+            await catalog.MarkMissingAsync(key, "snes", "provider-v1");
+        }
+
+        var complete = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        Assert.Empty(complete.PreviewGameIds);
+        Assert.Equal("inventory-a", complete.PreviewSelectionGeneration);
+
+        await catalog.FlushAsync();
+        var reloaded = new GameArtworkCatalog(_root);
+        var persisted = await reloaded.GetSystemAsync("library-a", "snes");
+        Assert.Empty(persisted.PreviewGameIds);
+        Assert.Equal("inventory-a", persisted.PreviewSelectionGeneration);
+
+        var reset = await reloaded.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-b", candidates);
+        Assert.Empty(reset.PreviewGameIds);
+        Assert.Null(reset.PreviewSelectionGeneration);
+    }
+
+    [Fact]
+    public async Task PreviewSelection_TraversesThousandsOfCachedTerminalCandidatesIteratively()
+    {
+        const int candidateCount = 5_000;
+        var catalog = new GameArtworkCatalog(_root);
+        var entries = Enumerable.Range(0, candidateCount)
+            .Select(index => new ArtworkCatalogProjectionEntry(
+                ArtworkCatalogKey.Create("library-a", $"SNES/Game-{index:D4}.sfc", $"fingerprint-{index:D4}", "boxart"),
+                "snes",
+                $"game-{index:D4}"))
+            .ToArray();
+
+        await catalog.SynchronizeProjectionAsync(
+            "library-a",
+            entries,
+            "provider-v1",
+            new ArtworkCatalogSystemMetadata("snes", "SNES", "snes9x", candidateCount));
+        await catalog.GetOrCreatePreviewDiscoveryAsync(
+            "library-a",
+            "snes",
+            "inventory-a",
+            entries.Select(entry => entry.GameId));
+        foreach (var entry in entries)
+        {
+            await catalog.MarkMissingAsync(entry.Key, "snes", "provider-v1");
+        }
+
+        var complete = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        Assert.Empty(complete.PreviewGameIds);
+        Assert.Equal("inventory-a", complete.PreviewSelectionGeneration);
+    }
+
+    // Reconciliation calls RecomputePreviewSelectionAsync once per boxart completion, always
+    // restarting the walk at index 0. On a sparse system (most games never get artwork) the
+    // terminal prefix grows with every call, so a full reconciliation pass is O(N^2) lookups.
+    // The scan must resume from where the last call proved the prefix terminal instead.
+    [Fact]
+    public async Task PreviewSelection_ResumesFromLastProvenIndexInsteadOfRescanningFromZero()
+    {
+        const int candidateCount = 2_000;
+        var catalog = new GameArtworkCatalog(_root);
+        var entries = Enumerable.Range(0, candidateCount)
+            .Select(index => new ArtworkCatalogProjectionEntry(
+                ArtworkCatalogKey.Create("library-a", $"SNES/Game-{index:D4}.sfc", $"fingerprint-{index:D4}", "boxart"),
+                "snes",
+                $"game-{index:D4}"))
+            .ToArray();
+
+        await catalog.SynchronizeProjectionAsync(
+            "library-a",
+            entries,
+            "provider-v1",
+            new ArtworkCatalogSystemMetadata("snes", "SNES", "snes9x", candidateCount));
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            "library-a",
+            "snes",
+            "inventory-a",
+            entries.Select(entry => entry.GameId));
+        var keysByGameId = entries.ToDictionary(entry => entry.GameId, entry => entry.Key, StringComparer.Ordinal);
+
+        // Resolved in the walk's own order (discovery permutes candidates by hash, not insertion
+        // order), so the terminal prefix genuinely grows by one every call -- the pathological
+        // pattern this fix targets. Mirrors the real call pattern: one boxart completion, then one
+        // recompute, repeated for every candidate; almost all resolve Missing, matching a large
+        // arcade set with poor provider coverage.
+        foreach (var gameId in discovery.PreviewCandidateGameIds)
+        {
+            await catalog.MarkMissingAsync(keysByGameId[gameId], "snes", "provider-v1");
+            await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        }
+
+        // O(N) resumed scanning costs roughly one lookup per candidate per call; O(N^2) rescanning
+        // from zero costs roughly N^2/2. A generous linear-ish bound still rejects the quadratic
+        // behavior by three orders of magnitude at this N.
+        Assert.True(
+            catalog.PreviewScanLookupCount <= candidateCount * 4L,
+            $"Expected roughly linear lookup cost (~{candidateCount * 4L}), but observed {catalog.PreviewScanLookupCount} lookups.");
+    }
+
+    // A candidate strictly before the resumed scan's stored index can still reopen (an explicit
+    // refresh, a reopened metadata defer, a provider-version change). The resumed scan must not
+    // treat a stale cached classification as authoritative once that happens.
+    [Fact]
+    public async Task PreviewSelection_ReopeningAConfirmedCandidateBeforeTheScanIndexIsPickedUpOnResume()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = new[] { "g0", "g1", "g2", "g3", "g4", "g5", "g6" };
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+        var ordered = discovery.PreviewCandidateGameIds;
+        var keys = ordered.ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+
+        foreach (var gameId in ordered)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+        }
+
+        // ordered[0] is a durable miss; ordered[1..4] are confirmed -- the walk advances the scan
+        // index past all five and publishes the first four confirmed candidates.
+        await catalog.MarkMissingAsync(keys[ordered[0]], "snes", "provider-v1");
+        foreach (var gameId in ordered.Skip(1).Take(4))
+        {
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        var initial = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        Assert.Equal(ordered.Skip(1).Take(4), initial.PreviewGameIds);
+
+        // ordered[0] reopens and becomes confirmed too. In candidate order it now outranks the
+        // fourth previously-confirmed candidate, so a correct from-scratch scan swaps it in.
+        await catalog.RequestRefreshAsync(keys[ordered[0]], "snes", ordered[0]);
+        await catalog.MarkOriginalReadyAsync(keys[ordered[0]], "snes", $"C:/catalog/{ordered[0]}.png");
+
+        var resumed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+
+        var expected = new[] { ordered[0] }.Concat(ordered.Skip(1).Take(3)).ToArray();
+        Assert.Equal(expected, resumed.PreviewGameIds);
+    }
+
+    // Same sparse-scan pattern as PreviewSelection_ResumesFromLastProvenIndexInsteadOfRescanningFromZero,
+    // but comparing against a fresh catalog that only ever does one full scan from index 0 -- the
+    // resumed scan's incremental result must match it exactly at every step, not just at the end.
+    [Fact]
+    public async Task PreviewSelection_ResumedScanMatchesAFullScanFromScratch()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = Enumerable.Range(0, 30).Select(index => $"game-{index:D2}").ToArray();
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+        var ordered = discovery.PreviewCandidateGameIds;
+        var keys = ordered.ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+
+        foreach (var gameId in ordered)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+        }
+
+        // Every fifth candidate confirms; the rest resolve missing. Resolve them one at a time,
+        // recomputing (resumed) after each, and compare against an independent from-scratch scan.
+        // An incomplete from-scratch walk keeps the previously published selection, exactly as
+        // RecomputePreviewSelectionAsync does -- so the oracle tracks that same "last published"
+        // state itself rather than assuming every step is complete.
+        var expectedPublished = new List<string>();
+        for (var index = 0; index < ordered.Count; index++)
+        {
+            var gameId = ordered[index];
+            if (index % 5 == 0)
+            {
+                await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+            }
+            else
+            {
+                await catalog.MarkMissingAsync(keys[gameId], "snes", "provider-v1");
+            }
+
+            var resumed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+            var (fromScratch, complete) = await ComputeFromScratchSelectionAsync(catalog, ordered);
+            if (complete)
+            {
+                expectedPublished = fromScratch;
+            }
+
+            Assert.Equal(expectedPublished, resumed.PreviewGameIds);
+        }
+    }
+
+    /// <summary>Independent oracle: an unindexed, always-from-zero walk of the current boxart states.</summary>
+    private static async Task<(List<string> Confirmed, bool Complete)> ComputeFromScratchSelectionAsync(
+        GameArtworkCatalog catalog,
+        IReadOnlyList<string> ordered)
+    {
+        var confirmed = new List<string>(4);
+        foreach (var gameId in ordered)
+        {
+            var entry = await catalog.GetByGameIdAsync("library-a", gameId, "boxart");
+            var isConfirmed = entry is { State: ArtworkCatalogState.ThumbnailReady } ||
+                (entry is { State: ArtworkCatalogState.OriginalReady } && !string.IsNullOrWhiteSpace(entry.OriginalPath));
+            if (isConfirmed)
+            {
+                confirmed.Add(gameId);
+                if (confirmed.Count == 4)
+                {
+                    return (confirmed, true);
+                }
+
+                continue;
+            }
+
+            var isTerminalSkip = entry is { State: ArtworkCatalogState.Missing or ArtworkCatalogState.MetadataDeferred };
+            if (isTerminalSkip)
+            {
+                continue;
+            }
+
+            return (confirmed, false);
+        }
+
+        return (confirmed, true);
     }
 
     [Fact]
@@ -184,8 +601,10 @@ public sealed class GameArtworkCatalogTests : IDisposable
 
         await catalog.GetOrCreateAsync(retained, "snes", "provider-v1", "current-game");
         await catalog.GetOrCreateAsync(removed, "snes", "provider-v1", "removed-game");
+        await catalog.MarkOriginalReadyAsync(retained, "snes", "C:/catalog/retained.png");
+        await catalog.MarkOriginalReadyAsync(removed, "snes", "C:/catalog/removed.png");
         await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", new[] { "current-game", "removed-game" });
-        await catalog.CommitPreviewSelectionAsync("library-a", "snes", "inventory-a", new[] { "current-game", "removed-game" });
+        await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
         var before = await catalog.GetSystemProjectionAsync("library-a", "snes");
 
         await catalog.PruneAsync("library-a", new[] { retained });
@@ -297,6 +716,7 @@ public sealed class GameArtworkCatalogTests : IDisposable
         var metadata = await reloaded.GetSystemMetadataAsync("library-a");
 
         Assert.Equal(5, snapshot.Generation);
+        Assert.Null(snapshot.PreviewSelectionGeneration);
         Assert.Single(metadata);
         Assert.Equal("Super Nintendo", metadata[0].Name);
     }

--- a/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkCatalogTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkCatalogTests.cs
@@ -317,6 +317,94 @@ public sealed class GameArtworkCatalogTests : IDisposable
         Assert.Contains(dropped, restored.PreviewGameIds);
     }
 
+    // A completed selection stops being the final answer the moment one of its games leaves the
+    // catalog, because the panels it publishes are a panel short.
+    [Fact]
+    public async Task PreviewSelection_RemovingAConfirmedEntryRetiresTheCompletionMarker()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var candidates = new[] { "g1", "g2", "g3", "g4", "g5", "g6" };
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync("library-a", "snes", "inventory-a", candidates);
+        var keys = discovery.PreviewCandidateGameIds.ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"SNES/{gameId}.sfc", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+        foreach (var gameId in discovery.PreviewCandidateGameIds)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        var completed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-a");
+        Assert.Equal("inventory-a", completed.PreviewSelectionGeneration);
+        Assert.Equal(4, completed.PreviewGameIds.Count);
+
+        Assert.True(await catalog.RemoveAsync(keys[completed.PreviewGameIds[0]], "snes"));
+
+        // Read straight through with no recompute in between, which is what a browse request that
+        // lands in that window actually gets.
+        var stale = await catalog.GetSystemAsync("library-a", "snes");
+
+        Assert.Null(stale.PreviewSelectionGeneration);
+        Assert.Equal(3, stale.PreviewGameIds.Count);
+    }
+
+    // An entry that moves to another system leaves one candidate list and joins another, so neither
+    // side's resume index still describes the list it was taken against. The state comparison that
+    // guards the cheap path can't see this, because a move doesn't change the entry's state.
+    [Fact]
+    public async Task PreviewSelection_MovingAnEntryBetweenSystemsResetsBothScans()
+    {
+        var catalog = new GameArtworkCatalog(_root);
+        var snes = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            "library-a",
+            "snes",
+            "inventory-snes",
+            new[] { "g1", "g2", "g3", "g4", "g5", "g6" });
+        var nes = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            "library-a",
+            "nes",
+            "inventory-nes",
+            new[] { "n1", "n2", "n3", "n4", "n5", "n6" });
+
+        var keys = snes.PreviewCandidateGameIds.Concat(nes.PreviewCandidateGameIds).ToDictionary(
+            gameId => gameId,
+            gameId => ArtworkCatalogKey.Create("library-a", $"roms/{gameId}.rom", $"fingerprint-{gameId}", "boxart"),
+            StringComparer.Ordinal);
+        foreach (var gameId in snes.PreviewCandidateGameIds)
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "snes", $"C:/catalog/{gameId}.png");
+        }
+
+        // The destination stalls on its third candidate, so its checkpoint is non-zero but its
+        // selection is still open. Resetting it has to be observable, not vacuously already-zero.
+        foreach (var gameId in nes.PreviewCandidateGameIds.Take(2))
+        {
+            await catalog.GetOrCreateAsync(keys[gameId], "nes", "provider-v1", gameId);
+            await catalog.MarkOriginalReadyAsync(keys[gameId], "nes", $"C:/catalog/{gameId}.png");
+        }
+
+        var completed = await catalog.RecomputePreviewSelectionAsync("library-a", "snes", "inventory-snes");
+        await catalog.RecomputePreviewSelectionAsync("library-a", "nes", "inventory-nes");
+        Assert.Equal("inventory-snes", completed.PreviewSelectionGeneration);
+        Assert.Equal(4, await catalog.PreviewScanStartIndexForTestsAsync("library-a", "snes"));
+        Assert.Equal(2, await catalog.PreviewScanStartIndexForTestsAsync("library-a", "nes"));
+
+        // Refile a confirmed entry under the other system with its state untouched, which is what
+        // a re-identified ROM looks like to the projection.
+        var moved = completed.PreviewGameIds[0];
+        await catalog.SynchronizeProjectionAsync(
+            "library-a",
+            new[] { new ArtworkCatalogProjectionEntry(keys[moved], "nes", moved) },
+            "provider-v1");
+
+        // Both sides rescan from zero. Resuming the source's index would keep counting a game it
+        // no longer holds, and resuming the destination's would skip straight past the arrival.
+        Assert.Equal(0, await catalog.PreviewScanStartIndexForTestsAsync("library-a", "snes"));
+        Assert.Equal(0, await catalog.PreviewScanStartIndexForTestsAsync("library-a", "nes"));
+    }
+
     [Fact]
     public async Task PreviewSelection_EmptyCompletionPersistsAndANewInventoryResetsIt()
     {
@@ -408,10 +496,10 @@ public sealed class GameArtworkCatalogTests : IDisposable
         var keysByGameId = entries.ToDictionary(entry => entry.GameId, entry => entry.Key, StringComparer.Ordinal);
 
         // Resolved in the walk's own order (discovery permutes candidates by hash, not insertion
-        // order), so the terminal prefix genuinely grows by one every call -- the pathological
-        // pattern this fix targets. Mirrors the real call pattern: one boxart completion, then one
-        // recompute, repeated for every candidate; almost all resolve Missing, matching a large
-        // arcade set with poor provider coverage.
+        // order), so the terminal prefix genuinely grows by one every call, which is the
+        // pathological pattern this fix targets. Mirrors the real call pattern: one boxart
+        // completion, then one recompute, repeated for every candidate, and almost all resolve
+        // Missing, matching a large arcade set with poor provider coverage.
         foreach (var gameId in discovery.PreviewCandidateGameIds)
         {
             await catalog.MarkMissingAsync(keysByGameId[gameId], "snes", "provider-v1");
@@ -446,8 +534,8 @@ public sealed class GameArtworkCatalogTests : IDisposable
             await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
         }
 
-        // ordered[0] is a durable miss; ordered[1..4] are confirmed -- the walk advances the scan
-        // index past all five and publishes the first four confirmed candidates.
+        // ordered[0] is a durable miss and ordered[1..4] are confirmed, so the walk advances the
+        // scan index past all five and publishes the first four confirmed candidates.
         await catalog.MarkMissingAsync(keys[ordered[0]], "snes", "provider-v1");
         foreach (var gameId in ordered.Skip(1).Take(4))
         {
@@ -469,7 +557,7 @@ public sealed class GameArtworkCatalogTests : IDisposable
     }
 
     // Same sparse-scan pattern as PreviewSelection_ResumesFromLastProvenIndexInsteadOfRescanningFromZero,
-    // but comparing against a fresh catalog that only ever does one full scan from index 0 -- the
+    // but comparing against a fresh catalog that only ever does one full scan from index 0. The
     // resumed scan's incremental result must match it exactly at every step, not just at the end.
     [Fact]
     public async Task PreviewSelection_ResumedScanMatchesAFullScanFromScratch()
@@ -488,10 +576,10 @@ public sealed class GameArtworkCatalogTests : IDisposable
             await catalog.GetOrCreateAsync(keys[gameId], "snes", "provider-v1", gameId);
         }
 
-        // Every fifth candidate confirms; the rest resolve missing. Resolve them one at a time,
+        // Every fifth candidate confirms and the rest resolve missing. Resolve them one at a time,
         // recomputing (resumed) after each, and compare against an independent from-scratch scan.
         // An incomplete from-scratch walk keeps the previously published selection, exactly as
-        // RecomputePreviewSelectionAsync does -- so the oracle tracks that same "last published"
+        // RecomputePreviewSelectionAsync does, so the oracle tracks that same "last published"
         // state itself rather than assuming every step is complete.
         var expectedPublished = new List<string>();
         for (var index = 0; index < ordered.Count; index++)

--- a/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkReconciliationServiceTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkReconciliationServiceTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Jellyfin.Data.Events;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moonfin.Server.Services;
 using Xunit;
@@ -316,14 +317,384 @@ public sealed class GameArtworkReconciliationServiceTests : IDisposable
     }
 
     [Fact]
+    public void RemoteQueue_AtCapacityGuaranteesPreviewAdmissionWithoutLettingInteractiveEvictIt()
+    {
+        const int bestEffortCapacity = 20_000;
+        var service = BuildService(_root);
+        for (var index = 0; index < bestEffortCapacity; index++)
+        {
+            Assert.True(service.EnqueueRemoteForTest(Candidate("library", $"bulk-{index}"), ArtworkLane.Bulk));
+        }
+
+        var preview = Candidate("library", "preview");
+        Assert.True(service.EnqueueRemoteForTest(preview, ArtworkLane.Preview));
+        Assert.Contains("remote:" + preview.Key.StorageKey, QueuedRemoteIdentities(service));
+
+        Assert.True(service.EnqueueRemoteForTest(Candidate("library", "interactive"), ArtworkLane.Interactive));
+        Assert.Contains("remote:" + preview.Key.StorageKey, QueuedRemoteIdentities(service));
+        Assert.Equal(bestEffortCapacity + 1, QueuedRemoteIdentities(service).Count);
+
+        Assert.False(service.EnqueueRemoteForTest(Candidate("library", "rejected-bulk"), ArtworkLane.Bulk));
+        Assert.Equal(bestEffortCapacity + 1, QueuedRemoteIdentities(service).Count);
+    }
+
+    private static ICollection<string> QueuedRemoteIdentities(GameArtworkReconciliationService service)
+    {
+        var field = typeof(GameArtworkReconciliationService)
+            .GetField("_queued", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var queued = (System.Collections.IDictionary)field.GetValue(service)!;
+        return queued.Keys.Cast<string>().ToArray();
+    }
+
+    [Fact]
+    public async Task SaturatedQueue_AdvancesToTheNextUnresolvedPreviewCandidateAfterAMiss()
+    {
+        const int bestEffortCapacity = 20_000;
+        var libraryRoot = Path.Combine(_root, "Games");
+        var systemRoot = Path.Combine(libraryRoot, "SNES");
+        Directory.CreateDirectory(systemRoot);
+        await File.WriteAllBytesAsync(Path.Combine(systemRoot, "First.sfc"), [1]);
+        await File.WriteAllBytesAsync(Path.Combine(systemRoot, "Second.sfc"), [2]);
+
+        var libraryId = Guid.NewGuid().ToString();
+        var folders = new List<VirtualFolderInfo>
+        {
+            new() { Name = "Games", ItemId = libraryId, Locations = [libraryRoot] },
+        };
+        var service = CreateWatchingService(folders, out var catalog);
+        var gamesField = typeof(GameArtworkReconciliationService)
+            .GetField("_games", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var games = (GamesService)gamesField.GetValue(service)!;
+        var candidates = games.GetGames(libraryId, null)
+            .Select(game => ResolveCandidate(service, libraryId, game.Id))
+            .ToDictionary(candidate => candidate.GameId, StringComparer.Ordinal);
+        foreach (var candidate in candidates.Values)
+        {
+            await catalog.GetOrCreateAsync(candidate.Key, candidate.SystemId, "libretro-thumbnails-v3", candidate.GameId);
+        }
+
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            libraryId,
+            "snes",
+            "inventory-a",
+            candidates.Keys);
+        var first = candidates[discovery.PreviewCandidateGameIds[0]];
+        var second = candidates[discovery.PreviewCandidateGameIds[1]];
+        for (var index = 0; index < bestEffortCapacity; index++)
+        {
+            Assert.True(service.EnqueueRemoteForTest(Candidate("bulk-library", $"bulk-{index}"), ArtworkLane.Bulk));
+        }
+
+        Assert.True(service.EnqueueRemoteForTest(first, ArtworkLane.Preview));
+        Assert.False(service.EnqueueRemoteForTest(second, ArtworkLane.Bulk));
+
+        await catalog.MarkMissingAsync(first.Key, first.SystemId, "libretro-thumbnails-v3");
+        await RefreshPreviewSelectionAsync(service, first);
+
+        Assert.Contains("remote:" + second.Key.StorageKey, QueuedRemoteIdentities(service));
+    }
+
+    [Fact]
+    public async Task RequestRefresh_DoesNotItselfRepublishThePreviewSelection()
+    {
+        var (service, catalog, libraryId, candidates) = await CreatePreviewFixtureAsync(4);
+        foreach (var candidate in candidates.Values)
+        {
+            await catalog.MarkOriginalReadyAsync(candidate.Key, candidate.SystemId, $"C:/catalog/{candidate.GameId}.png");
+        }
+
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            libraryId,
+            "snes",
+            "inventory-a",
+            candidates.Keys);
+        var completed = await catalog.RecomputePreviewSelectionAsync(libraryId, "snes", "inventory-a");
+        var refreshed = candidates[discovery.PreviewCandidateGameIds[0]];
+
+        Assert.True(await service.RequestRefreshAsync(libraryId, refreshed.GameId, "boxart"));
+
+        var after = await catalog.GetSystemAsync(libraryId, "snes");
+        Assert.Equal(completed.PreviewGameIds, after.PreviewGameIds);
+        Assert.Equal(completed.PreviewSelectionGeneration, after.PreviewSelectionGeneration);
+        Assert.Equal(ArtworkCatalogState.Pending, (await catalog.GetAsync(refreshed.Key))?.State);
+    }
+
+    [Fact]
+    public async Task ReopeningMetadataDeferred_DoesNotItselfRepublishThePreviewSelection()
+    {
+        var (service, catalog, libraryId, candidates) = await CreatePreviewFixtureAsync(5);
+        var discovery = await catalog.GetOrCreatePreviewDiscoveryAsync(
+            libraryId,
+            "snes",
+            "inventory-a",
+            candidates.Keys);
+        var reopened = candidates[discovery.PreviewCandidateGameIds[0]];
+        var started = DateTimeOffset.UtcNow.AddHours(-25);
+        await catalog.MarkMetadataPendingAsync(
+            reopened.Key,
+            reopened.SystemId,
+            "libretro-thumbnails-v3",
+            started,
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromHours(3),
+            TimeSpan.FromHours(24));
+        await catalog.MarkMetadataPendingAsync(
+            reopened.Key,
+            reopened.SystemId,
+            "libretro-thumbnails-v3",
+            DateTimeOffset.UtcNow,
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromHours(3),
+            TimeSpan.FromHours(24));
+        foreach (var candidate in discovery.PreviewCandidateGameIds.Skip(1).Select(gameId => candidates[gameId]))
+        {
+            await catalog.MarkOriginalReadyAsync(candidate.Key, candidate.SystemId, $"C:/catalog/{candidate.GameId}.png");
+        }
+
+        var completed = await catalog.RecomputePreviewSelectionAsync(libraryId, "snes", "inventory-a");
+
+        Assert.True(await QueueCandidateAsync(service, reopened, reopenMetadataDeferred: true));
+
+        var after = await catalog.GetSystemAsync(libraryId, "snes");
+        Assert.Equal(completed.PreviewGameIds, after.PreviewGameIds);
+        Assert.Equal(completed.PreviewSelectionGeneration, after.PreviewSelectionGeneration);
+        Assert.Equal(ArtworkCatalogState.Pending, (await catalog.GetAsync(reopened.Key))?.State);
+    }
+
+    private async Task<(GameArtworkReconciliationService Service, GameArtworkCatalog Catalog, string LibraryId,
+        Dictionary<string, GameArtworkReconciliationService.ArtworkCandidate> Candidates)> CreatePreviewFixtureAsync(int gameCount)
+    {
+        var libraryRoot = Path.Combine(_root, $"Games-{gameCount}");
+        var systemRoot = Path.Combine(libraryRoot, "SNES");
+        Directory.CreateDirectory(systemRoot);
+        for (var index = 0; index < gameCount; index++)
+        {
+            await File.WriteAllBytesAsync(Path.Combine(systemRoot, $"Game-{index}.sfc"), [(byte)index]);
+        }
+
+        var libraryId = Guid.NewGuid().ToString();
+        var folders = new List<VirtualFolderInfo>
+        {
+            new() { Name = "Games", ItemId = libraryId, Locations = [libraryRoot] },
+        };
+        var service = CreateWatchingService(folders, out var catalog);
+        var gamesField = typeof(GameArtworkReconciliationService)
+            .GetField("_games", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var games = (GamesService)gamesField.GetValue(service)!;
+        var candidates = games.GetGames(libraryId, null)
+            .Select(game => ResolveCandidate(service, libraryId, game.Id))
+            .ToDictionary(candidate => candidate.GameId, StringComparer.Ordinal);
+        foreach (var candidate in candidates.Values)
+        {
+            await catalog.GetOrCreateAsync(candidate.Key, candidate.SystemId, "libretro-thumbnails-v3", candidate.GameId);
+        }
+
+        return (service, catalog, libraryId, candidates);
+    }
+
+    private static async Task<bool> QueueCandidateAsync(
+        GameArtworkReconciliationService service,
+        GameArtworkReconciliationService.ArtworkCandidate candidate,
+        bool reopenMetadataDeferred)
+    {
+        var method = typeof(GameArtworkReconciliationService)
+            .GetMethod("QueueCandidateAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var task = (Task<bool>)method.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [candidate, ArtworkLane.Preview, CancellationToken.None, reopenMetadataDeferred],
+            culture: null)!;
+        return await task;
+    }
+
+    private static GameArtworkReconciliationService.ArtworkCandidate ResolveCandidate(
+        GameArtworkReconciliationService service,
+        string libraryId,
+        string gameId)
+    {
+        var method = typeof(GameArtworkReconciliationService)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Single(candidate => candidate.Name == "TryCreateCandidate" &&
+                candidate.GetParameters().FirstOrDefault()?.ParameterType == typeof(string));
+        return Assert.IsType<GameArtworkReconciliationService.ArtworkCandidate>(method.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [libraryId, gameId, GameThumbService.ThumbKind.Boxart, null],
+            culture: null));
+    }
+
+    private static Task RefreshPreviewSelectionAsync(
+        GameArtworkReconciliationService service,
+        GameArtworkReconciliationService.ArtworkCandidate candidate)
+    {
+        var method = typeof(GameArtworkReconciliationService)
+            .GetMethod("RefreshPreviewSelectionAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [candidate, CancellationToken.None],
+            culture: null)!;
+    }
+
+    [Fact]
     public async Task StopAsync_CompletesCleanlyAndDisposesTheTokenSource()
     {
         var service = BuildService(_root);
 
         await service.StartAsync(CancellationToken.None);
-        await service.StopAsync(CancellationToken.None); // currently throws TaskCanceledException
+        await service.StopAsync(CancellationToken.None);
         await service.StartAsync(CancellationToken.None); // must be restartable
         await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_AllowsAnActiveButPartiallyInitializedLifetime()
+    {
+        var service = BuildService(_root);
+        StopSourceField.SetValue(service, new CancellationTokenSource());
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_HonorsItsDeadlineAndAllowsRestartAfterGrace()
+    {
+        var libraryRoot = Path.Combine(_root, "Games-blocked-stop");
+        Directory.CreateDirectory(Path.Combine(libraryRoot, "SNES"));
+        await File.WriteAllBytesAsync(Path.Combine(libraryRoot, "SNES", "First.sfc"), [1, 2, 3]);
+
+        var libraryId = Guid.NewGuid().ToString();
+        var folders = new List<VirtualFolderInfo>
+        {
+            new() { Name = "Games", ItemId = libraryId, Locations = [libraryRoot] },
+        };
+        var blockNextResolution = 0;
+        var resolutionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseResolution = new ManualResetEventSlim();
+        var libraryManager = new FakeLibraryManager(
+            folders,
+            () =>
+            {
+                if (Interlocked.Exchange(ref blockNextResolution, 0) != 0)
+                {
+                    resolutionStarted.TrySetResult();
+                    releaseResolution.Wait();
+                }
+            });
+        var service = new GameArtworkReconciliationService(
+            new GamesService(libraryManager),
+            (GameThumbService)RuntimeHelpers.GetUninitializedObject(typeof(GameThumbService)),
+            new GameArtworkCatalog(Path.Combine(_root, "catalog-blocked-stop")),
+            NullLogger<GameArtworkReconciliationService>.Instance,
+            taskManager: null,
+            watchLibraryFileSystem: true,
+            workerStopGraceForTests: TimeSpan.FromMilliseconds(200));
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            Interlocked.Exchange(ref blockNextResolution, 1);
+            service.OnGameLibrariesChanged();
+            await resolutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using var stopDeadline = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            await service.StopAsync(stopDeadline.Token).WaitAsync(TimeSpan.FromSeconds(2));
+
+            // The blocked worker is parked in a non-cancelable call, so cleanup gives up on it
+            // after the grace and restart must still succeed -- otherwise one wedged filesystem
+            // call leaves the plugin permanently unstartable.
+            await service.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+            releaseResolution.Set();
+        }
+        finally
+        {
+            releaseResolution.Set();
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public void WatcherSync_FromCanceledLifetimeDoesNotUseTheReplacementStopSource()
+    {
+        var libraryRoot = Path.Combine(_root, "Games-canceled-lifetime");
+        Directory.CreateDirectory(libraryRoot);
+        var folders = new List<VirtualFolderInfo>
+        {
+            new() { Name = "Games", ItemId = Guid.NewGuid().ToString(), Locations = [libraryRoot] },
+        };
+        var service = CreateWatchingService(folders, out _);
+        using var replacementStop = new CancellationTokenSource();
+        using var canceledLifetime = new CancellationTokenSource();
+        canceledLifetime.Cancel();
+        StopSourceField.SetValue(service, replacementStop);
+
+        var sync = typeof(GameArtworkReconciliationService)
+            .GetMethod("SyncLibraryWatchers", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        sync.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [canceledLifetime.Token],
+            culture: null);
+
+        Assert.Empty(service.WatchedLibraryRootsForTests);
+    }
+
+    [Fact]
+    public async Task Restart_DoesNotLetCanceledDelayedPreviewWorkRemoveItsReplacement()
+    {
+        var service = BuildService(_root);
+        var candidate = Candidate("library", "delayed-preview");
+        var thumbnailCandidate = candidate with { OriginalPath = "C:/catalog/delayed-preview.png" };
+        var retryAfter = DateTimeOffset.UtcNow.AddHours(1);
+
+        await service.StartAsync(CancellationToken.None);
+        Assert.True(service.EnqueueRemoteForTest(candidate, ArtworkLane.Preview, retryAfter));
+        QueueThumbnail(service, thumbnailCandidate, retryAfter);
+        await service.StopAsync(CancellationToken.None);
+        Assert.DoesNotContain("remote:" + candidate.Key.StorageKey, QueuedRemoteIdentities(service));
+        Assert.DoesNotContain("thumbnail:" + candidate.Key.StorageKey, QueuedThumbnailIdentities(service));
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            Assert.True(service.EnqueueRemoteForTest(candidate, ArtworkLane.Preview, retryAfter));
+            QueueThumbnail(service, thumbnailCandidate, retryAfter);
+            await Task.Delay(100);
+            Assert.Contains("remote:" + candidate.Key.StorageKey, QueuedRemoteIdentities(service));
+            Assert.Contains("thumbnail:" + candidate.Key.StorageKey, QueuedThumbnailIdentities(service));
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private static void QueueThumbnail(
+        GameArtworkReconciliationService service,
+        GameArtworkReconciliationService.ArtworkCandidate candidate,
+        DateTimeOffset notBefore)
+    {
+        var method = typeof(GameArtworkReconciliationService)
+            .GetMethod("QueueThumbnail", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        method.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [candidate, notBefore],
+            culture: null);
+    }
+
+    private static ICollection<string> QueuedThumbnailIdentities(GameArtworkReconciliationService service)
+    {
+        var field = typeof(GameArtworkReconciliationService)
+            .GetField("_thumbnailQueued", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var queued = (IEnumerable<KeyValuePair<string, int>>)field.GetValue(service)!;
+        return queued.Select(entry => entry.Key).ToArray();
     }
 
     [Fact]
@@ -512,6 +883,160 @@ public sealed class GameArtworkReconciliationServiceTests : IDisposable
         Assert.Equal(2, await DistinctGameCountAsync(catalog, libraryId, "snes"));
     }
 
+    // Overflows arrive in bursts during a romset copy, and queueing a pass directly ran a full
+    // library enumeration back to back for the length of the import. Debouncing still guarantees
+    // the pass, since the overflow itself arms the timer.
+    [Fact]
+    public async Task WatcherOverflow_WaitsForTheQuietPeriodInsteadOfReconcilingImmediately()
+    {
+        var service = BuildService(_root);
+        var stop = new CancellationTokenSource();
+        StopSourceField.SetValue(service, stop);
+        try
+        {
+            RaiseWatcherOverflow(service);
+
+            Assert.Equal(0, PendingReconciliations(service));
+            await WaitForPendingReconciliationAsync(service);
+        }
+        finally
+        {
+            stop.Cancel();
+        }
+    }
+
+    private static readonly FieldInfo StopSourceField = typeof(GameArtworkReconciliationService)
+        .GetField("_stop", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static void RaiseWatcherOverflow(GameArtworkReconciliationService service)
+    {
+        var handler = typeof(GameArtworkReconciliationService)
+            .GetMethod("OnLibraryWatcherError", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        handler.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [service, new ErrorEventArgs(new InternalBufferOverflowException())],
+            culture: null);
+    }
+
+    // The service is never started here, so nothing drains the semaphore and its count is stable.
+    private static int PendingReconciliations(GameArtworkReconciliationService service)
+    {
+        var field = typeof(GameArtworkReconciliationService)
+            .GetField("_reconciliationAvailable", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return ((SemaphoreSlim)field.GetValue(service)!).CurrentCount;
+    }
+
+    private static async Task WaitForPendingReconciliationAsync(GameArtworkReconciliationService service)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(20);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (PendingReconciliations(service) > 0)
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Assert.Fail("Timed out waiting for the quiet period to queue the reconciliation pass");
+    }
+
+    // Only overflow leaves a working watcher. Any other error -- a deleted or disconnected root --
+    // leaves one that never reports again, and SyncLibraryWatchers skips any root already in the
+    // dictionary, so without recycling the root stays unwatched until a restart.
+    [Fact]
+    public async Task WatcherFailure_RecreatesTheWatcherSoTheRootStaysWatched()
+    {
+        var libraryRoot = Path.Combine(_root, "Games");
+        Directory.CreateDirectory(Path.Combine(libraryRoot, "SNES"));
+        await File.WriteAllBytesAsync(Path.Combine(libraryRoot, "SNES", "First.sfc"), [1, 2, 3]);
+
+        var folders = new List<VirtualFolderInfo>
+        {
+            new() { Name = "Games", ItemId = Guid.NewGuid().ToString(), Locations = [libraryRoot] },
+        };
+        var service = CreateWatchingService(folders, out _);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await WaitForWatchedRootsAsync(service, [libraryRoot]);
+            var original = LibraryWatchers(service)[libraryRoot];
+
+            RaiseWatcherError(service, original, new IOException("root disconnected"));
+
+            await WaitUntilAsync(() => LibraryWatchers(service).TryGetValue(libraryRoot, out var current)
+                && !ReferenceEquals(current, original));
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public void WatcherOverflow_KeepsTheWatcherItAlreadyHas()
+    {
+        var service = BuildService(_root);
+        var stop = new CancellationTokenSource();
+        StopSourceField.SetValue(service, stop);
+        try
+        {
+            Directory.CreateDirectory(_root);
+            using var watcher = new FileSystemWatcher(_root) { EnableRaisingEvents = true };
+            LibraryWatchers(service).Add(_root, watcher);
+
+            RaiseWatcherError(service, watcher, new InternalBufferOverflowException());
+
+            Assert.Same(watcher, LibraryWatchers(service)[_root]);
+        }
+        finally
+        {
+            stop.Cancel();
+        }
+    }
+
+    private static Dictionary<string, FileSystemWatcher> LibraryWatchers(GameArtworkReconciliationService service)
+    {
+        var field = typeof(GameArtworkReconciliationService)
+            .GetField("_libraryWatchers", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Dictionary<string, FileSystemWatcher>)field.GetValue(service)!;
+    }
+
+    private static void RaiseWatcherError(
+        GameArtworkReconciliationService service,
+        FileSystemWatcher sender,
+        Exception error)
+    {
+        var handler = typeof(GameArtworkReconciliationService)
+            .GetMethod("OnLibraryWatcherError", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        handler.Invoke(
+            service,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [sender, new ErrorEventArgs(error)],
+            culture: null);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(20);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Assert.Fail("Timed out waiting for the watcher to be recreated");
+    }
+
     private static async Task<int> DistinctGameCountAsync(GameArtworkCatalog catalog, string libraryId, string systemId)
     {
         var projection = await catalog.GetSystemProjectionAsync(libraryId, systemId);
@@ -585,7 +1110,7 @@ public sealed class GameArtworkReconciliationServiceTests : IDisposable
         var key = ArtworkCatalogKey.Create("library", gameId + ".sfc", "fingerprint", "boxart");
         var source = new GameThumbSource(new[] { "snes" }, gameId, "C:/roms/" + gameId + ".sfc", system, false);
         var candidate = new GameArtworkReconciliationService.ArtworkCandidate(gameId, system, GameThumbService.ThumbKind.Boxart, source, key, null);
-        return GameArtworkReconciliationService.ArtworkWork.Remote(candidate, lane, null);
+        return GameArtworkReconciliationService.ArtworkWork.Remote(candidate, lane);
     }
 
     private static GameArtworkReconciliationService.ArtworkCandidate Candidate(string libraryId, string gameId, string system = "snes")

--- a/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkReconciliationServiceTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkReconciliationServiceTests.cs
@@ -604,7 +604,7 @@ public sealed class GameArtworkReconciliationServiceTests : IDisposable
             await service.StopAsync(stopDeadline.Token).WaitAsync(TimeSpan.FromSeconds(2));
 
             // The blocked worker is parked in a non-cancelable call, so cleanup gives up on it
-            // after the grace and restart must still succeed -- otherwise one wedged filesystem
+            // after the grace and restart must still succeed, otherwise one wedged filesystem
             // call leaves the plugin permanently unstartable.
             await service.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
 
@@ -944,8 +944,8 @@ public sealed class GameArtworkReconciliationServiceTests : IDisposable
         Assert.Fail("Timed out waiting for the quiet period to queue the reconciliation pass");
     }
 
-    // Only overflow leaves a working watcher. Any other error -- a deleted or disconnected root --
-    // leaves one that never reports again, and SyncLibraryWatchers skips any root already in the
+    // Only overflow leaves a working watcher. Any other error, such as a deleted or disconnected
+    // root, leaves one that never reports again, and SyncLibraryWatchers skips any root already in the
     // dictionary, so without recycling the root stays unwatched until a restart.
     [Fact]
     public async Task WatcherFailure_RecreatesTheWatcherSoTheRootStaysWatched()

--- a/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkStoreTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/GameArtworkStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Net.Http;
@@ -225,7 +226,10 @@ public class GameArtworkStoreTests : IDisposable
             maxArtworkBytes ?? GameArtworkStore.MaxArtworkBytes);
     }
 
-    private Task<GameArtworkLookupResult> LookupAsync(GameArtworkStore store, CancellationToken cancellationToken = default) =>
+    private Task<GameArtworkLookupResult> LookupAsync(
+        GameArtworkStore store,
+        CancellationToken cancellationToken = default,
+        TimeSpan? budget = null) =>
         store.LookupThumbAsync(
             core: "segaMS",
             coreWasDefaulted: false,
@@ -233,7 +237,35 @@ public class GameArtworkStoreTests : IDisposable
             romPath: Path.Combine(_root, RomFileName),
             title: null,
             kind: GameThumbService.ThumbKind.Boxart,
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken,
+            budget: budget);
+
+    // A prewarm has no client waiting on it and must be able to outlast the interactive budget,
+    // which is itself the ceiling on how long a /Thumb/ response may hang for an old client and so
+    // must not move.
+    [Fact]
+    public async Task Lookup_HonoursAnExplicitBudgetWithoutMovingTheInteractiveDefault()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(3), GameArtworkStore.InteractiveRequestBudget);
+        Assert.True(GameArtworkStore.PrewarmRequestBudget > GameArtworkStore.InteractiveRequestBudget);
+
+        var gate = new SemaphoreSlim(0);
+        var body = new UnseekableStream(new byte[64], blockAfterFirstReadOn: gate);
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(ThumbUrl(RomFileName), HttpStatusCode.OK, new StreamContent(body));
+        var store = CreateStore(handler);
+
+        var elapsed = Stopwatch.StartNew();
+        var result = await LookupAsync(store, budget: TimeSpan.FromMilliseconds(250));
+        elapsed.Stop();
+
+        // An ignored budget would instead park on the gate for the 3s default.
+        Assert.True(result.TimedOut);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(2), $"Lookup took {elapsed.Elapsed}");
+
+        gate.Release();
+        await WaitUntil(() => Directory.GetFiles(_root, "*.tmp").Length == 0, TimeSpan.FromSeconds(5));
+    }
 
     private void AssertNothingCached()
     {

--- a/Jellyfin/tests/Moonfin.Server.Tests/GameThumbServiceTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/GameThumbServiceTests.cs
@@ -30,6 +30,19 @@ public class GameThumbServiceTests : IDisposable
     // Matches GameThumbService.LibretroThumbName's own escaping: '/' becomes '_'.
     private const string WorldThumbFileName = "Great Golf _ Masters Golf (World)";
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void DerivedThumbnailService_RejectsNonPositiveEncodeConcurrency(int concurrency)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DerivedThumbnailService(
+            new NoOpLogger<DerivedThumbnailService>(),
+            Path.Combine(_root, "game_thumbs"),
+            imageEncoder: null,
+            encodeConcurrencyForTests: concurrency,
+            derivedThumbBudgetForTests: null));
+    }
+
     [Fact]
     public async Task GetThumbPathAsync_BestMatchNameHasNoArt_FallsThroughToSiblingThatDoes()
     {


### PR DESCRIPTION
# Pull Request

## Summary
This is fix/refactor/redesign born out of findings during load testing I was performing. Basically I threw thousands of games at it at once, and also "burst" fed it in and discovered a leak in the preview plans. This triggered multiple full-library reconcillation passses. Thought it would be a simple fix, but then one thing led to another and finally got sick of playing whack-a-mole and ripped out the whole thing out and redesigned it.

Large ROM imports no longer degrade the server (e.g. memory). Loading a large arcade set used to leak an abandoned plan entries in a Map. Also filesystem watchers with large continuous back-to-back library scans and titles with long names blew through an artwork timeout so they timed out on every attempt and retried forever without succeeding. All three are fixed, memory is bounded, scans wait for the library to go quiet, and background artwork fetching gets the time it needs while client-facing requests getting priority. Preview selection is now iterative, resumable, and restart-safe rather than an in-memory callback chain. Systems can recover from interrupted, rejected, evicted, or stale work instead of remaining permanently blank. Cached misses are processed without a recursive async traversal, and queue growth remains controlled while guaranteeing that preview discovery continues.

Filesystem reconciliation now waits for imports to go quiet, failed watchers are recreated, and interactive requests retain a short response budget while background "pre-warming" receives enough time to finish. 
Missing artwork files are detected and reopened automatically.

Worker threading was fixed such that they actually spawn multi-threads based upon a CPU core formula but caps out at 4 regardless to guard against crushing a system. 

All of that, and then some, are covered by tests. 

There is should be no impact on previous users. No API or protocol surface changed, so old and new clients are unaffected in both directions. The noticable effects (IF noticed) are that stuck systems can recover and imports run quieter and faster. 


## Related Issues
None (yet!)


## Type of Change
- [X] Bug fix
- [X] New feature
- [X] Refactor
- [X] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [X] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared


## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?
API endpoints don't change, should be no impacts to existing clients

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [ ] Change to the settings profile is additive only, no renamed or removed properties
- [ ] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Testing with physical devices under heavy load scenarios and generally doing stupid stuff like deleting artwork directories from the plugin server storage etc. 

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Shield and Fire Cube
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [ ] Any new setting keys match the client-side keys exactly
