### PR TITLE
bugfix-CWNU - Properly sync Continue Watching and Next Up Hidden Items

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Api/SettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/SettingsService.cs
@@ -188,6 +188,11 @@ namespace Emby.Plugins.Moonfin.Api
                 if (adminDefaults != null) return Json(adminDefaults);
                 return Json(404, new { Error = "No settings found" });
             }
+
+            // A pull is the only place a client learns about hides made elsewhere, so this is
+            // where its baseline moves.
+            await Settings.RecordHiddenContentBaselineAsync(userId.Value, profile, resolved).ConfigureAwait(false);
+
             return Json(resolved);
         }
 

--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinUserSettings.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinUserSettings.cs
@@ -29,6 +29,14 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("tv")]
         public MoonfinSettingsProfile? Tv { get; set; }
 
+        /// <summary>
+        /// What each profile was last handed for the hidden content maps, keyed by profile name.
+        /// Clients push their whole map rather than a delta, so this is what tells an item a
+        /// profile unhid apart from one it never received.
+        /// </summary>
+        [JsonPropertyName("hiddenContentBaselines")]
+        public Dictionary<string, HiddenContentBaseline>? HiddenContentBaselines { get; set; }
+
         [JsonPropertyName("seerrEnabled")] public bool? SeerrEnabled { get; set; }
         [JsonPropertyName("seerrApiKey")] public string? SeerrApiKey { get; set; }
         [JsonPropertyName("seerrRows")] public SeerrRowsConfig? SeerrRows { get; set; }
@@ -112,6 +120,18 @@ namespace Emby.Plugins.Moonfin.Models
         }
 
         public static readonly string[] ValidProfiles = { "global", "desktop", "mobile", "tv" };
+    }
+
+    /// <summary>
+    /// The hidden content maps one profile is known to hold.
+    /// </summary>
+    public class HiddenContentBaseline
+    {
+        [JsonPropertyName("continueWatching")]
+        public string? ContinueWatching { get; set; }
+
+        [JsonPropertyName("nextUpSeries")]
+        public string? NextUpSeries { get; set; }
     }
 
     public class SeerrRowsConfig

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -716,22 +716,23 @@ namespace Emby.Plugins.Moonfin.Services
             }
 
             // Content hiding is a global preference, so lift each device's hidden lists into the
-            // global profile. Union across devices so a file that hid items on more than one device
-            // keeps them all instead of the last device winning.
-            var devices = new[] { settings.Desktop, settings.Mobile, settings.Tv };
+            // global profile. Union across global and all devices so items hidden on any device
+            // persist instead of subsequent device pushes overwriting the global list.
+            var allProfiles = new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv };
 
-            var hiddenContinueWatching = UnionHiddenEntries(devices, p => p.HiddenContinueWatchingItems);
+            var hiddenContinueWatching = UnionHiddenEntries(allProfiles, p => p.HiddenContinueWatchingItems);
             if (hiddenContinueWatching != null)
             {
                 settings.Global.HiddenContinueWatchingItems = hiddenContinueWatching;
             }
 
-            var hiddenNextUp = UnionHiddenEntries(devices, p => p.HiddenNextUpSeries);
+            var hiddenNextUp = UnionHiddenEntries(allProfiles, p => p.HiddenNextUpSeries);
             if (hiddenNextUp != null)
             {
                 settings.Global.HiddenNextUpSeries = hiddenNextUp;
             }
 
