### PR TITLE
feat-sync - Add customizable screensaver properties to MoonfinSettingsProfile

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -136,6 +136,15 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("screensaverClockMode")] public string? ScreensaverClockMode { get; set; }
         [JsonPropertyName("screensaverMaxAgeRating")] public string? ScreensaverMaxAgeRating { get; set; }
         [JsonPropertyName("screensaverRequireRating")] public bool? ScreensaverRequireRating { get; set; }
+        [JsonPropertyName("screensaverBackdrop")] public string? ScreensaverBackdrop { get; set; }
+        [JsonPropertyName("screensaverComponent")] public string? ScreensaverComponent { get; set; }
+        [JsonPropertyName("screensaverMovement")] public string? ScreensaverMovement { get; set; }
+        [JsonPropertyName("screensaverPosition")] public string? ScreensaverPosition { get; set; }
+        [JsonPropertyName("screensaverSize")] public string? ScreensaverSize { get; set; }
+        [JsonPropertyName("screensaverContentType")] public string? ScreensaverContentType { get; set; }
+        [JsonPropertyName("screensaverLibraryIds")] public List<string>? ScreensaverLibraryIds { get; set; }
+        [JsonPropertyName("screensaverCollectionIds")] public List<string>? ScreensaverCollectionIds { get; set; }
+        [JsonPropertyName("screensaverExcludedGenres")] public List<string>? ScreensaverExcludedGenres { get; set; }
 
         // Subtitles. Colours travel as #AARRGGBB strings so clients that store an int and
         // clients that store a CSS colour can both round-trip them without loss.

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -379,6 +379,33 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("screensaverRequireRating")]
     public bool? ScreensaverRequireRating { get; set; }
 
+    [JsonPropertyName("screensaverBackdrop")]
+    public string? ScreensaverBackdrop { get; set; }
+
+    [JsonPropertyName("screensaverComponent")]
+    public string? ScreensaverComponent { get; set; }
+
+    [JsonPropertyName("screensaverMovement")]
+    public string? ScreensaverMovement { get; set; }
+
+    [JsonPropertyName("screensaverPosition")]
+    public string? ScreensaverPosition { get; set; }
+
+    [JsonPropertyName("screensaverSize")]
+    public string? ScreensaverSize { get; set; }
+
+    [JsonPropertyName("screensaverContentType")]
+    public string? ScreensaverContentType { get; set; }
+
+    [JsonPropertyName("screensaverLibraryIds")]
+    public List<string>? ScreensaverLibraryIds { get; set; }
+
+    [JsonPropertyName("screensaverCollectionIds")]
+    public List<string>? ScreensaverCollectionIds { get; set; }
+
+    [JsonPropertyName("screensaverExcludedGenres")]
+    public List<string>? ScreensaverExcludedGenres { get; set; }
+
     // Subtitles. Colours travel as #AARRGGBB strings so clients that store an int and
     // clients that store a CSS colour can both round-trip them without loss.
 


### PR DESCRIPTION
# Pull Request

## Summary
Adds nine new screensaver preference properties to `MoonfinSettingsProfile` in both Jellyfin and Emby plugin models to support cross-device synchronization of screensaver backdrops, visual components, speeds, anchor positions, sizing, and library/collection/genre filtering with Moonfin clients.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1417

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `ScreensaverBackdrop`, `ScreensaverComponent`, `ScreensaverMovement`, `ScreensaverPosition`, `ScreensaverSize`, `ScreensaverContentType`, `ScreensaverLibraryIds`, `ScreensaverCollectionIds`, and `ScreensaverExcludedGenres` to `MoonfinSettingsProfile` in **Jellyfin/backend/Models/MoonfinSettingsProfile.cs**.
- Added matching properties with explicit `[JsonPropertyName]` tags to `MoonfinSettingsProfile` in **Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs**.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1417
- [X ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `screensaverBackdrop`
  - `screensaverComponent`
  - `screensaverMovement`
  - `screensaverPosition`
  - `screensaverSize`
  - `screensaverContentType`
  - `screensaverLibraryIds`
  - `screensaverCollectionIds`
  - `screensaverExcludedGenres`
  
## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why): Tested via build tests but not deployed yet as I need to build clients to sync between.

### Test Steps
1. Built **Moonfin.Server.csproj** with `dotnet build`: Build succeeded with 0 warnings and 0 errors.
2. Built **Emby.Plugins.Moonfin.csproj** with `dotnet build`: Build succeeded with 0 warnings and 0 errors.
3. Verified matching key names and types against Moonfin-Core `syncedFields` table and unit tests.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
