### PR TITLE
Add rate button as detail screen action button option

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -627,6 +627,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { id: 'watchWithGroup', label: 'Watch with group' },
         { id: 'watched', label: 'Watched' },
         { id: 'favorite', label: 'Favorite' },
+        { id: 'personalRating', label: 'Rate' },
         { id: 'playlist', label: 'Playlist' },
         { id: 'download', label: 'Download' },
         { id: 'deleteFiles', label: 'Delete files' },

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -3392,6 +3392,7 @@
                 { id: 'watchWithGroup', label: 'Watch with group' },
                 { id: 'watched', label: 'Watched' },
                 { id: 'favorite', label: 'Favorite' },
+                { id: 'personalRating', label: 'Rate' },
                 { id: 'playlist', label: 'Playlist' },
                 { id: 'download', label: 'Download' },
                 { id: 'deleteFiles', label: 'Delete files' },


### PR DESCRIPTION
# Pull Request

## Summary
Core has button option personalRating that was missing here. I added it. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #274
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- add personalRating to action button list for jf and emby
-
-

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