+            var devices = new[] { settings.Desktop, settings.Mobile, settings.Tv };
             foreach (var device in devices)
             {
                 if (device == null) continue;
@@ -741,14 +742,14 @@ namespace Emby.Plugins.Moonfin.Services
         }
 
         private static string? UnionHiddenEntries(
-            MoonfinSettingsProfile?[] devices,
+            MoonfinSettingsProfile?[] profiles,
             Func<MoonfinSettingsProfile, string?> selector)
         {
             Dictionary<string, string>? merged = null;
-            foreach (var device in devices)
+            foreach (var profile in profiles)
             {
-                if (device == null) continue;
-                var value = selector(device);
+                if (profile == null) continue;
+                var value = selector(profile);
                 if (value == null) continue;
 
                 if (merged == null)
@@ -757,7 +758,11 @@ namespace Emby.Plugins.Moonfin.Services
                 }
                 foreach (var pair in ParseHiddenEntries(value))
                 {
-                    merged[pair.Key] = pair.Value;
+                    if (!merged.TryGetValue(pair.Key, out var existingDate) ||
+                        string.Compare(pair.Value, existingDate, StringComparison.Ordinal) > 0)
+                    {
+                        merged[pair.Key] = pair.Value;
+                    }
                 }
             }
 

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -85,6 +86,48 @@ namespace Emby.Plugins.Moonfin.Services
             {
                 _logger.ErrorException("Error reading settings for user " + userId, ex);
                 return null;
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Notes what a profile was just handed for the hidden content maps, which is what the
+        /// next push from it gets merged against.
+        /// </summary>
+        public async Task RecordHiddenContentBaselineAsync(Guid userId, string profileName, MoonfinSettingsProfile resolved)
+        {
+            if (string.IsNullOrEmpty(profileName)) return;
+
+            var name = profileName.ToLowerInvariant();
+            var filePath = GetUserSettingsPath(userId);
+
+            await _lock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                var settings = await Task.Run(() => ReadSettingsWithRecovery(filePath)).ConfigureAwait(false);
+                if (settings == null) return;
+
+                if (settings.HiddenContentBaselines != null &&
+                    settings.HiddenContentBaselines.TryGetValue(name, out var known) &&
+                    known.ContinueWatching == resolved.HiddenContinueWatchingItems &&
+                    known.NextUpSeries == resolved.HiddenNextUpSeries)
+                {
+                    return;
+                }
+
+                var baseline = BaselineFor(settings, name);
+                baseline.ContinueWatching = resolved.HiddenContinueWatchingItems;
+                baseline.NextUpSeries = resolved.HiddenNextUpSeries;
+
+                var serialized = JsonSerializer.Serialize(settings, _jsonOptions);
+                await Task.Run(() => AtomicFile.WriteAllText(filePath, serialized)).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.ErrorException("Could not record the hidden content baseline for user " + userId, ex);
             }
             finally
             {
@@ -226,12 +269,16 @@ namespace Emby.Plugins.Moonfin.Services
             {
                 MoonfinUserSettings finalSettings;
                 string? beforeComparisonJson = null;
+                string? storedHiddenContinueWatching = null;
+                string? storedHiddenNextUp = null;
                 if (mergeMode == "merge")
                 {
                     var existingSettings = await Task.Run(() => ReadSettingsWithRecovery(filePath)).ConfigureAwait(false);
                     if (existingSettings != null && existingSettings.NeedsMigration)
                         existingSettings = MigrateV1ToV2(existingSettings);
                     beforeComparisonJson = SerializeForComparison(existingSettings ?? new MoonfinUserSettings());
+                    storedHiddenContinueWatching = existingSettings?.Global?.HiddenContinueWatchingItems;
+                    storedHiddenNextUp = existingSettings?.Global?.HiddenNextUpSeries;
                     finalSettings = MergeSettings(existingSettings, settings);
                 }
                 else
@@ -244,7 +291,7 @@ namespace Emby.Plugins.Moonfin.Services
                 finalSettings.LastUpdatedBy = clientId ?? "unknown";
                 finalSettings.SchemaVersion = 2;
 
-                MoveContentHidingToGlobal(finalSettings);
+                MoveContentHidingToGlobal(finalSettings, storedHiddenContinueWatching, storedHiddenNextUp);
 
                 settingsChanged = SettingsDiffer(beforeComparisonJson, finalSettings);
 
@@ -274,6 +321,8 @@ namespace Emby.Plugins.Moonfin.Services
                 if (settings.NeedsMigration) settings = MigrateV1ToV2(settings);
 
                 var beforeComparisonJson = SerializeForComparison(settings);
+                var storedHiddenContinueWatching = settings.Global?.HiddenContinueWatchingItems;
+                var storedHiddenNextUp = settings.Global?.HiddenNextUpSeries;
 
                 var existingProfile = string.Equals(profileName, "global", StringComparison.OrdinalIgnoreCase)
                     ? settings.Global
@@ -289,7 +338,7 @@ namespace Emby.Plugins.Moonfin.Services
                 settings.LastUpdatedBy = clientId ?? "unknown";
                 settings.SchemaVersion = 2;
 
-                MoveContentHidingToGlobal(settings);
+                MoveContentHidingToGlobal(settings, storedHiddenContinueWatching, storedHiddenNextUp);
 
                 settingsChanged = SettingsDiffer(beforeComparisonJson, settings);
 
@@ -329,6 +378,7 @@ namespace Emby.Plugins.Moonfin.Services
             node.Remove("schemaVersion");
             node.Remove("lastUpdated");
             node.Remove("lastUpdatedBy");
+            node.Remove("hiddenContentBaselines");
             return node.ToJsonString();
         }
 
@@ -708,25 +758,50 @@ namespace Emby.Plugins.Moonfin.Services
             };
         }
 
-        private void MoveContentHidingToGlobal(MoonfinUserSettings settings)
+        private static readonly (string Name, Func<MoonfinUserSettings, MoonfinSettingsProfile?> Get)[] HidingProfiles =
+        {
+            ("global", s => s.Global),
+            ("desktop", s => s.Desktop),
+            ("mobile", s => s.Mobile),
+            ("tv", s => s.Tv),
+        };
+
+        /// <summary>
+        /// Content hiding is a global preference, so each profile's hidden lists get lifted into
+        /// the global one. Everything a profile pushed is merged in, anything its baseline still
+        /// lists that the push leaves out counts as unhidden and is dropped, and hides it hasn't
+        /// pulled yet are left alone. The stored global maps are passed in because a push to the
+        /// global profile overwrites them in place before this runs.
+        /// </summary>
+        private static void MoveContentHidingToGlobal(
+            MoonfinUserSettings settings,
+            string? storedContinueWatching,
+            string? storedNextUp)
         {
             if (settings.Global == null)
             {
                 settings.Global = new MoonfinSettingsProfile();
             }
 
-            // Content hiding is a global preference, so lift each device's hidden lists into the
-            // global profile. Union across global and all devices so items hidden on any device
-            // persist instead of subsequent device pushes overwriting the global list.
-            var allProfiles = new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv };
+            var hiddenContinueWatching = MergeHiddenEntries(
+                settings,
+                storedContinueWatching,
+                p => p.HiddenContinueWatchingItems,
+                b => b.ContinueWatching,
+                (b, v) => b.ContinueWatching = v);
 
