### PR TITLE
feat-sync - Add new loading animation properties to MoonfinSettingsProfile

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -315,6 +315,11 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("mergeRecentRowsByType")] public bool? MergeRecentRowsByType { get; set; }
         [JsonPropertyName("playlistsRowShowEpisodes")] public bool? PlaylistsRowShowEpisodes { get; set; }
         [JsonPropertyName("recentlyReleasedSeriesType")] public string? RecentlyReleasedSeriesType { get; set; }
+        [JsonPropertyName("loadingAnimationImage")] public string? LoadingAnimationImage { get; set; }
+        [JsonPropertyName("loadingAnimationSize")] public string? LoadingAnimationSize { get; set; }
+        [JsonPropertyName("loadingAnimationPosition")] public string? LoadingAnimationPosition { get; set; }
+        [JsonPropertyName("loadingAnimationSpeed")] public string? LoadingAnimationSpeed { get; set; }
+        [JsonPropertyName("showLoadingAnimationText")] public bool? ShowLoadingAnimationText { get; set; }
     }
 
     /// <summary>

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -889,6 +889,21 @@ public class MoonfinSettingsProfile
 
     [JsonPropertyName("recentlyReleasedSeriesType")]
     public string? RecentlyReleasedSeriesType { get; set; }
+
+    [JsonPropertyName("loadingAnimationImage")]
+    public string? LoadingAnimationImage { get; set; }
+
+    [JsonPropertyName("loadingAnimationSize")]
+    public string? LoadingAnimationSize { get; set; }
+
+    [JsonPropertyName("loadingAnimationPosition")]
+    public string? LoadingAnimationPosition { get; set; }
+
+    [JsonPropertyName("loadingAnimationSpeed")]
+    public string? LoadingAnimationSpeed { get; set; }
+
+    [JsonPropertyName("showLoadingAnimationText")]
+    public bool? ShowLoadingAnimationText { get; set; }
 }
 
 


### PR DESCRIPTION
# Pull Request

## Summary
Adds five loading animation preference properties (from https://github.com/Moonfin-Client/Moonfin-Core/pull/1416) to `MoonfinSettingsProfile` in both Jellyfin and Emby plugin models to support cross-device synchronization with Moonfin clients.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1416

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `LoadingAnimationImage`, `LoadingAnimationSize`, `LoadingAnimationPosition`, `LoadingAnimationSpeed`, and `ShowLoadingAnimationText` nullable properties to `MoonfinSettingsProfile` in **Jellyfin/backend/Models/MoonfinSettingsProfile.cs**.
- Added corresponding properties with explicit `[JsonPropertyName]` tags to `MoonfinSettingsProfile` in **Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs**.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1416
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `loadingAnimationImage`
  - `loadingAnimationSize`
  - `loadingAnimationPosition`
  - `loadingAnimationSpeed`
  - `showLoadingAnimationText`

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why): Tested via build tests but not deployed yet as I need to build clients to sync between.

### Test Steps
1. Build `Moonfin.Server.csproj` with `dotnet build`.
2. Build `Emby.Plugins.Moonfin.csproj` with `dotnet build`.
3. Verify 0 compilation errors or warnings.
4. Verify property reflection and serialization in `MoonfinSettingsProfile`.
5. Verify matching client keys in companion PR Moonfin-Client/Moonfin-Core#1416 with unit tests in `test/data/synced_fields_test.dart`.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