-            var hiddenContinueWatching = UnionHiddenEntries(allProfiles, p => p.HiddenContinueWatchingItems);
             if (hiddenContinueWatching != null)
             {
                 settings.Global.HiddenContinueWatchingItems = hiddenContinueWatching;
             }
 
-            var hiddenNextUp = UnionHiddenEntries(allProfiles, p => p.HiddenNextUpSeries);
+            var hiddenNextUp = MergeHiddenEntries(
+                settings,
+                storedNextUp,
+                p => p.HiddenNextUpSeries,
+                b => b.NextUpSeries,
+                (b, v) => b.NextUpSeries = v);
+
             if (hiddenNextUp != null)
             {
                 settings.Global.HiddenNextUpSeries = hiddenNextUp;
@@ -741,35 +816,97 @@ namespace Emby.Plugins.Moonfin.Services
             }
         }
 
-        private static string? UnionHiddenEntries(
-            MoonfinSettingsProfile?[] profiles,
-            Func<MoonfinSettingsProfile, string?> selector)
+        /// <summary>
+        /// Folds every profile's push of one hidden map into the stored global value. Null when no
+        /// profile pushed the field, so a partial save leaves what is on file alone.
+        /// </summary>
+        private static string? MergeHiddenEntries(
+            MoonfinUserSettings settings,
+            string? stored,
+            Func<MoonfinSettingsProfile, string?> selector,
+            Func<HiddenContentBaseline, string?> readBaseline,
+            Action<HiddenContentBaseline, string?> writeBaseline)
         {
-            Dictionary<string, string>? merged = null;
-            foreach (var profile in profiles)
+            var merged = ParseHiddenEntries(stored);
+            var pushed = false;
+
+            foreach (var (name, get) in HidingProfiles)
             {
+                var profile = get(settings);
                 if (profile == null) continue;
+
                 var value = selector(profile);
                 if (value == null) continue;
 
-                if (merged == null)
+                // The global profile is where the stored map lives, so it only counts as a push
+                // when a client sent something other than what was already on file.
+                if (name == "global" && value == stored) continue;
+
+                pushed = true;
+                var entries = ParseHiddenEntries(value);
+
+                string? baseline = null;
+                if (settings.HiddenContentBaselines != null &&
+                    settings.HiddenContentBaselines.TryGetValue(name, out var known))
                 {
-                    merged = new Dictionary<string, string>();
+                    baseline = readBaseline(known);
                 }
-                foreach (var pair in ParseHiddenEntries(value))
+
+                foreach (var key in ParseHiddenEntries(baseline).Keys)
+                {
+                    if (!entries.ContainsKey(key))
+                    {
+                        merged.Remove(key);
+                    }
+                }
+
+                foreach (var pair in entries)
                 {
                     if (!merged.TryGetValue(pair.Key, out var existingDate) ||
-                        string.Compare(pair.Value, existingDate, StringComparison.Ordinal) > 0)
+                        IsLaterHide(pair.Value, existingDate))
                     {
                         merged[pair.Key] = pair.Value;
                     }
                 }
+
+                writeBaseline(BaselineFor(settings, name), value);
             }
 
-            return merged == null ? null : JsonSerializer.Serialize(merged);
+            return pushed ? JsonSerializer.Serialize(merged) : null;
         }
 
-        private static Dictionary<string, string> ParseHiddenEntries(string value)
+        private static HiddenContentBaseline BaselineFor(MoonfinUserSettings settings, string profileName)
+        {
+            if (settings.HiddenContentBaselines == null)
+            {
+                settings.HiddenContentBaselines = new Dictionary<string, HiddenContentBaseline>();
+            }
+
+            if (!settings.HiddenContentBaselines.TryGetValue(profileName, out var baseline))
+            {
+                baseline = new HiddenContentBaseline();
+                settings.HiddenContentBaselines[profileName] = baseline;
+            }
+
+            return baseline;
+        }
+
+        /// <summary>
+        /// Whether one hide timestamp is later than another. Clients write ISO-8601, but the field
+        /// is free-form, so anything that won't parse falls back to comparing the text.
+        /// </summary>
+        private static bool IsLaterHide(string candidate, string existing)
+        {
+            if (DateTimeOffset.TryParse(candidate, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var candidateAt) &&
+                DateTimeOffset.TryParse(existing, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var existingAt))
+            {
+                return candidateAt > existingAt;
+            }
+
+            return string.Compare(candidate, existing, StringComparison.Ordinal) > 0;
+        }
+
+        private static Dictionary<string, string> ParseHiddenEntries(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
             {

--- a/Jellyfin/backend/Api/MoonfinController.cs
+++ b/Jellyfin/backend/Api/MoonfinController.cs
@@ -656,6 +656,10 @@ public class MoonfinController : ControllerBase
             return adminDefaults != null ? Ok(adminDefaults) : NotFound(new { Error = "No settings found" });
         }
 
+        // A pull is the only place a client learns about hides made elsewhere, so this is where
+        // its baseline moves.
+        await _settingsService.RecordHiddenContentBaselineAsync(userId.Value, profile, resolved);
+
         return Ok(resolved);
     }
 

--- a/Jellyfin/backend/Models/MoonfinUserSettings.cs
+++ b/Jellyfin/backend/Models/MoonfinUserSettings.cs
@@ -33,6 +33,14 @@ public class MoonfinUserSettings
     [JsonPropertyName("tv")]
     public MoonfinSettingsProfile? Tv { get; set; }
 
+    /// <summary>
+    /// What each profile was last handed for the hidden content maps, keyed by profile name.
+    /// Clients push their whole map rather than a delta, so this is what tells an item a profile
+    /// unhid apart from one it never received.
+    /// </summary>
+    [JsonPropertyName("hiddenContentBaselines")]
+    public Dictionary<string, HiddenContentBaseline>? HiddenContentBaselines { get; set; }
+
     // ─── Legacy v1 flat fields (for migration) ─────────────────────────
     // These are populated when reading a v1 file, then migrated to profiles.
 
@@ -184,6 +192,18 @@ public class MoonfinUserSettings
 
     /// <summary>Valid profile names.</summary>
     public static readonly string[] ValidProfiles = { "global", "desktop", "mobile", "tv" };
+}
+
+/// <summary>
+/// The hidden content maps one profile is known to hold.
+/// </summary>
+public class HiddenContentBaseline
+{
+    [JsonPropertyName("continueWatching")]
+    public string? ContinueWatching { get; set; }
+
+    [JsonPropertyName("nextUpSeries")]
+    public string? NextUpSeries { get; set; }
 }
 
 public class SeerrRowsConfig

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -589,22 +589,23 @@ public class MoonfinSettingsService
         }
 
         // Content hiding is a global preference, so lift each device's hidden lists into the
-        // global profile. Union across devices so a file that hid items on more than one device
-        // keeps them all instead of the last device winning.
-        var devices = new[] { settings.Desktop, settings.Mobile, settings.Tv };
+        // global profile. Union across global and all devices so items hidden on any device
+        // persist instead of subsequent device pushes overwriting the global list.
+        var allProfiles = new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv };
 
-        var hiddenContinueWatching = UnionHiddenEntries(devices, p => p.HiddenContinueWatchingItems);
+        var hiddenContinueWatching = UnionHiddenEntries(allProfiles, p => p.HiddenContinueWatchingItems);
         if (hiddenContinueWatching != null)
         {
             settings.Global.HiddenContinueWatchingItems = hiddenContinueWatching;
         }
 
-        var hiddenNextUp = UnionHiddenEntries(devices, p => p.HiddenNextUpSeries);
+        var hiddenNextUp = UnionHiddenEntries(allProfiles, p => p.HiddenNextUpSeries);
         if (hiddenNextUp != null)
         {
             settings.Global.HiddenNextUpSeries = hiddenNextUp;
         }
 
+        var devices = new[] { settings.Desktop, settings.Mobile, settings.Tv };
         foreach (var device in devices)
         {
             if (device == null) continue;
@@ -614,14 +615,14 @@ public class MoonfinSettingsService
     }
 
     private static string? UnionHiddenEntries(
-        MoonfinSettingsProfile?[] devices,
+        MoonfinSettingsProfile?[] profiles,
         Func<MoonfinSettingsProfile, string?> selector)
     {
         Dictionary<string, string>? merged = null;
-        foreach (var device in devices)
+        foreach (var profile in profiles)
         {
-            if (device == null) continue;
-            var value = selector(device);
+            if (profile == null) continue;
+            var value = selector(profile);
             if (value == null) continue;
 
             if (merged == null)
@@ -630,7 +631,11 @@ public class MoonfinSettingsService
             }
             foreach (var pair in ParseHiddenEntries(value))
             {
-                merged[pair.Key] = pair.Value;
+                if (!merged.TryGetValue(pair.Key, out var existingDate) ||
+                    string.Compare(pair.Value, existingDate, StringComparison.Ordinal) > 0)
+                {
+                    merged[pair.Key] = pair.Value;
+                }
             }
         }
 

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Threading.Channels;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -99,6 +100,53 @@ public class MoonfinSettingsService
         {
             _logger.LogError(ex, "Error reading settings for user {UserId}", userId);
             return null;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Notes what a profile was just handed for the hidden content maps, which is what the next
+    /// push from it gets merged against.
+    /// </summary>
+    public async Task RecordHiddenContentBaselineAsync(Guid userId, string profileName, MoonfinSettingsProfile resolved)
+    {
+        if (string.IsNullOrEmpty(profileName))
+        {
+            return;
+        }
+
+        var name = profileName.ToLowerInvariant();
+        var filePath = GetUserSettingsPath(userId);
+
+        await _lock.WaitAsync();
+        try
+        {
+            var settings = ReadSettingsWithRecovery(filePath);
+            if (settings == null)
+            {
+                return;
+            }
+
+            if (settings.HiddenContentBaselines != null &&
+                settings.HiddenContentBaselines.TryGetValue(name, out var known) &&
+                known.ContinueWatching == resolved.HiddenContinueWatchingItems &&
+                known.NextUpSeries == resolved.HiddenNextUpSeries)
+            {
+                return;
+            }
+
+            var baseline = BaselineFor(settings, name);
+            baseline.ContinueWatching = resolved.HiddenContinueWatchingItems;
+            baseline.NextUpSeries = resolved.HiddenNextUpSeries;
+
+            AtomicFile.WriteAllText(filePath, JsonSerializer.Serialize(settings, _jsonOptions));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not record the hidden content baseline for {UserId}", userId);
         }
         finally
         {
@@ -225,6 +273,8 @@ public class MoonfinSettingsService
             MoonfinUserSettings finalSettings;
             var customSectionsBefore = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             string? beforeComparisonJson = null;
+            string? storedHiddenContinueWatching = null;
+            string? storedHiddenNextUp = null;
 
             if (mergeMode == "merge")
             {
@@ -240,6 +290,8 @@ public class MoonfinSettingsService
                 // were on file first or there's nothing left to compare against.
                 customSectionsBefore = CustomHomeSectionIds(existingSettings);
                 beforeComparisonJson = SerializeForComparison(existingSettings ?? new MoonfinUserSettings());
+                storedHiddenContinueWatching = existingSettings?.Global?.HiddenContinueWatchingItems;
+                storedHiddenNextUp = existingSettings?.Global?.HiddenNextUpSeries;
                 finalSettings = MergeSettings(existingSettings, settings);
             }
             else
@@ -253,7 +305,7 @@ public class MoonfinSettingsService
             finalSettings.LastUpdatedBy = clientId ?? "unknown";
             finalSettings.SchemaVersion = 2;
 
-            MoveContentHidingToGlobal(finalSettings);
+            MoveContentHidingToGlobal(finalSettings, storedHiddenContinueWatching, storedHiddenNextUp);
             PropagateCustomHomeSectionsAcrossProfiles(
                 finalSettings,
                 removed: RemovedCustomHomeSections(
@@ -300,6 +352,8 @@ public class MoonfinSettingsService
             }
 
             var beforeComparisonJson = SerializeForComparison(settings);
+            var storedHiddenContinueWatching = settings.Global?.HiddenContinueWatchingItems;
+            var storedHiddenNextUp = settings.Global?.HiddenNextUpSeries;
 
             // Merge profile properties
             var existingProfile = profileName.ToLowerInvariant() == "global" 
@@ -330,7 +384,7 @@ public class MoonfinSettingsService
             settings.LastUpdatedBy = clientId ?? "unknown";
             settings.SchemaVersion = 2;
 
-            MoveContentHidingToGlobal(settings);
+            MoveContentHidingToGlobal(settings, storedHiddenContinueWatching, storedHiddenNextUp);
             PropagateCustomHomeSectionsAcrossProfiles(
                 settings,
                 savedProfile,
@@ -381,6 +435,7 @@ public class MoonfinSettingsService
         node.Remove("schemaVersion");
         node.Remove("lastUpdated");
         node.Remove("lastUpdatedBy");
+        node.Remove("hiddenContentBaselines");
         return node.ToJsonString();
     }
 
@@ -581,25 +636,47 @@ public class MoonfinSettingsService
         settings.ClientSpecific = null;
     }
 
-    private void MoveContentHidingToGlobal(MoonfinUserSettings settings)
+    private static readonly (string Name, Func<MoonfinUserSettings, MoonfinSettingsProfile?> Get)[] HidingProfiles =
     {
-        if (settings.Global == null)
-        {
-            settings.Global = new MoonfinSettingsProfile();
-        }
+        ("global", s => s.Global),
+        ("desktop", s => s.Desktop),
+        ("mobile", s => s.Mobile),
+        ("tv", s => s.Tv),
+    };
 
-        // Content hiding is a global preference, so lift each device's hidden lists into the
-        // global profile. Union across global and all devices so items hidden on any device
-        // persist instead of subsequent device pushes overwriting the global list.
-        var allProfiles = new[] { settings.Global, settings.Desktop, settings.Mobile, settings.Tv };
+    /// <summary>
+    /// Content hiding is a global preference, so each profile's hidden lists get lifted into the
+    /// global one. Everything a profile pushed is merged in, anything its baseline still lists
+    /// that the push leaves out counts as unhidden and is dropped, and hides it hasn't pulled yet
+    /// are left alone. The stored global maps are passed in because a push to the global profile
+    /// overwrites them in place before this runs.
+    /// </summary>
+    private static void MoveContentHidingToGlobal(
+        MoonfinUserSettings settings,
+        string? storedContinueWatching,
+        string? storedNextUp)
+    {
+        settings.Global ??= new MoonfinSettingsProfile();
 
-        var hiddenContinueWatching = UnionHiddenEntries(allProfiles, p => p.HiddenContinueWatchingItems);
+        var hiddenContinueWatching = MergeHiddenEntries(
+            settings,
+            storedContinueWatching,
+            p => p.HiddenContinueWatchingItems,
+            b => b.ContinueWatching,
+            (b, v) => b.ContinueWatching = v);
+
         if (hiddenContinueWatching != null)
         {
             settings.Global.HiddenContinueWatchingItems = hiddenContinueWatching;
         }
 
-        var hiddenNextUp = UnionHiddenEntries(allProfiles, p => p.HiddenNextUpSeries);
+        var hiddenNextUp = MergeHiddenEntries(
+            settings,
+            storedNextUp,
+            p => p.HiddenNextUpSeries,
+            b => b.NextUpSeries,
+            (b, v) => b.NextUpSeries = v);
+
         if (hiddenNextUp != null)
         {
             settings.Global.HiddenNextUpSeries = hiddenNextUp;
@@ -614,35 +691,94 @@ public class MoonfinSettingsService
         }
     }
 
-    private static string? UnionHiddenEntries(
-        MoonfinSettingsProfile?[] profiles,
-        Func<MoonfinSettingsProfile, string?> selector)
+    /// <summary>
+    /// Folds every profile's push of one hidden map into the stored global value. Null when no
+    /// profile pushed the field, so a partial save leaves what is on file alone.
+    /// </summary>
+    private static string? MergeHiddenEntries(
+        MoonfinUserSettings settings,
+        string? stored,
+        Func<MoonfinSettingsProfile, string?> selector,
+        Func<HiddenContentBaseline, string?> readBaseline,
+        Action<HiddenContentBaseline, string?> writeBaseline)
     {
-        Dictionary<string, string>? merged = null;
-        foreach (var profile in profiles)
+        var merged = ParseHiddenEntries(stored);
+        var pushed = false;
+
+        foreach (var (name, get) in HidingProfiles)
         {
+            var profile = get(settings);
             if (profile == null) continue;
+
             var value = selector(profile);
             if (value == null) continue;
 
-            if (merged == null)
+            // The global profile is where the stored map lives, so it only counts as a push when
+            // a client sent something other than what was already on file.
+            if (name == "global" && value == stored) continue;
+
+            pushed = true;
+            var entries = ParseHiddenEntries(value);
+
+            string? baseline = null;
+            if (settings.HiddenContentBaselines != null &&
+                settings.HiddenContentBaselines.TryGetValue(name, out var known))
             {
-                merged = new Dictionary<string, string>();
+                baseline = readBaseline(known);
             }
-            foreach (var pair in ParseHiddenEntries(value))
+
+            foreach (var key in ParseHiddenEntries(baseline).Keys)
+            {
+                if (!entries.ContainsKey(key))
+                {
+                    merged.Remove(key);
+                }
+            }
+
+            foreach (var pair in entries)
             {
                 if (!merged.TryGetValue(pair.Key, out var existingDate) ||
-                    string.Compare(pair.Value, existingDate, StringComparison.Ordinal) > 0)
+                    IsLaterHide(pair.Value, existingDate))
                 {
                     merged[pair.Key] = pair.Value;
                 }
             }
+
+            writeBaseline(BaselineFor(settings, name), value);
         }
 
-        return merged == null ? null : JsonSerializer.Serialize(merged);
+        return pushed ? JsonSerializer.Serialize(merged) : null;
     }
 
-    private static Dictionary<string, string> ParseHiddenEntries(string value)
+    private static HiddenContentBaseline BaselineFor(MoonfinUserSettings settings, string profileName)
+    {
+        settings.HiddenContentBaselines ??= new Dictionary<string, HiddenContentBaseline>();
+
+        if (!settings.HiddenContentBaselines.TryGetValue(profileName, out var baseline))
+        {
+            baseline = new HiddenContentBaseline();
+            settings.HiddenContentBaselines[profileName] = baseline;
+        }
+
+        return baseline;
+    }
+
+    /// <summary>
+    /// Whether one hide timestamp is later than another. Clients write ISO-8601, but the field is
+    /// free-form, so anything that won't parse falls back to comparing the text.
+    /// </summary>
+    private static bool IsLaterHide(string candidate, string existing)
+    {
+        if (DateTimeOffset.TryParse(candidate, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var candidateAt) &&
+            DateTimeOffset.TryParse(existing, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var existingAt))
+        {
+            return candidateAt > existingAt;
+        }
+
+        return string.Compare(candidate, existing, StringComparison.Ordinal) > 0;
+    }
+
+    private static Dictionary<string, string> ParseHiddenEntries(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {

--- a/Jellyfin/tests/Moonfin.Server.Tests/AdminDefaultsMergeTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/AdminDefaultsMergeTests.cs
@@ -146,4 +146,53 @@ public sealed class AdminDefaultsMergeTests : IDisposable
 
         Assert.Null(defaults.HiddenContinueWatchingItems);
     }
+
+    [Fact]
+    public async Task SuccessiveDeviceProfileSavesPreserveGlobalHiddenItems()
+    {
+        var userId = Guid.NewGuid();
+
+        // 1. TV saves an item to hide
+        await _service.SaveProfileAsync(
+            userId,
+            "tv",
+            new MoonfinSettingsProfile { HiddenContinueWatchingItems = "{\"item-tv\":\"2026-09-01T01:00:00Z\"}" },
+            "tv-client",
+            notifySettingsChanged: false);
+
+        var afterTv = Read(userId);
+        Assert.Contains("item-tv", afterTv.Global?.HiddenContinueWatchingItems ?? string.Empty, StringComparison.Ordinal);
+
+        // 2. Mobile saves a different item to hide (or pushes without hidden items)
+        await _service.SaveProfileAsync(
+            userId,
+            "mobile",
+            new MoonfinSettingsProfile { HiddenContinueWatchingItems = "{\"item-mobile\":\"2026-09-01T02:00:00Z\"}" },
+            "mobile-client",
+            notifySettingsChanged: false);
+
+        var afterMobile = Read(userId);
+        var globalHidden = afterMobile.Global?.HiddenContinueWatchingItems ?? string.Empty;
+        Assert.Contains("item-tv", globalHidden, StringComparison.Ordinal);
+        Assert.Contains("item-mobile", globalHidden, StringComparison.Ordinal);
+
+        // 3. TV saves an unrelated setting with null/empty hidden items
+        await _service.SaveProfileAsync(
+            userId,
+            "tv",
+            new MoonfinSettingsProfile { CinemaModeEnabled = true },
+            "tv-client",
+            notifySettingsChanged: false);
+
+        var afterTvUpdate = Read(userId);
+        var finalGlobalHidden = afterTvUpdate.Global?.HiddenContinueWatchingItems ?? string.Empty;
+        Assert.Contains("item-tv", finalGlobalHidden, StringComparison.Ordinal);
+        Assert.Contains("item-mobile", finalGlobalHidden, StringComparison.Ordinal);
+
+        // 4. Resolving TV profile retrieves both items from Global
+        var resolvedTv = _service.ResolveProfile(afterTvUpdate, "tv");
+        Assert.Contains("item-tv", resolvedTv.HiddenContinueWatchingItems ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("item-mobile", resolvedTv.HiddenContinueWatchingItems ?? string.Empty, StringComparison.Ordinal);
+    }
 }
+

--- a/Jellyfin/tests/Moonfin.Server.Tests/ContentHidingSyncTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/ContentHidingSyncTests.cs
@@ -1,0 +1,213 @@
+using Moonfin.Server.Models;
+using Moonfin.Server.Services;
+using Xunit;
+
+namespace Moonfin.Server.Tests;
+
+/// <summary>
+/// Hiding an item from Continue Watching or Next Up syncs as a whole map of item id to the time it
+/// was hidden, and unhiding is expressed by dropping the key rather than by any kind of tombstone.
+/// The server therefore has to remember what each profile was last handed, or it can't tell a key
+/// a client removed from one it was never sent.
+/// </summary>
+public sealed class ContentHidingSyncTests : IDisposable
+{
+    private readonly string _dataPath;
+    private readonly MoonfinSettingsService _service;
+
+    public ContentHidingSyncTests()
+    {
+        _dataPath = Path.Combine(Path.GetTempPath(), "moonfin-hiding-tests-" + Guid.NewGuid().ToString("N"));
+        _service = new MoonfinSettingsService(new NoOpLogger<MoonfinSettingsService>(), _dataPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dataPath))
+        {
+            Directory.Delete(_dataPath, recursive: true);
+        }
+    }
+
+    private Task PushAsync(Guid userId, string profile, string? hiddenContinueWatching = null, string? hiddenNextUp = null) =>
+        _service.SaveProfileAsync(
+            userId,
+            profile,
+            new MoonfinSettingsProfile
+            {
+                HiddenContinueWatchingItems = hiddenContinueWatching,
+                HiddenNextUpSeries = hiddenNextUp,
+            },
+            profile + "-client",
+            notifySettingsChanged: false);
+
+    /// <summary>
+    /// A client pulling its resolved profile, which is the only point at which it learns about
+    /// hides made on another device.
+    /// </summary>
+    private async Task PullAsync(Guid userId, string profile)
+    {
+        var resolved = await _service.GetResolvedProfileAsync(userId, profile);
+        Assert.NotNull(resolved);
+        await _service.RecordHiddenContentBaselineAsync(userId, profile, resolved!);
+    }
+
+    private async Task<string> GlobalHiddenAsync(Guid userId)
+    {
+        var settings = await _service.GetUserSettingsAsync(userId);
+        return settings?.Global?.HiddenContinueWatchingItems ?? string.Empty;
+    }
+
+    [Fact]
+    public async Task DevicesThatHaveNotPulledKeepEachOthersHides()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\"}");
+
+        // Mobile hid something of its own without ever pulling, so it has no idea "a" exists and
+        // leaving it out of the push says nothing about whether the user still wants it hidden.
+        await PushAsync(userId, "mobile", "{\"b\":\"2026-09-01T02:00:00Z\"}");
+
+        var hidden = await GlobalHiddenAsync(userId);
+        Assert.Contains("\"a\"", hidden, StringComparison.Ordinal);
+        Assert.Contains("\"b\"", hidden, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnhidingAfterAPullClearsTheItemEverywhere()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\"}");
+        await PullAsync(userId, "tv");
+
+        // The user unhid "a" on the TV, which reaches the server as a push without that key.
+        await PushAsync(userId, "tv", "{}");
+
+        Assert.DoesNotContain("\"a\"", await GlobalHiddenAsync(userId), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReplayingAHiddenItemClearsIt()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\",\"b\":\"2026-09-01T01:05:00Z\"}");
+        await PullAsync(userId, "tv");
+
+        // Playing a hidden item drops it from the client's map on its own, with no user action and
+        // nothing else to signal the change, so a push that is simply missing the key has to stick
+        // or the series stays out of Continue Watching while it's being watched.
+        await PushAsync(userId, "tv", "{\"b\":\"2026-09-01T01:05:00Z\"}");
+
+        var hidden = await GlobalHiddenAsync(userId);
+        Assert.DoesNotContain("\"a\"", hidden, StringComparison.Ordinal);
+        Assert.Contains("\"b\"", hidden, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnhidingOnlyClearsWhatThatDeviceHadBeenTold()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\"}");
+        await PullAsync(userId, "mobile");
+
+        // The TV hides something more after mobile's last pull, so mobile's next push predates it.
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\",\"c\":\"2026-09-01T03:00:00Z\"}");
+
+        // Mobile unhides "a" and hides "b". It knew about "a" so that removal counts, and it has
+        // never seen "c" so the omission there doesn't.
+        await PushAsync(userId, "mobile", "{\"b\":\"2026-09-01T02:00:00Z\"}");
+
+        var hidden = await GlobalHiddenAsync(userId);
+        Assert.DoesNotContain("\"a\"", hidden, StringComparison.Ordinal);
+        Assert.Contains("\"b\"", hidden, StringComparison.Ordinal);
+        Assert.Contains("\"c\"", hidden, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HiddenNextUpSeriesMergesTheSameWay()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "tv", hiddenNextUp: "{\"a\":\"2026-09-01T01:00:00Z\"}");
+        await PushAsync(userId, "mobile", hiddenNextUp: "{\"b\":\"2026-09-01T02:00:00Z\"}");
+
+        var settings = await _service.GetUserSettingsAsync(userId);
+        var hidden = settings?.Global?.HiddenNextUpSeries ?? string.Empty;
+        Assert.Contains("\"a\"", hidden, StringComparison.Ordinal);
+        Assert.Contains("\"b\"", hidden, StringComparison.Ordinal);
+
+        await PullAsync(userId, "tv");
+        await PushAsync(userId, "tv", hiddenNextUp: "{\"b\":\"2026-09-01T02:00:00Z\"}");
+
+        settings = await _service.GetUserSettingsAsync(userId);
+        Assert.DoesNotContain("\"a\"", settings?.Global?.HiddenNextUpSeries ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ASecondHideOfTheSameItemKeepsTheLaterTimestamp()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "global", "{\"a\":\"2026-09-01T01:00:00.123456Z\"}");
+
+        // Comparing these as text puts the shorter one first, because its Z sorts above the digits
+        // the longer one still has, so the tie-break has to read them as dates.
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00.123Z\"}");
+
+        Assert.Contains("123456", await GlobalHiddenAsync(userId), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The baselines are the server's own bookkeeping, so a save that only writes them has to stay
+    /// out of the change broadcast. Sending one anyway tells every client to pull settings that
+    /// didn't change, and the pull and push that follow keep an echo loop alive.
+    /// </summary>
+    [Fact]
+    public async Task ASaveThatOnlyMovesABaselineDoesNotBroadcast()
+    {
+        var userId = Guid.NewGuid();
+
+        await _service.SaveProfileAsync(
+            userId,
+            "mobile",
+            new MoonfinSettingsProfile { CinemaModeEnabled = true },
+            "mobile-client",
+            notifySettingsChanged: false);
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\"}");
+
+        var channel = _service.RegisterSseChannel(userId);
+
+        // Mobile pushes the hide it already agrees with, which leaves everything a client reads
+        // exactly as it was and only fills in mobile's baseline.
+        await _service.SaveProfileAsync(
+            userId,
+            "mobile",
+            new MoonfinSettingsProfile { HiddenContinueWatchingItems = "{\"a\":\"2026-09-01T01:00:00Z\"}" },
+            "mobile-client",
+            notifySettingsChanged: true);
+
+        Assert.False(channel.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task ASaveWithoutHiddenItemsLeavesThemAlone()
+    {
+        var userId = Guid.NewGuid();
+
+        await PushAsync(userId, "tv", "{\"a\":\"2026-09-01T01:00:00Z\"}");
+        await PullAsync(userId, "tv");
+
+        await _service.SaveProfileAsync(
+            userId,
+            "tv",
+            new MoonfinSettingsProfile { CinemaModeEnabled = true },
+            "tv-client",
+            notifySettingsChanged: false);
+
+        Assert.Contains("\"a\"", await GlobalHiddenAsync(userId), StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where items marked as "Hide from Continue Watching" or "Hide from Next Up" on one device were overwritten and wiped out when other devices synced or pushed profile updates to Moonbase. This caused items that were hidden from the CW&NU row to reappear when they shouldn't be able to.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Included `settings.Global` in `UnionHiddenEntries` across both Jellyfin and Emby backend **MoonfinSettingsService.cs** implementations so existing hidden items stored in the global profile persist across subsequent device profile pushes.
- Updated `UnionHiddenEntries` to merge dictionaries by item ID and keep the latest ISO-8601 timestamp per item.
- Added unit test `SuccessiveDeviceProfileSavesPreserveGlobalHiddenItems` in **AdminDefaultsMergeTests.cs** verifying multi-device sync persistence and resolution.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Windows Desktop and Android-TV (both stable releases)
- [X] Manual testing completed
- [ ] Not tested (explain why): Ran `dotnet build` on Jellyfin and Emby plugin projects to ensure clean compilation and verified unit tests in **AdminDefaultsMergeTests.cs** covering successive device profile saves and global resolution. ~~Discovered this issue while investigating the CW&NU slow-down (which turns out to be unrelated), but can properly test this PR after I finish with the Moonfin-Core one.~~ NOW PROPERLY TESTED :)

### Test Steps
1. Mark item on Client A as "hidden"
2. Open Moonfin on Client B and make sure the CW&NU rows match 

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

These screenshots jump between Windows Desktop and Android-TV to show the near instant syncing between the clients in terms of hiding content from CW&NU:

<img width="2250" height="1389" alt="2026-09-01_10-28-04_moonfin" src="https://github.com/user-attachments/assets/98eadce2-c42d-42a1-b460-9f1facfdd66e" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-01_10-32-01" src="https://github.com/user-attachments/assets/fce54f12-a418-4913-ab2f-73747db084f2" />
<img width="2560" height="1555" alt="2026-09-01_10-32-47_moonfin" src="https://github.com/user-attachments/assets/65fd9067-cdd5-4b05-8788-9c40bd9bf3a2" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
