### PR TITLE
feat-recs - Moonbase + Jellyfin 12 Super Search

### DIFF
--- a/Jellyfin/backend/Api/MoonfinController.cs
+++ b/Jellyfin/backend/Api/MoonfinController.cs
@@ -1086,10 +1086,10 @@ public class MoonfinController : ControllerBase
     /// </summary>
     /// <param name="id">Item ID of the seed movie or series.</param>
     /// <param name="userId">Optional user ID for library filtering.</param>
-    /// <param name="limit">Optional maximum number of suggestions to return (default 15).</param>
+    /// <param name="limit">Optional maximum number of suggestions to return. Defaults to 20 and is capped at 200.</param>
     /// <param name="excludeItemIds">Optional item IDs to exclude from results.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Scored similar items matching Jellyfin BaseItemDto shape.</returns>
+    /// <returns>Scored similar items, as the same trimmed card shape the other Moonfin browse endpoints return.</returns>
     [HttpGet("Items/{id}/Similar")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -1110,6 +1110,13 @@ public class MoonfinController : ControllerBase
         var effectiveUserId = (userId.HasValue && userId.Value != Guid.Empty) ? userId : this.GetUserIdFromClaims();
         var queryUser = (effectiveUserId.HasValue && effectiveUserId.Value != Guid.Empty) ? ResolveQueryUser(effectiveUserId.Value) : null;
 
+        // Without a resolved user we can't tell which libraries this caller is allowed to see, so
+        // return nothing rather than everything.
+        if (queryUser == null)
+        {
+            return Ok(new { Items = Array.Empty<object>(), TotalRecordCount = 0 });
+        }
+
         var items = await _similarItemsService.GetSimilarItemsAsync(
             item,
             queryUser,
@@ -1117,7 +1124,9 @@ public class MoonfinController : ControllerBase
             excludeItemIds,
             cancellationToken).ConfigureAwait(false);
 
-        var dtos = items.Select(MapItemToDto).ToList();
+        // The query only applies parental ratings and blocked tags. Library access is a separate
+        // check every other browse endpoint here makes, so make it here too.
+        var dtos = items.Where(i => IsItemVisibleToUser(i, queryUser)).Select(MapItemToDto).ToList();
         return Ok(new
         {
             Items = dtos,

--- a/Jellyfin/backend/Api/MoonfinController.cs
+++ b/Jellyfin/backend/Api/MoonfinController.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Controller.Dto;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -32,6 +33,7 @@ public class MoonfinController : ControllerBase
     private readonly NotificationStore _notificationStore;
     private readonly PushDeliveryService _pushDelivery;
     private readonly ConfigBackupService _configBackup;
+    private readonly MoonfinSimilarItemsService _similarItemsService;
     private readonly ILogger<MoonfinController> _logger;
     
     private static readonly Type? _userManagerType = Type.GetType("MediaBrowser.Controller.Library.IUserManager, MediaBrowser.Controller");
@@ -67,6 +69,7 @@ public class MoonfinController : ControllerBase
         NotificationStore notificationStore,
         PushDeliveryService pushDelivery,
         ConfigBackupService configBackup,
+        MoonfinSimilarItemsService similarItemsService,
         ILogger<MoonfinController> logger)
     {
         _settingsService = settingsService;
@@ -74,6 +77,7 @@ public class MoonfinController : ControllerBase
         _notificationStore = notificationStore;
         _pushDelivery = pushDelivery;
         _configBackup = configBackup;
+        _similarItemsService = similarItemsService;
         _logger = logger;
     }
 
@@ -147,6 +151,7 @@ public class MoonfinController : ControllerBase
             MdblistAvailable = !string.IsNullOrWhiteSpace(config?.MdblistApiKey),
             TmdbAvailable = !string.IsNullOrWhiteSpace(config?.TmdbApiKey),
             MessagesSupported = true,
+            RecommendationsSupported = true,
             DefaultSettings = config?.DefaultUserSettings
         });
     }
@@ -1077,6 +1082,50 @@ public class MoonfinController : ControllerBase
     }
 
     /// <summary>
+    /// Gets similar items (recommendations) for an item scored by Moonfin's recommendation algorithm.
+    /// </summary>
+    /// <param name="id">Item ID of the seed movie or series.</param>
+    /// <param name="userId">Optional user ID for library filtering.</param>
+    /// <param name="limit">Optional maximum number of suggestions to return (default 15).</param>
+    /// <param name="excludeItemIds">Optional item IDs to exclude from results.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Scored similar items matching Jellyfin BaseItemDto shape.</returns>
+    [HttpGet("Items/{id}/Similar")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetSimilarItems(
+        [FromRoute] Guid id,
+        [FromQuery] Guid? userId,
+        [FromQuery] int? limit,
+        [FromQuery] Guid[]? excludeItemIds,
+        CancellationToken cancellationToken)
+    {
+        var item = _libraryManager.GetItemById(id);
+        if (item == null)
+        {
+            return NotFound();
+        }
+
+        var effectiveUserId = (userId.HasValue && userId.Value != Guid.Empty) ? userId : this.GetUserIdFromClaims();
+        var queryUser = (effectiveUserId.HasValue && effectiveUserId.Value != Guid.Empty) ? ResolveQueryUser(effectiveUserId.Value) : null;
+
+        var items = await _similarItemsService.GetSimilarItemsAsync(
+            item,
+            queryUser,
+            limit,
+            excludeItemIds,
+            cancellationToken).ConfigureAwait(false);
+
+        var dtos = items.Select(MapItemToDto).ToList();
+        return Ok(new
+        {
+            Items = dtos,
+            TotalRecordCount = dtos.Count
+        });
+    }
+
+    /// <summary>
     /// Gets resolved media bar content for the current user.
     /// Combines user settings resolution with server-side item queries so all clients
     /// (web, Android, TV) get identical results from a single call.
@@ -1189,6 +1238,11 @@ public class MoonfinController : ControllerBase
 
     private object? ResolveQueryUser(Guid userId)
     {
+        if (userId == Guid.Empty)
+        {
+            return null;
+        }
+
         if (_userManagerType == null || _userManagerGetUserById == null)
         {
             return null;
@@ -1630,6 +1684,12 @@ public class MoonfinPingResponse
     /// </summary>
     [JsonPropertyName("messagesSupported")]
     public bool? MessagesSupported { get; set; }
+
+    /// <summary>
+    /// True when this plugin supports server-side recommendations scoring.
+    /// </summary>
+    [JsonPropertyName("recommendationsSupported")]
+    public bool? RecommendationsSupported { get; set; }
 
     [JsonPropertyName("defaultSettings")]
     public MoonfinSettingsProfile? DefaultSettings { get; set; }

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -611,6 +611,22 @@
                     </div>
 
                     <div class="verticalSection">
+                        <h3 class="sectionTitle">Recommendations</h3>
+                        <div class="checkboxContainer">
+                            <label>
+                                <input type="checkbox" id="RecommendationsProviderEnabled" is="emby-checkbox" />
+                                <span>Use Moonfin Recommends for similar items (Jellyfin 12+)</span>
+                            </label>
+                            <div class="fieldDescription">
+                                Registers Moonfin's scoring with Jellyfin's similar items pipeline, so every client
+                                on this server gets Moonfin recommendations, including the stock web client.
+                                Jellyfin's own providers only fill slots Moonfin leaves empty. Turn this off to hand
+                                similar items back to the server. Moonfin clients keep working either way.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="verticalSection">
                         <h3 class="sectionTitle">Studio Logos</h3>
                         <div class="checkboxContainer">
                             <label>
@@ -5301,6 +5317,7 @@
                     document.querySelector('#MdblistOfficialListsEnabled').checked = config.MdblistOfficialListsEnabled !== false;
                     document.querySelector('#MdblistOfficialListsMaxItems').value = config.MdblistOfficialListsMaxItems || 250;
                     document.querySelector('#ImdbListsEnabled').checked = config.ImdbListsEnabled !== false;
+                    document.querySelector('#RecommendationsProviderEnabled').checked = config.RecommendationsProviderEnabled !== false;
                     document.querySelector('#StudioLogosEnabled').checked = config.StudioLogosEnabled !== false;
                     document.querySelector('#StudioLogosMaxAgeDays').value = config.StudioLogosMaxAgeDays || 30;
                     document.querySelector('#WebDefaultServerUrl').value = config.WebDefaultServerUrl || '';
@@ -5774,6 +5791,7 @@
                         config.MdblistOfficialListsEnabled = document.querySelector('#MdblistOfficialListsEnabled').checked;
                         config.MdblistOfficialListsMaxItems = parseInt(document.querySelector('#MdblistOfficialListsMaxItems').value, 10) || 250;
                         config.ImdbListsEnabled = document.querySelector('#ImdbListsEnabled').checked;
+                        config.RecommendationsProviderEnabled = document.querySelector('#RecommendationsProviderEnabled').checked;
                         config.StudioLogosEnabled = document.querySelector('#StudioLogosEnabled').checked;
                         config.StudioLogosMaxAgeDays = parseInt(document.querySelector('#StudioLogosMaxAgeDays').value, 10) || 30;
                         config.WebDefaultServerUrl = document.querySelector('#WebDefaultServerUrl').value || null;

--- a/Jellyfin/backend/PluginConfiguration.cs
+++ b/Jellyfin/backend/PluginConfiguration.cs
@@ -80,6 +80,15 @@ public class PluginConfiguration : BasePluginConfiguration
     public int MdblistOfficialListsMaxItems { get; set; } = 250;
 
     /// <summary>
+    /// Register Moonfin Recommends with Jellyfin 12's similar items pipeline. When this is on,
+    /// Moonfin scores recommendations for every client on the server, including the stock web
+    /// client, and Jellyfin's own providers only fill in whatever slots Moonfin leaves empty.
+    /// Turn it off to hand recommendations back to the server. Has no effect before Jellyfin 12,
+    /// where the Moonfin endpoint is the only way to reach this scoring.
+    /// </summary>
+    public bool RecommendationsProviderEnabled { get; set; } = true;
+
+    /// <summary>
     /// Fetch and cache TMDB studio (production company) logos on a schedule so clients
     /// can show them on the details screen. Uses the server-wide TMDB key above.
     /// </summary>

--- a/Jellyfin/backend/PluginServiceRegistrator.cs
+++ b/Jellyfin/backend/PluginServiceRegistrator.cs
@@ -65,5 +65,9 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddHostedService<SeerrProvisioningStartupService>();
         serviceCollection.AddHostedService<NewMediaNotifier>();
         serviceCollection.AddHostedService(provider => provider.GetRequiredService<GameArtworkReconciliationService>());
+
+        // Recommendations / Similar Items
+        serviceCollection.AddSingleton<MoonfinSimilarItemsService>();
+        serviceCollection.AddHostedService<MoonfinSimilarItemsProviderManager>();
     }
 }

--- a/Jellyfin/backend/Services/MoonfinSimilarItemsProviderManager.cs
+++ b/Jellyfin/backend/Services/MoonfinSimilarItemsProviderManager.cs
@@ -1,0 +1,501 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Moonfin.Server.Services;
+
+/// <summary>
+/// Hosted service that detects whether Jellyfin 12's ISimilarItemsManager is available
+/// and dynamically generates and registers an ILocalSimilarItemsProvider implementation ("Moonfin Recommends").
+/// </summary>
+public class MoonfinSimilarItemsProviderManager : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly MoonfinSimilarItemsService _similarItemsService;
+    private readonly ILogger<MoonfinSimilarItemsProviderManager> _logger;
+
+    private static readonly List<object> _stockProviders = [];
+
+    public MoonfinSimilarItemsProviderManager(
+        IServiceProvider serviceProvider,
+        MoonfinSimilarItemsService similarItemsService,
+        ILogger<MoonfinSimilarItemsProviderManager> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _similarItemsService = similarItemsService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            RegisterSimilarItemsProvider();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to register Moonfin similar items provider with Jellyfin host.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    private void RegisterSimilarItemsProvider()
+    {
+        var simMgrInterfaceType = Type.GetType("MediaBrowser.Controller.Library.ISimilarItemsManager, MediaBrowser.Controller");
+        if (simMgrInterfaceType == null)
+        {
+            _logger.LogInformation("MediaBrowser.Controller.Library.ISimilarItemsManager not found; running on Jellyfin 10.x or Emby. Native similar items provider registration skipped.");
+            return;
+        }
+
+        var provBaseType = Type.GetType("MediaBrowser.Controller.Library.ISimilarItemsProvider, MediaBrowser.Controller");
+        var localProvType = Type.GetType("MediaBrowser.Controller.Library.ILocalSimilarItemsProvider, MediaBrowser.Controller");
+
+        if (localProvType == null || provBaseType == null)
+        {
+            _logger.LogWarning("Required similarity provider types missing from MediaBrowser.Controller.");
+            return;
+        }
+
+        var simMgr = _serviceProvider.GetService(simMgrInterfaceType);
+        if (simMgr == null)
+        {
+            _logger.LogWarning("ISimilarItemsManager resolved as null from IServiceProvider.");
+            return;
+        }
+
+        var providerInstance = CreateDynamicProvider(localProvType, provBaseType);
+        if (providerInstance == null)
+        {
+            _logger.LogWarning("Failed to create dynamic Moonfin similar items provider.");
+            return;
+        }
+
+        // Preserve existing registered providers (e.g. built-in Local Genre/Tag) alongside Moonfin Recommends
+        var flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+        var existingField = simMgr.GetType().GetField("_similarItemsProviders", flags);
+        var existingArr = existingField?.GetValue(simMgr) as Array;
+
+        var allList = new List<object>();
+        var stockList = new List<object>();
+        if (existingArr != null)
+        {
+            foreach (var item in existingArr)
+            {
+                if (item != null && item != providerInstance && !item.GetType().FullName!.Contains("Moonfin"))
+                {
+                    allList.Add(item);
+                    stockList.Add(item);
+                }
+            }
+        }
+
+        lock (_stockProviders)
+        {
+            _stockProviders.Clear();
+            _stockProviders.AddRange(stockList);
+        }
+
+        allList.Add(providerInstance);
+
+        // Register with ISimilarItemsManager.AddParts
+        var addPartsMethod = simMgrInterfaceType.GetMethod("AddParts");
+        if (addPartsMethod != null)
+        {
+            var arr = Array.CreateInstance(provBaseType, allList.Count);
+            for (var i = 0; i < allList.Count; i++)
+            {
+                arr.SetValue(allList[i], i);
+            }
+            addPartsMethod.Invoke(simMgr, [arr]);
+            _logger.LogInformation("Successfully registered 'Moonfin Recommends' provider alongside {ExistingCount} existing providers via ISimilarItemsManager.AddParts.", allList.Count - 1);
+        }
+        else
+        {
+            _logger.LogWarning("ISimilarItemsManager.AddParts method not found.");
+        }
+
+        // Ensure Moonfin Recommends is prioritized by moving to the beginning of internal provider lists if accessible
+        PrioritizeProvider(simMgr, providerInstance);
+    }
+
+    private void PrioritizeProvider(object simMgr, object providerInstance)
+    {
+        try
+        {
+            var flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            var currType = simMgr.GetType();
+
+            while (currType != null && currType != typeof(object))
+            {
+                foreach (var field in currType.GetFields(flags))
+                {
+                    var val = field.GetValue(simMgr);
+                    if (val == null) continue;
+
+                    if (val is IList list)
+                    {
+                        _logger.LogInformation("ISimilarItemsManager field {FieldName} has IList with {Count} elements.", field.Name, list.Count);
+                        if (list.Contains(providerInstance))
+                        {
+                            list.Remove(providerInstance);
+                            list.Insert(0, providerInstance);
+                            _logger.LogInformation("Prioritized 'Moonfin Recommends' at head of {FieldName} (IList).", field.Name);
+                        }
+                    }
+                    else if (val is Array arr && arr.Length > 0)
+                    {
+                        _logger.LogInformation("ISimilarItemsManager field {FieldName} has Array with {Count} elements of type {ElemType}.", field.Name, arr.Length, arr.GetType().GetElementType());
+                        var elemType = arr.GetType().GetElementType()!;
+                        var listType = typeof(List<>).MakeGenericType(elemType);
+                        var listObj = (IList)Activator.CreateInstance(listType, arr)!;
+                        if (listObj.Contains(providerInstance))
+                        {
+                            listObj.Remove(providerInstance);
+                            listObj.Insert(0, providerInstance);
+                            var newArr = Array.CreateInstance(elemType, listObj.Count);
+                            listObj.CopyTo(newArr, 0);
+                            field.SetValue(simMgr, newArr);
+                            _logger.LogInformation("Prioritized 'Moonfin Recommends' at head of {FieldName} (Array).", field.Name);
+                        }
+                    }
+                }
+
+                currType = currType.BaseType;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not adjust provider priority ordering (non-critical).");
+        }
+    }
+
+    private object? CreateDynamicProvider(Type localProvType, Type provBaseType)
+    {
+        var asmName = new AssemblyName("Moonfin.Server.DynamicSimilarity");
+        var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = asmBuilder.DefineDynamicModule("MainModule");
+
+        var typeBuilder = moduleBuilder.DefineType(
+            "MoonfinSimilarItemsProviderDynamic",
+            TypeAttributes.Public | TypeAttributes.Class,
+            typeof(object),
+            [localProvType]);
+
+        const MethodAttributes ifaceMethodAttrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot | MethodAttributes.HideBySig | MethodAttributes.Final;
+        const MethodAttributes propMethodAttrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Final;
+
+        // Explicit parameterless constructor calling base()
+        var ctor = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        var ilCtor = ctor.GetILGenerator();
+        ilCtor.Emit(OpCodes.Ldarg_0);
+        ilCtor.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ilCtor.Emit(OpCodes.Ret);
+
+        // string Name { get; } => "Moonfin Recommends"
+        var ifacePropName = provBaseType.GetProperty("Name")!;
+        var ifaceGetName = ifacePropName.GetGetMethod()!;
+        var propName = typeBuilder.DefineProperty("Name", PropertyAttributes.None, typeof(string), Type.EmptyTypes);
+        var getName = typeBuilder.DefineMethod("get_Name", propMethodAttrs, typeof(string), Type.EmptyTypes);
+        var ilName = getName.GetILGenerator();
+        ilName.Emit(OpCodes.Ldstr, "Moonfin Recommends");
+        ilName.Emit(OpCodes.Ret);
+        propName.SetGetMethod(getName);
+        typeBuilder.DefineMethodOverride(getName, ifaceGetName);
+
+        // MetadataPluginType Type { get; }
+        var ifacePropType = provBaseType.GetProperty("Type")!;
+        var ifaceGetType = ifacePropType.GetGetMethod()!;
+        var metaPluginEnumType = ifacePropType.PropertyType;
+        var propType = typeBuilder.DefineProperty("Type", PropertyAttributes.None, metaPluginEnumType, Type.EmptyTypes);
+        var getType = typeBuilder.DefineMethod("get_Type", propMethodAttrs, metaPluginEnumType, Type.EmptyTypes);
+        var ilType = getType.GetILGenerator();
+        int enumVal = 9; // Default fallback for LocalSimilarityProvider
+        try
+        {
+            enumVal = Convert.ToInt32(Enum.Parse(metaPluginEnumType, "LocalSimilarityProvider"));
+        }
+        catch
+        {
+            // Fallback to integer 9
+        }
+        ilType.Emit(OpCodes.Ldc_I4, enumVal);
+        ilType.Emit(OpCodes.Ret);
+        propType.SetGetMethod(getType);
+        typeBuilder.DefineMethodOverride(getType, ifaceGetType);
+
+        // TimeSpan? CacheDuration { get; } => 1 day
+        var ifacePropCache = provBaseType.GetProperty("CacheDuration")!;
+        var ifaceGetCache = ifacePropCache.GetGetMethod()!;
+        var nullableTimeSpanType = ifacePropCache.PropertyType;
+        var propCache = typeBuilder.DefineProperty("CacheDuration", PropertyAttributes.None, nullableTimeSpanType, Type.EmptyTypes);
+        var getCache = typeBuilder.DefineMethod("get_CacheDuration", propMethodAttrs, nullableTimeSpanType, Type.EmptyTypes);
+        var ilCache = getCache.GetILGenerator();
+        var ctorNullable = nullableTimeSpanType.GetConstructor([typeof(TimeSpan)])!;
+        var fromHoursMethod = typeof(TimeSpan).GetMethod("FromHours", [typeof(double)])!;
+        ilCache.Emit(OpCodes.Ldc_R8, 24.0);
+        ilCache.Emit(OpCodes.Call, fromHoursMethod);
+        ilCache.Emit(OpCodes.Newobj, ctorNullable);
+        ilCache.Emit(OpCodes.Ret);
+        propCache.SetGetMethod(getCache);
+        typeBuilder.DefineMethodOverride(getCache, ifaceGetCache);
+
+        // Static delegate fields
+        var fSupports = typeBuilder.DefineField("_supportsDelegate", typeof(Func<object, bool>), FieldAttributes.Public | FieldAttributes.Static);
+        var fGetSimilar = typeBuilder.DefineField("_getSimilarDelegate", typeof(Func<object, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>), FieldAttributes.Public | FieldAttributes.Static);
+
+        // bool Supports(BaseItem item)
+        var ifaceSupports = localProvType.GetMethod("Supports")!;
+        var supportsParams = ifaceSupports.GetParameters().Select(p => p.ParameterType).ToArray();
+        var mSupports = typeBuilder.DefineMethod("Supports", ifaceMethodAttrs, typeof(bool), supportsParams);
+        var ilSupports = mSupports.GetILGenerator();
+        ilSupports.Emit(OpCodes.Ldsfld, fSupports);
+        ilSupports.Emit(OpCodes.Ldarg_1);
+        ilSupports.Emit(OpCodes.Callvirt, typeof(Func<object, bool>).GetMethod("Invoke")!);
+        ilSupports.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(mSupports, ifaceSupports);
+
+        // Task<IReadOnlyList<BaseItem>> GetSimilarItemsAsync(BaseItem item, SimilarItemsQuery query, CancellationToken cancellationToken)
+        var ifaceGetSimilar = localProvType.GetMethod("GetSimilarItemsAsync")!;
+        var getSimilarParams = ifaceGetSimilar.GetParameters().Select(p => p.ParameterType).ToArray();
+        var getSimilarReturn = ifaceGetSimilar.ReturnType;
+        var mGetSimilar = typeBuilder.DefineMethod("GetSimilarItemsAsync", ifaceMethodAttrs, getSimilarReturn, getSimilarParams);
+        var ilGetSimilar = mGetSimilar.GetILGenerator();
+        ilGetSimilar.Emit(OpCodes.Ldsfld, fGetSimilar);
+        ilGetSimilar.Emit(OpCodes.Ldarg_1);
+        ilGetSimilar.Emit(OpCodes.Ldarg_2);
+        ilGetSimilar.Emit(OpCodes.Ldarg_3);
+        ilGetSimilar.Emit(OpCodes.Callvirt, typeof(Func<object, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>).GetMethod("Invoke")!);
+        ilGetSimilar.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(mGetSimilar, ifaceGetSimilar);
+
+        var generatedType = typeBuilder.CreateType();
+        if (generatedType == null) return null;
+
+        // Hook up handlers
+        generatedType.GetField("_supportsDelegate")!.SetValue(null, (Func<object, bool>)HandleSupports);
+        generatedType.GetField("_getSimilarDelegate")!.SetValue(
+            null,
+            (Func<object, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>)HandleGetSimilarAsync);
+
+        return Activator.CreateInstance(generatedType);
+    }
+
+    private bool HandleSupports(object? rawItem)
+    {
+        try
+        {
+            if (rawItem == null) return false;
+
+            if (rawItem is Type t)
+            {
+                var supported = t.Name is "Movie" or "Series"
+                    || typeof(Movie).IsAssignableFrom(t)
+                    || typeof(Series).IsAssignableFrom(t);
+                _logger.LogInformation("Moonfin Recommends HandleSupports(Type: {TypeName}): {Supported}", t.FullName, supported);
+                return supported;
+            }
+
+            var typeName = rawItem.GetType().Name;
+            var isSupported = typeName is "Movie" or "Series" || rawItem is Movie or Series;
+            _logger.LogInformation("Moonfin Recommends HandleSupports(Instance: {TypeName}): {Supported}", typeName, isSupported);
+            return isSupported;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in Moonfin Recommends HandleSupports");
+            return false;
+        }
+    }
+
+    private async Task<IReadOnlyList<BaseItem>> HandleGetSimilarAsync(
+        object? rawItem,
+        object? rawQuery,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (rawItem is not BaseItem item)
+            {
+                _logger.LogWarning("Moonfin Recommends HandleGetSimilarAsync called with non-BaseItem: {Type}", rawItem?.GetType().FullName);
+                return Array.Empty<BaseItem>();
+            }
+
+            // Check if the current HTTP request explicitly requested stock/bypass (e.g. asking specifically for Jellyfin stock engine)
+            try
+            {
+                var httpAccessorType = Type.GetType("Microsoft.AspNetCore.Http.IHttpContextAccessor, Microsoft.AspNetCore.Http.Abstractions");
+                if (httpAccessorType != null)
+                {
+                    var accessor = _serviceProvider.GetService(httpAccessorType);
+                    if (accessor != null)
+                    {
+                        var httpContext = accessor.GetType().GetProperty("HttpContext")?.GetValue(accessor);
+                        if (httpContext != null)
+                        {
+                            var req = httpContext.GetType().GetProperty("Request")?.GetValue(httpContext);
+                            var queryString = req?.GetType().GetProperty("QueryString")?.GetValue(req)?.ToString() ?? string.Empty;
+                            if (queryString.Contains("bypass=moonfin", StringComparison.OrdinalIgnoreCase) ||
+                                queryString.Contains("engine=jellyfin", StringComparison.OrdinalIgnoreCase) ||
+                                queryString.Contains("engine=stock", StringComparison.OrdinalIgnoreCase))
+                            {
+                                _logger.LogInformation("Moonfin Recommends bypassed via query parameter for '{ItemName}'. Invoking stock provider directly.", item.Name);
+                                var stockResults = await InvokeStockProviderAsync(item, rawQuery, cancellationToken).ConfigureAwait(false);
+                                return stockResults;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not check HttpContext for bypass parameter.");
+            }
+
+            _logger.LogInformation("Moonfin Recommends HandleGetSimilarAsync invoked for '{ItemName}' ({ItemId}).", item.Name, item.Id);
+
+            object? user = null;
+            int? limit = null;
+            IReadOnlyList<Guid>? excludeItemIds = null;
+
+            if (rawQuery != null)
+            {
+                var qType = rawQuery.GetType();
+                user = qType.GetProperty("User")?.GetValue(rawQuery);
+                limit = qType.GetProperty("Limit")?.GetValue(rawQuery) as int?;
+                excludeItemIds = qType.GetProperty("ExcludeItemIds")?.GetValue(rawQuery) as IReadOnlyList<Guid>;
+            }
+
+            var results = await _similarItemsService.GetSimilarItemsAsync(
+                item,
+                user,
+                limit,
+                excludeItemIds,
+                cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Moonfin Recommends returning {Count} recommendations for '{ItemName}'.", results.Count, item.Name);
+            return results;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating similar items in provider.");
+            return Array.Empty<BaseItem>();
+        }
+    }
+
+    private async Task<IReadOnlyList<BaseItem>> InvokeStockProviderAsync(
+        BaseItem item,
+        object? rawQuery,
+        CancellationToken cancellationToken)
+    {
+        List<object> providers;
+        lock (_stockProviders)
+        {
+            providers = new List<object>(_stockProviders);
+        }
+
+        // Boost candidate limit for stock provider so internal Take(limit) covers entire library
+        if (rawQuery != null)
+        {
+            try
+            {
+                var limitProp = rawQuery.GetType().GetProperty("Limit");
+                if (limitProp != null && limitProp.CanWrite)
+                {
+                    var currentLimit = limitProp.GetValue(rawQuery) as int?;
+                    if (currentLimit == null || currentLimit < 5000)
+                    {
+                        limitProp.SetValue(rawQuery, 5000);
+                    }
+                }
+            }
+            catch { }
+        }
+
+        var itemType = item.GetType();
+        foreach (var sp in providers)
+        {
+            try
+            {
+                var spType = sp.GetType();
+                var localProvType = Type.GetType("MediaBrowser.Controller.Library.ILocalSimilarItemsProvider, MediaBrowser.Controller");
+                var supportsMethod = localProvType != null
+                    ? localProvType.GetMethod("Supports")
+                    : spType.GetMethod("Supports", [typeof(Type)]);
+
+                var isSupported = false;
+                if (supportsMethod != null)
+                {
+                    var res = supportsMethod.Invoke(sp, [itemType]);
+                    if (res is bool b && b)
+                    {
+                        isSupported = true;
+                    }
+                }
+                else
+                {
+                    var directSupports = spType.GetMethod("Supports", [typeof(BaseItem)])
+                        ?? spType.GetMethod("Supports", [itemType]);
+                    if (directSupports != null)
+                    {
+                        var res = directSupports.Invoke(sp, [item]);
+                        if (res is bool b && b)
+                        {
+                            isSupported = true;
+                        }
+                    }
+                }
+
+                if (isSupported)
+                {
+                    var getSimMethod = localProvType != null
+                        ? localProvType.GetMethod("GetSimilarItemsAsync")
+                        : spType.GetMethod("GetSimilarItemsAsync");
+
+                    if (getSimMethod != null)
+                    {
+                        var taskObj = getSimMethod.Invoke(sp, [item, rawQuery, cancellationToken]);
+                        if (taskObj is Task<IReadOnlyList<BaseItem>> typedTask)
+                        {
+                            var list = await typedTask.ConfigureAwait(false);
+                            _logger.LogInformation("Stock provider {ProviderName} returned {Count} items for '{ItemName}'.", spType.Name, list.Count, item.Name);
+                            return list;
+                        }
+                        if (taskObj is Task genericTask)
+                        {
+                            await genericTask.ConfigureAwait(false);
+                            var prop = genericTask.GetType().GetProperty("Result");
+                            if (prop?.GetValue(genericTask) is IReadOnlyList<BaseItem> list)
+                            {
+                                _logger.LogInformation("Stock provider {ProviderName} returned {Count} items for '{ItemName}'.", spType.Name, list.Count, item.Name);
+                                return list;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to invoke stock similarity provider {ProviderType} for '{ItemName}'.", sp.GetType().FullName, item.Name);
+            }
+        }
+
+        return Array.Empty<BaseItem>();
+    }
+}

--- a/Jellyfin/backend/Services/MoonfinSimilarItemsProviderManager.cs
+++ b/Jellyfin/backend/Services/MoonfinSimilarItemsProviderManager.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -9,14 +9,16 @@ using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Moonfin.Server.Services;
 
 /// <summary>
-/// Hosted service that detects whether Jellyfin 12's ISimilarItemsManager is available
-/// and dynamically generates and registers an ILocalSimilarItemsProvider implementation ("Moonfin Recommends").
+/// Registers "Moonfin Recommends" with Jellyfin 12's similar items pipeline when the host exposes
+/// one. The provider is emitted at runtime rather than declared because the plugin compiles against
+/// Jellyfin.Controller 10.10, where none of those interfaces exist yet.
 /// </summary>
 public class MoonfinSimilarItemsProviderManager : IHostedService
 {
@@ -24,7 +26,14 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
     private readonly MoonfinSimilarItemsService _similarItemsService;
     private readonly ILogger<MoonfinSimilarItemsProviderManager> _logger;
 
-    private static readonly List<object> _stockProviders = [];
+    private readonly List<object> _stockProviders = [];
+
+    private Type? _localProviderType;
+    private MethodInfo? _stockSupports;
+    private MethodInfo? _stockGetSimilarItemsAsync;
+    private PropertyInfo? _queryUser;
+    private PropertyInfo? _queryLimit;
+    private PropertyInfo? _queryExcludeItemIds;
 
     public MoonfinSimilarItemsProviderManager(
         IServiceProvider serviceProvider,
@@ -35,6 +44,9 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
         _similarItemsService = similarItemsService;
         _logger = logger;
     }
+
+    private static bool IsProviderEnabled =>
+        MoonfinPlugin.Instance?.Configuration?.RecommendationsProviderEnabled ?? true;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -60,7 +72,7 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
         var simMgrInterfaceType = Type.GetType("MediaBrowser.Controller.Library.ISimilarItemsManager, MediaBrowser.Controller");
         if (simMgrInterfaceType == null)
         {
-            _logger.LogInformation("MediaBrowser.Controller.Library.ISimilarItemsManager not found; running on Jellyfin 10.x or Emby. Native similar items provider registration skipped.");
+            _logger.LogDebug("ISimilarItemsManager not found, so this is Jellyfin 10.x or Emby. Provider registration skipped.");
             return;
         }
 
@@ -80,114 +92,78 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
             return;
         }
 
-        var providerInstance = CreateDynamicProvider(localProvType, provBaseType);
-        if (providerInstance == null)
+        var addPartsMethod = simMgrInterfaceType.GetMethod("AddParts");
+        if (addPartsMethod == null)
         {
-            _logger.LogWarning("Failed to create dynamic Moonfin similar items provider.");
+            _logger.LogWarning("ISimilarItemsManager.AddParts method not found.");
             return;
         }
 
-        // Preserve existing registered providers (e.g. built-in Local Genre/Tag) alongside Moonfin Recommends
+        // AddParts replaces the provider set rather than appending to it, so the providers Jellyfin
+        // registered at startup have to be read back and passed in again. If that read ever fails
+        // we have to leave the pipeline alone, because registering Moonfin on its own would
+        // silently drop every stock provider.
         var flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
         var existingField = simMgr.GetType().GetField("_similarItemsProviders", flags);
-        var existingArr = existingField?.GetValue(simMgr) as Array;
+        if (existingField?.GetValue(simMgr) is not Array existingArr)
+        {
+            _logger.LogWarning(
+                "Could not read the existing similar items providers from {ManagerType}, so Moonfin Recommends was not registered. Registering it would have removed Jellyfin's own providers.",
+                simMgr.GetType().FullName);
+            return;
+        }
+
+        var providerInstance = CreateDynamicProvider(localProvType, provBaseType);
+        if (providerInstance == null)
+        {
+            return;
+        }
 
         var allList = new List<object>();
-        var stockList = new List<object>();
-        if (existingArr != null)
+        foreach (var existing in existingArr)
         {
-            foreach (var item in existingArr)
+            if (existing != null && !existing.GetType().FullName!.Contains("Moonfin", StringComparison.Ordinal))
             {
-                if (item != null && item != providerInstance && !item.GetType().FullName!.Contains("Moonfin"))
-                {
-                    allList.Add(item);
-                    stockList.Add(item);
-                }
+                allList.Add(existing);
             }
         }
 
         lock (_stockProviders)
         {
             _stockProviders.Clear();
-            _stockProviders.AddRange(stockList);
+            _stockProviders.AddRange(allList);
         }
 
-        allList.Add(providerInstance);
+        // The manager sorts providers by their configured order and that sort is stable, so sitting
+        // at the head of the array is what puts Moonfin first among equals.
+        allList.Insert(0, providerInstance);
 
-        // Register with ISimilarItemsManager.AddParts
-        var addPartsMethod = simMgrInterfaceType.GetMethod("AddParts");
-        if (addPartsMethod != null)
+        var arr = Array.CreateInstance(provBaseType, allList.Count);
+        for (var i = 0; i < allList.Count; i++)
         {
-            var arr = Array.CreateInstance(provBaseType, allList.Count);
-            for (var i = 0; i < allList.Count; i++)
-            {
-                arr.SetValue(allList[i], i);
-            }
-            addPartsMethod.Invoke(simMgr, [arr]);
-            _logger.LogInformation("Successfully registered 'Moonfin Recommends' provider alongside {ExistingCount} existing providers via ISimilarItemsManager.AddParts.", allList.Count - 1);
-        }
-        else
-        {
-            _logger.LogWarning("ISimilarItemsManager.AddParts method not found.");
+            arr.SetValue(allList[i], i);
         }
 
-        // Ensure Moonfin Recommends is prioritized by moving to the beginning of internal provider lists if accessible
-        PrioritizeProvider(simMgr, providerInstance);
-    }
-
-    private void PrioritizeProvider(object simMgr, object providerInstance)
-    {
-        try
-        {
-            var flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-            var currType = simMgr.GetType();
-
-            while (currType != null && currType != typeof(object))
-            {
-                foreach (var field in currType.GetFields(flags))
-                {
-                    var val = field.GetValue(simMgr);
-                    if (val == null) continue;
-
-                    if (val is IList list)
-                    {
-                        _logger.LogInformation("ISimilarItemsManager field {FieldName} has IList with {Count} elements.", field.Name, list.Count);
-                        if (list.Contains(providerInstance))
-                        {
-                            list.Remove(providerInstance);
-                            list.Insert(0, providerInstance);
-                            _logger.LogInformation("Prioritized 'Moonfin Recommends' at head of {FieldName} (IList).", field.Name);
-                        }
-                    }
-                    else if (val is Array arr && arr.Length > 0)
-                    {
-                        _logger.LogInformation("ISimilarItemsManager field {FieldName} has Array with {Count} elements of type {ElemType}.", field.Name, arr.Length, arr.GetType().GetElementType());
-                        var elemType = arr.GetType().GetElementType()!;
-                        var listType = typeof(List<>).MakeGenericType(elemType);
-                        var listObj = (IList)Activator.CreateInstance(listType, arr)!;
-                        if (listObj.Contains(providerInstance))
-                        {
-                            listObj.Remove(providerInstance);
-                            listObj.Insert(0, providerInstance);
-                            var newArr = Array.CreateInstance(elemType, listObj.Count);
-                            listObj.CopyTo(newArr, 0);
-                            field.SetValue(simMgr, newArr);
-                            _logger.LogInformation("Prioritized 'Moonfin Recommends' at head of {FieldName} (Array).", field.Name);
-                        }
-                    }
-                }
-
-                currType = currType.BaseType;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Could not adjust provider priority ordering (non-critical).");
-        }
+        addPartsMethod.Invoke(simMgr, [arr]);
+        _logger.LogInformation(
+            "Registered 'Moonfin Recommends' ahead of {ExistingCount} existing similar items providers.",
+            allList.Count - 1);
     }
 
     private object? CreateDynamicProvider(Type localProvType, Type provBaseType)
     {
+        var ifaceSupports = localProvType.GetMethod("Supports")!;
+        var ifaceGetSimilar = localProvType.GetMethod("GetSimilarItemsAsync")!;
+        var queryType = ifaceGetSimilar.GetParameters()[1].ParameterType;
+
+        var ifacePropType = provBaseType.GetProperty("Type")!;
+        var metaPluginEnumType = ifacePropType.PropertyType;
+        if (!Enum.TryParse(metaPluginEnumType, "LocalSimilarityProvider", out var localSimilarityKind) || localSimilarityKind == null)
+        {
+            _logger.LogWarning("{EnumType} has no LocalSimilarityProvider member, so Moonfin Recommends was not registered.", metaPluginEnumType.FullName);
+            return null;
+        }
+
         var asmName = new AssemblyName("Moonfin.Server.DynamicSimilarity");
         var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
         var moduleBuilder = asmBuilder.DefineDynamicModule("MainModule");
@@ -201,202 +177,173 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
         const MethodAttributes ifaceMethodAttrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot | MethodAttributes.HideBySig | MethodAttributes.Final;
         const MethodAttributes propMethodAttrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Final;
 
-        // Explicit parameterless constructor calling base()
         var ctor = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
         var ilCtor = ctor.GetILGenerator();
         ilCtor.Emit(OpCodes.Ldarg_0);
         ilCtor.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
         ilCtor.Emit(OpCodes.Ret);
 
-        // string Name { get; } => "Moonfin Recommends"
         var ifacePropName = provBaseType.GetProperty("Name")!;
-        var ifaceGetName = ifacePropName.GetGetMethod()!;
         var propName = typeBuilder.DefineProperty("Name", PropertyAttributes.None, typeof(string), Type.EmptyTypes);
         var getName = typeBuilder.DefineMethod("get_Name", propMethodAttrs, typeof(string), Type.EmptyTypes);
         var ilName = getName.GetILGenerator();
         ilName.Emit(OpCodes.Ldstr, "Moonfin Recommends");
         ilName.Emit(OpCodes.Ret);
         propName.SetGetMethod(getName);
-        typeBuilder.DefineMethodOverride(getName, ifaceGetName);
+        typeBuilder.DefineMethodOverride(getName, ifacePropName.GetGetMethod()!);
 
-        // MetadataPluginType Type { get; }
-        var ifacePropType = provBaseType.GetProperty("Type")!;
-        var ifaceGetType = ifacePropType.GetGetMethod()!;
-        var metaPluginEnumType = ifacePropType.PropertyType;
         var propType = typeBuilder.DefineProperty("Type", PropertyAttributes.None, metaPluginEnumType, Type.EmptyTypes);
         var getType = typeBuilder.DefineMethod("get_Type", propMethodAttrs, metaPluginEnumType, Type.EmptyTypes);
         var ilType = getType.GetILGenerator();
-        int enumVal = 9; // Default fallback for LocalSimilarityProvider
-        try
-        {
-            enumVal = Convert.ToInt32(Enum.Parse(metaPluginEnumType, "LocalSimilarityProvider"));
-        }
-        catch
-        {
-            // Fallback to integer 9
-        }
-        ilType.Emit(OpCodes.Ldc_I4, enumVal);
+        ilType.Emit(OpCodes.Ldc_I4, Convert.ToInt32(localSimilarityKind, CultureInfo.InvariantCulture));
         ilType.Emit(OpCodes.Ret);
         propType.SetGetMethod(getType);
-        typeBuilder.DefineMethodOverride(getType, ifaceGetType);
+        typeBuilder.DefineMethodOverride(getType, ifacePropType.GetGetMethod()!);
 
-        // TimeSpan? CacheDuration { get; } => 1 day
+        // Jellyfin only caches remote providers, so this value is never read. The interface still
+        // asks for one.
         var ifacePropCache = provBaseType.GetProperty("CacheDuration")!;
-        var ifaceGetCache = ifacePropCache.GetGetMethod()!;
         var nullableTimeSpanType = ifacePropCache.PropertyType;
         var propCache = typeBuilder.DefineProperty("CacheDuration", PropertyAttributes.None, nullableTimeSpanType, Type.EmptyTypes);
         var getCache = typeBuilder.DefineMethod("get_CacheDuration", propMethodAttrs, nullableTimeSpanType, Type.EmptyTypes);
         var ilCache = getCache.GetILGenerator();
-        var ctorNullable = nullableTimeSpanType.GetConstructor([typeof(TimeSpan)])!;
-        var fromHoursMethod = typeof(TimeSpan).GetMethod("FromHours", [typeof(double)])!;
         ilCache.Emit(OpCodes.Ldc_R8, 24.0);
-        ilCache.Emit(OpCodes.Call, fromHoursMethod);
-        ilCache.Emit(OpCodes.Newobj, ctorNullable);
+        ilCache.Emit(OpCodes.Call, typeof(TimeSpan).GetMethod("FromHours", [typeof(double)])!);
+        ilCache.Emit(OpCodes.Newobj, nullableTimeSpanType.GetConstructor([typeof(TimeSpan)])!);
         ilCache.Emit(OpCodes.Ret);
         propCache.SetGetMethod(getCache);
-        typeBuilder.DefineMethodOverride(getCache, ifaceGetCache);
+        typeBuilder.DefineMethodOverride(getCache, ifacePropCache.GetGetMethod()!);
 
-        // Static delegate fields
-        var fSupports = typeBuilder.DefineField("_supportsDelegate", typeof(Func<object, bool>), FieldAttributes.Public | FieldAttributes.Static);
-        var fGetSimilar = typeBuilder.DefineField("_getSimilarDelegate", typeof(Func<object, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>), FieldAttributes.Public | FieldAttributes.Static);
+        // The emitted methods hold no state of their own, they just forward to handlers on this
+        // instance through static delegate fields.
+        var fSupports = typeBuilder.DefineField("_supportsDelegate", typeof(Func<Type, bool>), FieldAttributes.Public | FieldAttributes.Static);
+        var fGetSimilar = typeBuilder.DefineField("_getSimilarDelegate", typeof(Func<BaseItem, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>), FieldAttributes.Public | FieldAttributes.Static);
 
-        // bool Supports(BaseItem item)
-        var ifaceSupports = localProvType.GetMethod("Supports")!;
-        var supportsParams = ifaceSupports.GetParameters().Select(p => p.ParameterType).ToArray();
-        var mSupports = typeBuilder.DefineMethod("Supports", ifaceMethodAttrs, typeof(bool), supportsParams);
+        var mSupports = typeBuilder.DefineMethod("Supports", ifaceMethodAttrs, typeof(bool), ifaceSupports.GetParameters().Select(p => p.ParameterType).ToArray());
         var ilSupports = mSupports.GetILGenerator();
         ilSupports.Emit(OpCodes.Ldsfld, fSupports);
         ilSupports.Emit(OpCodes.Ldarg_1);
-        ilSupports.Emit(OpCodes.Callvirt, typeof(Func<object, bool>).GetMethod("Invoke")!);
+        ilSupports.Emit(OpCodes.Callvirt, typeof(Func<Type, bool>).GetMethod("Invoke")!);
         ilSupports.Emit(OpCodes.Ret);
         typeBuilder.DefineMethodOverride(mSupports, ifaceSupports);
 
-        // Task<IReadOnlyList<BaseItem>> GetSimilarItemsAsync(BaseItem item, SimilarItemsQuery query, CancellationToken cancellationToken)
-        var ifaceGetSimilar = localProvType.GetMethod("GetSimilarItemsAsync")!;
-        var getSimilarParams = ifaceGetSimilar.GetParameters().Select(p => p.ParameterType).ToArray();
-        var getSimilarReturn = ifaceGetSimilar.ReturnType;
-        var mGetSimilar = typeBuilder.DefineMethod("GetSimilarItemsAsync", ifaceMethodAttrs, getSimilarReturn, getSimilarParams);
+        var mGetSimilar = typeBuilder.DefineMethod(
+            "GetSimilarItemsAsync",
+            ifaceMethodAttrs,
+            ifaceGetSimilar.ReturnType,
+            ifaceGetSimilar.GetParameters().Select(p => p.ParameterType).ToArray());
         var ilGetSimilar = mGetSimilar.GetILGenerator();
         ilGetSimilar.Emit(OpCodes.Ldsfld, fGetSimilar);
         ilGetSimilar.Emit(OpCodes.Ldarg_1);
         ilGetSimilar.Emit(OpCodes.Ldarg_2);
         ilGetSimilar.Emit(OpCodes.Ldarg_3);
-        ilGetSimilar.Emit(OpCodes.Callvirt, typeof(Func<object, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>).GetMethod("Invoke")!);
+        ilGetSimilar.Emit(OpCodes.Callvirt, typeof(Func<BaseItem, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>).GetMethod("Invoke")!);
         ilGetSimilar.Emit(OpCodes.Ret);
         typeBuilder.DefineMethodOverride(mGetSimilar, ifaceGetSimilar);
 
         var generatedType = typeBuilder.CreateType();
-        if (generatedType == null) return null;
+        if (generatedType == null)
+        {
+            _logger.LogWarning("Failed to create dynamic Moonfin similar items provider.");
+            return null;
+        }
 
-        // Hook up handlers
-        generatedType.GetField("_supportsDelegate")!.SetValue(null, (Func<object, bool>)HandleSupports);
+        generatedType.GetField("_supportsDelegate")!.SetValue(null, (Func<Type, bool>)HandleSupports);
         generatedType.GetField("_getSimilarDelegate")!.SetValue(
             null,
-            (Func<object, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>)HandleGetSimilarAsync);
+            (Func<BaseItem, object, CancellationToken, Task<IReadOnlyList<BaseItem>>>)HandleGetSimilarAsync);
+
+        _localProviderType = localProvType;
+        _stockSupports = ifaceSupports;
+        _stockGetSimilarItemsAsync = ifaceGetSimilar;
+        _queryUser = queryType.GetProperty("User");
+        _queryLimit = queryType.GetProperty("Limit");
+        _queryExcludeItemIds = queryType.GetProperty("ExcludeItemIds");
 
         return Activator.CreateInstance(generatedType);
     }
 
-    private bool HandleSupports(object? rawItem)
+    /// <summary>
+    /// Jellyfin asks this on every similar items request, so an admin turning the setting off takes
+    /// Moonfin back out of the pipeline straight away without needing a restart.
+    /// </summary>
+    private bool HandleSupports(Type? itemType)
     {
-        try
+        if (itemType == null || !IsProviderEnabled)
         {
-            if (rawItem == null) return false;
-
-            if (rawItem is Type t)
-            {
-                var supported = t.Name is "Movie" or "Series"
-                    || typeof(Movie).IsAssignableFrom(t)
-                    || typeof(Series).IsAssignableFrom(t);
-                _logger.LogInformation("Moonfin Recommends HandleSupports(Type: {TypeName}): {Supported}", t.FullName, supported);
-                return supported;
-            }
-
-            var typeName = rawItem.GetType().Name;
-            var isSupported = typeName is "Movie" or "Series" || rawItem is Movie or Series;
-            _logger.LogInformation("Moonfin Recommends HandleSupports(Instance: {TypeName}): {Supported}", typeName, isSupported);
-            return isSupported;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error in Moonfin Recommends HandleSupports");
             return false;
         }
+
+        return typeof(Movie).IsAssignableFrom(itemType) || typeof(Series).IsAssignableFrom(itemType);
     }
 
     private async Task<IReadOnlyList<BaseItem>> HandleGetSimilarAsync(
-        object? rawItem,
+        BaseItem item,
         object? rawQuery,
         CancellationToken cancellationToken)
     {
+        if (WantsStockEngine())
+        {
+            return await InvokeStockProviderAsync(item, rawQuery, cancellationToken).ConfigureAwait(false);
+        }
+
+        object? user = null;
+        int? limit = null;
+        IReadOnlyList<Guid>? excludeItemIds = null;
+
+        if (rawQuery != null)
+        {
+            user = _queryUser?.GetValue(rawQuery);
+            limit = _queryLimit?.GetValue(rawQuery) as int?;
+            excludeItemIds = _queryExcludeItemIds?.GetValue(rawQuery) as IReadOnlyList<Guid>;
+        }
+
         try
         {
-            if (rawItem is not BaseItem item)
-            {
-                _logger.LogWarning("Moonfin Recommends HandleGetSimilarAsync called with non-BaseItem: {Type}", rawItem?.GetType().FullName);
-                return Array.Empty<BaseItem>();
-            }
-
-            // Check if the current HTTP request explicitly requested stock/bypass (e.g. asking specifically for Jellyfin stock engine)
-            try
-            {
-                var httpAccessorType = Type.GetType("Microsoft.AspNetCore.Http.IHttpContextAccessor, Microsoft.AspNetCore.Http.Abstractions");
-                if (httpAccessorType != null)
-                {
-                    var accessor = _serviceProvider.GetService(httpAccessorType);
-                    if (accessor != null)
-                    {
-                        var httpContext = accessor.GetType().GetProperty("HttpContext")?.GetValue(accessor);
-                        if (httpContext != null)
-                        {
-                            var req = httpContext.GetType().GetProperty("Request")?.GetValue(httpContext);
-                            var queryString = req?.GetType().GetProperty("QueryString")?.GetValue(req)?.ToString() ?? string.Empty;
-                            if (queryString.Contains("bypass=moonfin", StringComparison.OrdinalIgnoreCase) ||
-                                queryString.Contains("engine=jellyfin", StringComparison.OrdinalIgnoreCase) ||
-                                queryString.Contains("engine=stock", StringComparison.OrdinalIgnoreCase))
-                            {
-                                _logger.LogInformation("Moonfin Recommends bypassed via query parameter for '{ItemName}'. Invoking stock provider directly.", item.Name);
-                                var stockResults = await InvokeStockProviderAsync(item, rawQuery, cancellationToken).ConfigureAwait(false);
-                                return stockResults;
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Could not check HttpContext for bypass parameter.");
-            }
-
-            _logger.LogInformation("Moonfin Recommends HandleGetSimilarAsync invoked for '{ItemName}' ({ItemId}).", item.Name, item.Id);
-
-            object? user = null;
-            int? limit = null;
-            IReadOnlyList<Guid>? excludeItemIds = null;
-
-            if (rawQuery != null)
-            {
-                var qType = rawQuery.GetType();
-                user = qType.GetProperty("User")?.GetValue(rawQuery);
-                limit = qType.GetProperty("Limit")?.GetValue(rawQuery) as int?;
-                excludeItemIds = qType.GetProperty("ExcludeItemIds")?.GetValue(rawQuery) as IReadOnlyList<Guid>;
-            }
-
-            var results = await _similarItemsService.GetSimilarItemsAsync(
+            return await _similarItemsService.GetSimilarItemsAsync(
                 item,
                 user,
                 limit,
                 excludeItemIds,
                 cancellationToken).ConfigureAwait(false);
-
-            _logger.LogInformation("Moonfin Recommends returning {Count} recommendations for '{ItemName}'.", results.Count, item.Name);
-            return results;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error generating similar items in provider.");
+            // Returning nothing lets the stock providers fill the slots instead of failing the
+            // whole request.
+            _logger.LogError(ex, "Error generating similar items for '{ItemName}'.", item.Name);
             return Array.Empty<BaseItem>();
         }
+    }
+
+    /// <summary>
+    /// Lets a caller ask for Jellyfin's own recommendations on a single request, so the two engines
+    /// can be compared without touching the server config.
+    /// </summary>
+    private bool WantsStockEngine()
+    {
+        var httpContext = _serviceProvider.GetService(typeof(IHttpContextAccessor)) is IHttpContextAccessor accessor
+            ? accessor.HttpContext
+            : null;
+
+        if (httpContext == null)
+        {
+            return false;
+        }
+
+        var query = httpContext.Request.Query;
+        if (string.Equals(query["bypass"].ToString(), "moonfin", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var engine = query["engine"].ToString();
+        return string.Equals(engine, "jellyfin", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(engine, "stock", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<IReadOnlyList<BaseItem>> InvokeStockProviderAsync(
@@ -404,96 +351,48 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
         object? rawQuery,
         CancellationToken cancellationToken)
     {
+        if (_localProviderType == null || _stockSupports == null || _stockGetSimilarItemsAsync == null)
+        {
+            return Array.Empty<BaseItem>();
+        }
+
         List<object> providers;
         lock (_stockProviders)
         {
             providers = new List<object>(_stockProviders);
         }
 
-        // Boost candidate limit for stock provider so internal Take(limit) covers entire library
-        if (rawQuery != null)
+        var itemType = item.GetType();
+
+        foreach (var provider in providers)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var providerType = provider.GetType();
+            if (!_localProviderType.IsAssignableFrom(providerType))
+            {
+                continue;
+            }
+
             try
             {
-                var limitProp = rawQuery.GetType().GetProperty("Limit");
-                if (limitProp != null && limitProp.CanWrite)
+                if (_stockSupports.Invoke(provider, [itemType]) is not true)
                 {
-                    var currentLimit = limitProp.GetValue(rawQuery) as int?;
-                    if (currentLimit == null || currentLimit < 5000)
-                    {
-                        limitProp.SetValue(rawQuery, 5000);
-                    }
+                    continue;
+                }
+
+                if (_stockGetSimilarItemsAsync.Invoke(provider, [item, rawQuery, cancellationToken]) is Task<IReadOnlyList<BaseItem>> typedTask)
+                {
+                    return await typedTask.ConfigureAwait(false);
                 }
             }
-            catch { }
-        }
-
-        var itemType = item.GetType();
-        foreach (var sp in providers)
-        {
-            try
+            catch (OperationCanceledException)
             {
-                var spType = sp.GetType();
-                var localProvType = Type.GetType("MediaBrowser.Controller.Library.ILocalSimilarItemsProvider, MediaBrowser.Controller");
-                var isLocalProv = localProvType != null && localProvType.IsAssignableFrom(spType);
-                var supportsMethod = isLocalProv
-                    ? localProvType!.GetMethod("Supports")
-                    : spType.GetMethod("Supports", [typeof(Type)]);
-
-                var isSupported = false;
-                if (supportsMethod != null)
-                {
-                    var res = supportsMethod.Invoke(sp, [itemType]);
-                    if (res is bool b && b)
-                    {
-                        isSupported = true;
-                    }
-                }
-                else
-                {
-                    var directSupports = spType.GetMethod("Supports", [typeof(BaseItem)])
-                        ?? spType.GetMethod("Supports", [itemType]);
-                    if (directSupports != null)
-                    {
-                        var res = directSupports.Invoke(sp, [item]);
-                        if (res is bool b && b)
-                        {
-                            isSupported = true;
-                        }
-                    }
-                }
-
-                if (isSupported)
-                {
-                    var getSimMethod = isLocalProv
-                        ? localProvType!.GetMethod("GetSimilarItemsAsync")
-                        : spType.GetMethod("GetSimilarItemsAsync");
-
-                    if (getSimMethod != null)
-                    {
-                        var taskObj = getSimMethod.Invoke(sp, [item, rawQuery, cancellationToken]);
-                        if (taskObj is Task<IReadOnlyList<BaseItem>> typedTask)
-                        {
-                            var list = await typedTask.ConfigureAwait(false);
-                            _logger.LogInformation("Stock provider {ProviderName} returned {Count} items for '{ItemName}'.", spType.Name, list.Count, item.Name);
-                            return list;
-                        }
-                        if (taskObj is Task genericTask)
-                        {
-                            await genericTask.ConfigureAwait(false);
-                            var prop = genericTask.GetType().GetProperty("Result");
-                            if (prop?.GetValue(genericTask) is IReadOnlyList<BaseItem> list)
-                            {
-                                _logger.LogInformation("Stock provider {ProviderName} returned {Count} items for '{ItemName}'.", spType.Name, list.Count, item.Name);
-                                return list;
-                            }
-                        }
-                    }
-                }
+                throw;
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to invoke stock similarity provider {ProviderType} for '{ItemName}'.", sp.GetType().FullName, item.Name);
+                _logger.LogWarning(ex, "Failed to invoke stock similarity provider {ProviderType} for '{ItemName}'.", providerType.FullName, item.Name);
             }
         }
 

--- a/Jellyfin/backend/Services/MoonfinSimilarItemsProviderManager.cs
+++ b/Jellyfin/backend/Services/MoonfinSimilarItemsProviderManager.cs
@@ -435,8 +435,9 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
             {
                 var spType = sp.GetType();
                 var localProvType = Type.GetType("MediaBrowser.Controller.Library.ILocalSimilarItemsProvider, MediaBrowser.Controller");
-                var supportsMethod = localProvType != null
-                    ? localProvType.GetMethod("Supports")
+                var isLocalProv = localProvType != null && localProvType.IsAssignableFrom(spType);
+                var supportsMethod = isLocalProv
+                    ? localProvType!.GetMethod("Supports")
                     : spType.GetMethod("Supports", [typeof(Type)]);
 
                 var isSupported = false;
@@ -464,8 +465,8 @@ public class MoonfinSimilarItemsProviderManager : IHostedService
 
                 if (isSupported)
                 {
-                    var getSimMethod = localProvType != null
-                        ? localProvType.GetMethod("GetSimilarItemsAsync")
+                    var getSimMethod = isLocalProv
+                        ? localProvType!.GetMethod("GetSimilarItemsAsync")
                         : spType.GetMethod("GetSimilarItemsAsync");
 
                     if (getSimMethod != null)

--- a/Jellyfin/backend/Services/MoonfinSimilarItemsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSimilarItemsService.cs
@@ -1,0 +1,403 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.Extensions.Logging;
+
+namespace Moonfin.Server.Services;
+
+/// <summary>
+/// Server-side scoring service for Moonfin Recommends.
+/// Matches the weighted recommendation algorithm used by Moonfin clients.
+/// </summary>
+public class MoonfinSimilarItemsService
+{
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger<MoonfinSimilarItemsService> _logger;
+
+    private static readonly HashSet<string> StopWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "the", "and", "with", "from", "under", "over", "about", "chapter", "part", "movie", "film"
+    };
+
+    public MoonfinSimilarItemsService(
+        ILibraryManager libraryManager,
+        ILogger<MoonfinSimilarItemsService> logger)
+    {
+        _libraryManager = libraryManager;
+        _logger = logger;
+    }
+
+    private static readonly MethodInfo? _internalItemsQuerySetUser = typeof(InternalItemsQuery).GetMethod("SetUser", BindingFlags.Public | BindingFlags.Instance);
+    private static readonly PropertyInfo? _internalItemsQueryUserProperty = typeof(InternalItemsQuery).GetProperty("User", BindingFlags.Public | BindingFlags.Instance);
+
+    private static void ApplyUser(InternalItemsQuery query, object? user)
+    {
+        if (user == null) return;
+        if (_internalItemsQuerySetUser != null)
+        {
+            _internalItemsQuerySetUser.Invoke(query, [user]);
+        }
+        else if (_internalItemsQueryUserProperty != null)
+        {
+            _internalItemsQueryUserProperty.SetValue(query, user);
+        }
+    }
+
+    private static readonly MethodInfo? _baseItemGetPeople = typeof(BaseItem).GetMethod("GetPeople", Type.EmptyTypes);
+    private static readonly PropertyInfo? _baseItemPeopleProp = typeof(BaseItem).GetProperty("People", BindingFlags.Public | BindingFlags.Instance);
+    private static readonly MethodInfo? _libMgrGetPeople = typeof(ILibraryManager).GetMethod("GetPeople", [typeof(BaseItem)]);
+
+    private IEnumerable<object> GetItemPeople(BaseItem item)
+    {
+        if (_baseItemGetPeople != null)
+        {
+            try
+            {
+                var res = _baseItemGetPeople.Invoke(item, null);
+                if (res is IEnumerable list) return list.Cast<object>();
+            }
+            catch { }
+        }
+
+        if (_baseItemPeopleProp != null)
+        {
+            try
+            {
+                var res = _baseItemPeopleProp.GetValue(item);
+                if (res is IEnumerable list) return list.Cast<object>();
+            }
+            catch { }
+        }
+
+        if (_libMgrGetPeople != null)
+        {
+            try
+            {
+                var res = _libMgrGetPeople.Invoke(_libraryManager, [item]);
+                if (res is IEnumerable list) return list.Cast<object>();
+            }
+            catch { }
+        }
+
+        return Array.Empty<object>();
+    }
+
+    private static (string? Name, string? Role) GetPersonDetails(object p)
+    {
+        var pType = p.GetType();
+        var name = pType.GetProperty("Name")?.GetValue(p)?.ToString();
+        var role = pType.GetProperty("Type")?.GetValue(p)?.ToString();
+        return (name, role);
+    }
+
+    /// <summary>
+    /// Gets scored recommendations for a given media item.
+    /// </summary>
+    public Task<IReadOnlyList<BaseItem>> GetSimilarItemsAsync(
+        BaseItem item,
+        object? user,
+        int? limit,
+        IReadOnlyList<Guid>? excludeItemIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var effectiveLimit = limit.GetValueOrDefault(100);
+        if (effectiveLimit <= 0) effectiveLimit = 100;
+
+        var isSeries = item is Series;
+        var isMovie = item is Movie;
+
+        // Only Movie and Series types are eligible for Moonfin Recommends
+        if (!isMovie && !isSeries)
+        {
+            return Task.FromResult<IReadOnlyList<BaseItem>>(Array.Empty<BaseItem>());
+        }
+
+        var baseGenres = new HashSet<string>(item.Genres ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        var baseTags = new HashSet<string>(item.Tags ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        var baseStudios = new HashSet<string>(item.Studios ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        var baseYear = item.ProductionYear;
+        var baseName = item.Name ?? string.Empty;
+
+        var people = GetItemPeople(item);
+        var actorNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var directorNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var writerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var p in people)
+        {
+            var (pName, pRole) = GetPersonDetails(p);
+            if (string.IsNullOrEmpty(pName) || string.IsNullOrEmpty(pRole)) continue;
+
+            if (string.Equals(pRole, "Actor", StringComparison.OrdinalIgnoreCase))
+            {
+                actorNames.Add(pName);
+            }
+            else if (string.Equals(pRole, "Director", StringComparison.OrdinalIgnoreCase))
+            {
+                directorNames.Add(pName);
+            }
+            else if (string.Equals(pRole, "Writer", StringComparison.OrdinalIgnoreCase))
+            {
+                writerNames.Add(pName);
+            }
+        }
+
+        var excludedIds = new HashSet<Guid>(excludeItemIds ?? Array.Empty<Guid>())
+        {
+            item.Id
+        };
+
+        var targetType = isSeries ? BaseItemKind.Series : BaseItemKind.Movie;
+        var candidatesMap = new Dictionary<Guid, BaseItem>();
+
+        // Query candidates sharing genres (unbounded across library)
+        if (baseGenres.Count > 0)
+        {
+            var genreQuery = new InternalItemsQuery
+            {
+                IncludeItemTypes = [targetType],
+                IsVirtualItem = false,
+                Recursive = true,
+                Genres = baseGenres.ToArray(),
+                DtoOptions = new DtoOptions { Fields = [ItemFields.Genres, ItemFields.Tags, ItemFields.Studios, ItemFields.People] }
+            };
+            ApplyUser(genreQuery, user);
+
+            var results = _libraryManager.GetItemsResult(genreQuery).Items;
+            foreach (var cand in results)
+            {
+                if (!excludedIds.Contains(cand.Id))
+                {
+                    candidatesMap[cand.Id] = cand;
+                }
+            }
+        }
+
+        // Query candidates sharing tags (unbounded across library)
+        if (baseTags.Count > 0)
+        {
+            var tagQuery = new InternalItemsQuery
+            {
+                IncludeItemTypes = [targetType],
+                IsVirtualItem = false,
+                Recursive = true,
+                Tags = baseTags.ToArray(),
+                DtoOptions = new DtoOptions { Fields = [ItemFields.Genres, ItemFields.Tags, ItemFields.Studios, ItemFields.People] }
+            };
+            ApplyUser(tagQuery, user);
+
+            var results = _libraryManager.GetItemsResult(tagQuery).Items;
+            foreach (var cand in results)
+            {
+                if (!excludedIds.Contains(cand.Id))
+                {
+                    candidatesMap[cand.Id] = cand;
+                }
+            }
+        }
+
+        // If candidate pool is still sparse, fetch recent items of same type
+        if (candidatesMap.Count < 20)
+        {
+            var fallbackQuery = new InternalItemsQuery
+            {
+                IncludeItemTypes = [targetType],
+                IsVirtualItem = false,
+                Recursive = true,
+                Limit = 40,
+                DtoOptions = new DtoOptions { Fields = [ItemFields.Genres, ItemFields.Tags, ItemFields.Studios, ItemFields.People] }
+            };
+            SetPremiereDateDescending(fallbackQuery);
+            ApplyUser(fallbackQuery, user);
+
+            var results = _libraryManager.GetItemsResult(fallbackQuery).Items;
+            foreach (var cand in results)
+            {
+                if (!excludedIds.Contains(cand.Id))
+                {
+                    candidatesMap[cand.Id] = cand;
+                }
+            }
+        }
+
+        // Score candidates
+        var scoredList = new List<(BaseItem Item, double Score)>(candidatesMap.Count);
+        foreach (var cand in candidatesMap.Values)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var score = ScoreCandidate(
+                cand,
+                baseGenres,
+                baseTags,
+                baseStudios,
+                baseYear,
+                baseName,
+                actorNames,
+                directorNames,
+                writerNames);
+
+            scoredList.Add((cand, score));
+        }
+
+        // Sort by score descending, then premiere date descending
+        var sorted = scoredList
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.Item.PremiereDate ?? DateTime.MinValue)
+            .Take(effectiveLimit)
+            .Select(x => x.Item)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<BaseItem>>(sorted);
+    }
+
+    private double ScoreCandidate(
+        BaseItem candidate,
+        HashSet<string> genres,
+        HashSet<string> tags,
+        HashSet<string> studios,
+        int? baseYear,
+        string baseName,
+        HashSet<string> actorNames,
+        HashSet<string> directorNames,
+        HashSet<string> writerNames)
+    {
+        double score = 0.0;
+
+        // Shared Genres: +3.0 each
+        if (candidate.Genres != null)
+        {
+            foreach (var g in candidate.Genres)
+            {
+                if (genres.Contains(g)) score += 3.0;
+            }
+        }
+
+        // Shared Tags: +3.0 each
+        if (candidate.Tags != null)
+        {
+            foreach (var t in candidate.Tags)
+            {
+                if (tags.Contains(t)) score += 3.0;
+            }
+        }
+
+        // Shared People (Actors +5.0, Directors +6.0, Writers +6.0)
+        var candPeople = GetItemPeople(candidate);
+        foreach (var p in candPeople)
+        {
+            var (pName, pRole) = GetPersonDetails(p);
+            if (string.IsNullOrEmpty(pName) || string.IsNullOrEmpty(pRole)) continue;
+
+            if (string.Equals(pRole, "Actor", StringComparison.OrdinalIgnoreCase))
+            {
+                if (actorNames.Contains(pName)) score += 5.0;
+            }
+            else if (string.Equals(pRole, "Director", StringComparison.OrdinalIgnoreCase))
+            {
+                if (directorNames.Contains(pName)) score += 6.0;
+            }
+            else if (string.Equals(pRole, "Writer", StringComparison.OrdinalIgnoreCase))
+            {
+                if (writerNames.Contains(pName)) score += 6.0;
+            }
+        }
+
+        // Shared Studios: +3.0 each
+        if (candidate.Studios != null)
+        {
+            foreach (var s in candidate.Studios)
+            {
+                if (studios.Contains(s)) score += 3.0;
+            }
+        }
+
+        // Production Year: +2.0 same year, +1.0 within 3 years
+        if (candidate.ProductionYear.HasValue && baseYear.HasValue)
+        {
+            var diff = Math.Abs(candidate.ProductionYear.Value - baseYear.Value);
+            if (diff == 0) score += 2.0;
+            else if (diff <= 3) score += 1.0;
+        }
+
+        // Sequel or Similar Title: +10.0
+        if (IsSequelOrSimilarTitle(baseName, candidate.Name ?? string.Empty))
+        {
+            score += 10.0;
+        }
+
+        // Community Rating: +(CommunityRating / 10.0)
+        if (candidate.CommunityRating.HasValue)
+        {
+            score += candidate.CommunityRating.Value / 10.0;
+        }
+
+        return score;
+    }
+
+    private static List<string> ExtractKeyWords(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return new List<string>();
+        var cleaned = Regex.Replace(s.ToLowerInvariant(), @"[^\w\s]", " ");
+        return cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => w.Length >= 4 && !StopWords.Contains(w))
+            .ToList();
+    }
+
+    private static bool IsSequelOrSimilarTitle(string titleA, string titleB)
+    {
+        var a = ExtractKeyWords(titleA);
+        var b = ExtractKeyWords(titleB);
+        if (a.Count == 0 || b.Count == 0) return false;
+
+        var setA = new HashSet<string>(a, StringComparer.OrdinalIgnoreCase);
+        var setB = new HashSet<string>(b, StringComparer.OrdinalIgnoreCase);
+
+        // One title's keywords are completely contained in the other
+        if (setA.IsSubsetOf(setB) || setB.IsSubsetOf(setA)) return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sets OrderBy to (ItemSortBy.PremiereDate, SortOrder.Descending) via reflection
+    /// to avoid compile-time or runtime type mismatches between Jellyfin 10.x, 11.x, and 12.x.
+    /// </summary>
+    private static void SetPremiereDateDescending(InternalItemsQuery query)
+    {
+        try
+        {
+            var orderByProp = typeof(InternalItemsQuery).GetProperty(nameof(InternalItemsQuery.OrderBy));
+            if (orderByProp == null) return;
+
+            var elementType = orderByProp.PropertyType.GetGenericArguments()[0];
+            var sortOrderType = elementType.GetGenericArguments()[1];
+            // SortOrder.Descending is enum value 1 (Ascending = 0, Descending = 1)
+            var descending = Enum.ToObject(sortOrderType, 1);
+
+            var tuple = Activator.CreateInstance(elementType, ItemSortBy.PremiereDate, descending);
+            var array = Array.CreateInstance(elementType, 1);
+            array.SetValue(tuple, 0);
+
+            orderByProp.SetValue(query, array);
+        }
+        catch
+        {
+            // Silently ignore if order cannot be set dynamically
+        }
+    }
+}

--- a/Jellyfin/backend/Services/MoonfinSimilarItemsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSimilarItemsService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -7,23 +6,48 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
-using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Querying;
 using Microsoft.Extensions.Logging;
 
 namespace Moonfin.Server.Services;
 
 /// <summary>
-/// Server-side scoring service for Moonfin Recommends.
-/// Matches the weighted recommendation algorithm used by Moonfin clients.
+/// Server side scoring for Moonfin Recommends.
+///
+/// Scoring runs in two passes. The first scores every candidate on metadata that already sits on
+/// the item, which costs nothing extra. The second takes only the best of those and adds cast and
+/// crew overlap, which needs a database read per item on Jellyfin 10.x. Splitting it keeps the
+/// people reads bounded no matter how large the library is.
 /// </summary>
 public class MoonfinSimilarItemsService
 {
+    private const int MaxCandidatesPerQuery = 400;
+    private const int PeopleScoringPoolSize = 60;
+    private const int SparseCandidateThreshold = 20;
+    private const int SparseFallbackCount = 40;
+    private const int DefaultLimit = 20;
+    private const int MaxLimit = 200;
+
+    private const double GenrePoints = 5.0;
+    private const double GenreCap = 35.0;
+    private const double TagPoints = 4.0;
+    private const double TagCap = 20.0;
+    private const double StudioPoints = 4.0;
+    private const double StudioCap = 8.0;
+    private const double ActorPoints = 6.0;
+    private const double ActorCap = 18.0;
+    private const double DirectorPoints = 8.0;
+    private const double DirectorCap = 15.0;
+    private const double WriterPoints = 4.0;
+    private const double WriterCap = 8.0;
+    private const double YearMaxPoints = 10.0;
+    private const int YearDecayRange = 15;
+    private const double RatingMaxPoints = 5.0;
+    private const double TitleMatchPoints = 10.0;
+
     private readonly ILibraryManager _libraryManager;
     private readonly ILogger<MoonfinSimilarItemsService> _logger;
 
@@ -31,6 +55,18 @@ public class MoonfinSimilarItemsService
     {
         "the", "and", "with", "from", "under", "over", "about", "chapter", "part", "movie", "film"
     };
+
+    private static readonly Regex NonWordRegex = new(@"[^\w\s]", RegexOptions.Compiled);
+
+    private static readonly MethodInfo? _internalItemsQuerySetUser = typeof(InternalItemsQuery).GetMethod("SetUser", BindingFlags.Public | BindingFlags.Instance);
+    private static readonly PropertyInfo? _internalItemsQueryOrderBy = typeof(InternalItemsQuery).GetProperty(nameof(InternalItemsQuery.OrderBy));
+
+    // GetPeople returned List<PersonInfo> on 10.10 and IReadOnlyList<PersonInfo> from 10.11 on, so
+    // a direct call only binds on the version it was compiled against. Looking the method up by
+    // name and parameters ignores the return type and works on every version. GetPeopleByItems is
+    // Jellyfin 12 only and reads the whole batch in a single query.
+    private static readonly MethodInfo? _libMgrGetPeople = typeof(ILibraryManager).GetMethod("GetPeople", [typeof(BaseItem)]);
+    private static readonly MethodInfo? _libMgrGetPeopleByItems = typeof(ILibraryManager).GetMethod("GetPeopleByItems", [typeof(IReadOnlyList<Guid>)]);
 
     public MoonfinSimilarItemsService(
         ILibraryManager libraryManager,
@@ -40,72 +76,6 @@ public class MoonfinSimilarItemsService
         _logger = logger;
     }
 
-    private static readonly MethodInfo? _internalItemsQuerySetUser = typeof(InternalItemsQuery).GetMethod("SetUser", BindingFlags.Public | BindingFlags.Instance);
-    private static readonly PropertyInfo? _internalItemsQueryUserProperty = typeof(InternalItemsQuery).GetProperty("User", BindingFlags.Public | BindingFlags.Instance);
-
-    private static void ApplyUser(InternalItemsQuery query, object? user)
-    {
-        if (user == null) return;
-        if (_internalItemsQuerySetUser != null)
-        {
-            _internalItemsQuerySetUser.Invoke(query, [user]);
-        }
-        else if (_internalItemsQueryUserProperty != null)
-        {
-            _internalItemsQueryUserProperty.SetValue(query, user);
-        }
-    }
-
-    private static readonly MethodInfo? _baseItemGetPeople = typeof(BaseItem).GetMethod("GetPeople", Type.EmptyTypes);
-    private static readonly PropertyInfo? _baseItemPeopleProp = typeof(BaseItem).GetProperty("People", BindingFlags.Public | BindingFlags.Instance);
-    private static readonly MethodInfo? _libMgrGetPeople = typeof(ILibraryManager).GetMethod("GetPeople", [typeof(BaseItem)]);
-
-    private IEnumerable<object> GetItemPeople(BaseItem item)
-    {
-        if (_baseItemGetPeople != null)
-        {
-            try
-            {
-                var res = _baseItemGetPeople.Invoke(item, null);
-                if (res is IEnumerable list) return list.Cast<object>();
-            }
-            catch { }
-        }
-
-        if (_baseItemPeopleProp != null)
-        {
-            try
-            {
-                var res = _baseItemPeopleProp.GetValue(item);
-                if (res is IEnumerable list) return list.Cast<object>();
-            }
-            catch { }
-        }
-
-        if (_libMgrGetPeople != null)
-        {
-            try
-            {
-                var res = _libMgrGetPeople.Invoke(_libraryManager, [item]);
-                if (res is IEnumerable list) return list.Cast<object>();
-            }
-            catch { }
-        }
-
-        return Array.Empty<object>();
-    }
-
-    private static (string? Name, string? Role) GetPersonDetails(object p)
-    {
-        var pType = p.GetType();
-        var name = pType.GetProperty("Name")?.GetValue(p)?.ToString();
-        var role = pType.GetProperty("Type")?.GetValue(p)?.ToString();
-        return (name, role);
-    }
-
-    /// <summary>
-    /// Gets scored recommendations for a given media item.
-    /// </summary>
     public Task<IReadOnlyList<BaseItem>> GetSimilarItemsAsync(
         BaseItem item,
         object? user,
@@ -114,47 +84,17 @@ public class MoonfinSimilarItemsService
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(item);
-        var effectiveLimit = limit.GetValueOrDefault(100);
-        if (effectiveLimit <= 0) effectiveLimit = 100;
+        var effectiveLimit = limit.GetValueOrDefault(DefaultLimit);
+        if (effectiveLimit <= 0) effectiveLimit = DefaultLimit;
+        if (effectiveLimit > MaxLimit) effectiveLimit = MaxLimit;
 
         var isSeries = item is Series;
-        var isMovie = item is Movie;
-
-        // Only Movie and Series types are eligible for Moonfin Recommends
-        if (!isMovie && !isSeries)
+        if (item is not Movie && !isSeries)
         {
             return Task.FromResult<IReadOnlyList<BaseItem>>(Array.Empty<BaseItem>());
         }
 
-        var baseGenres = new HashSet<string>(item.Genres ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
-        var baseTags = new HashSet<string>(item.Tags ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
-        var baseStudios = new HashSet<string>(item.Studios ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
-        var baseYear = item.ProductionYear;
-        var baseName = item.Name ?? string.Empty;
-
-        var people = GetItemPeople(item);
-        var actorNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var directorNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var writerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var p in people)
-        {
-            var (pName, pRole) = GetPersonDetails(p);
-            if (string.IsNullOrEmpty(pName) || string.IsNullOrEmpty(pRole)) continue;
-
-            if (string.Equals(pRole, "Actor", StringComparison.OrdinalIgnoreCase))
-            {
-                actorNames.Add(pName);
-            }
-            else if (string.Equals(pRole, "Director", StringComparison.OrdinalIgnoreCase))
-            {
-                directorNames.Add(pName);
-            }
-            else if (string.Equals(pRole, "Writer", StringComparison.OrdinalIgnoreCase))
-            {
-                writerNames.Add(pName);
-            }
-        }
+        var seed = new SeedProfile(item, GetItemPeople(item));
 
         var excludedIds = new HashSet<Guid>(excludeItemIds ?? Array.Empty<Guid>())
         {
@@ -164,98 +104,50 @@ public class MoonfinSimilarItemsService
         var targetType = isSeries ? BaseItemKind.Series : BaseItemKind.Movie;
         var candidatesMap = new Dictionary<Guid, BaseItem>();
 
-        // Query candidates sharing genres (unbounded across library)
-        if (baseGenres.Count > 0)
+        if (seed.Genres.Count > 0)
         {
-            var genreQuery = new InternalItemsQuery
-            {
-                IncludeItemTypes = [targetType],
-                IsVirtualItem = false,
-                Recursive = true,
-                Genres = baseGenres.ToArray(),
-                DtoOptions = new DtoOptions { Fields = [ItemFields.Genres, ItemFields.Tags, ItemFields.Studios, ItemFields.People] }
-            };
-            ApplyUser(genreQuery, user);
-
-            var results = _libraryManager.GetItemsResult(genreQuery).Items;
-            foreach (var cand in results)
-            {
-                if (!excludedIds.Contains(cand.Id))
-                {
-                    candidatesMap[cand.Id] = cand;
-                }
-            }
+            CollectCandidates(candidatesMap, excludedIds, targetType, user, q => q.Genres = seed.Genres.ToArray());
         }
 
-        // Query candidates sharing tags (unbounded across library)
-        if (baseTags.Count > 0)
+        if (seed.Tags.Count > 0)
         {
-            var tagQuery = new InternalItemsQuery
-            {
-                IncludeItemTypes = [targetType],
-                IsVirtualItem = false,
-                Recursive = true,
-                Tags = baseTags.ToArray(),
-                DtoOptions = new DtoOptions { Fields = [ItemFields.Genres, ItemFields.Tags, ItemFields.Studios, ItemFields.People] }
-            };
-            ApplyUser(tagQuery, user);
-
-            var results = _libraryManager.GetItemsResult(tagQuery).Items;
-            foreach (var cand in results)
-            {
-                if (!excludedIds.Contains(cand.Id))
-                {
-                    candidatesMap[cand.Id] = cand;
-                }
-            }
+            CollectCandidates(candidatesMap, excludedIds, targetType, user, q => q.Tags = seed.Tags.ToArray());
         }
 
-        // If candidate pool is still sparse, fetch recent items of same type
-        if (candidatesMap.Count < 20)
+        if (candidatesMap.Count < SparseCandidateThreshold)
         {
-            var fallbackQuery = new InternalItemsQuery
-            {
-                IncludeItemTypes = [targetType],
-                IsVirtualItem = false,
-                Recursive = true,
-                Limit = 40,
-                DtoOptions = new DtoOptions { Fields = [ItemFields.Genres, ItemFields.Tags, ItemFields.Studios, ItemFields.People] }
-            };
-            SetPremiereDateDescending(fallbackQuery);
-            ApplyUser(fallbackQuery, user);
-
-            var results = _libraryManager.GetItemsResult(fallbackQuery).Items;
-            foreach (var cand in results)
-            {
-                if (!excludedIds.Contains(cand.Id))
-                {
-                    candidatesMap[cand.Id] = cand;
-                }
-            }
+            CollectCandidates(candidatesMap, excludedIds, targetType, user, null, SparseFallbackCount);
         }
 
-        // Score candidates
-        var scoredList = new List<(BaseItem Item, double Score)>(candidatesMap.Count);
-        foreach (var cand in candidatesMap.Values)
+        var scored = new List<(BaseItem Item, double Score)>(candidatesMap.Count);
+        foreach (var candidate in candidatesMap.Values)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            var score = ScoreCandidate(
-                cand,
-                baseGenres,
-                baseTags,
-                baseStudios,
-                baseYear,
-                baseName,
-                actorNames,
-                directorNames,
-                writerNames);
-
-            scoredList.Add((cand, score));
+            scored.Add((candidate, ScoreMetadata(candidate, seed)));
         }
 
-        // Sort by score descending, then premiere date descending
-        var sorted = scoredList
+        var pool = scored
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.Item.PremiereDate ?? DateTime.MinValue)
+            .Take(Math.Max(effectiveLimit, PeopleScoringPoolSize))
+            .ToList();
+
+        var peopleCount = Math.Min(pool.Count, PeopleScoringPoolSize);
+        if (seed.HasPeople && peopleCount > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var peopleByItem = GetPeopleForItems(pool.Take(peopleCount).Select(x => x.Item).ToList());
+            for (var i = 0; i < peopleCount; i++)
+            {
+                var (candidate, score) = pool[i];
+                if (peopleByItem.TryGetValue(candidate.Id, out var people))
+                {
+                    pool[i] = (candidate, score + ScorePeople(people, seed));
+                }
+            }
+        }
+
+        var sorted = pool
             .OrderByDescending(x => x.Score)
             .ThenByDescending(x => x.Item.PremiereDate ?? DateTime.MinValue)
             .Take(effectiveLimit)
@@ -265,139 +157,267 @@ public class MoonfinSimilarItemsService
         return Task.FromResult<IReadOnlyList<BaseItem>>(sorted);
     }
 
-    private double ScoreCandidate(
-        BaseItem candidate,
-        HashSet<string> genres,
-        HashSet<string> tags,
-        HashSet<string> studios,
-        int? baseYear,
-        string baseName,
-        HashSet<string> actorNames,
-        HashSet<string> directorNames,
-        HashSet<string> writerNames)
+    private void CollectCandidates(
+        Dictionary<Guid, BaseItem> candidatesMap,
+        HashSet<Guid> excludedIds,
+        BaseItemKind targetType,
+        object? user,
+        Action<InternalItemsQuery>? applyFilter,
+        int? limitOverride = null)
+    {
+        var query = new InternalItemsQuery
+        {
+            IncludeItemTypes = [targetType],
+            IsVirtualItem = false,
+            Recursive = true,
+            Limit = limitOverride ?? MaxCandidatesPerQuery,
+            EnableTotalRecordCount = false
+        };
+
+        applyFilter?.Invoke(query);
+
+        // A genre or tag filter matches any of the supplied values, so a popular genre alone can
+        // cover most of the library, and the unfiltered fallback covers all of it. Ordering first
+        // means the capped pool is the best rated or the newest rather than whatever the database
+        // happened to return.
+        SetOrderByDescending(query, applyFilter == null ? ItemSortBy.PremiereDate : ItemSortBy.CommunityRating);
+        ApplyUser(query, user);
+
+        foreach (var candidate in _libraryManager.GetItemsResult(query).Items)
+        {
+            if (!excludedIds.Contains(candidate.Id))
+            {
+                candidatesMap[candidate.Id] = candidate;
+            }
+        }
+    }
+
+    private static void ApplyUser(InternalItemsQuery query, object? user)
+    {
+        if (user == null || _internalItemsQuerySetUser == null) return;
+        _internalItemsQuerySetUser.Invoke(query, [user]);
+    }
+
+    /// <summary>
+    /// Sets OrderBy descending through reflection. The SortOrder half of the tuple moved assemblies
+    /// between Jellyfin 10.10 and 10.11, so a direct assignment only binds on one of them.
+    /// </summary>
+    private static void SetOrderByDescending(InternalItemsQuery query, ItemSortBy sortBy)
+    {
+        if (_internalItemsQueryOrderBy == null) return;
+
+        var elementType = _internalItemsQueryOrderBy.PropertyType.GetGenericArguments()[0];
+        var sortOrderType = elementType.GetGenericArguments()[1];
+        var descending = Enum.Parse(sortOrderType, "Descending");
+
+        var array = Array.CreateInstance(elementType, 1);
+        array.SetValue(Activator.CreateInstance(elementType, sortBy, descending), 0);
+
+        _internalItemsQueryOrderBy.SetValue(query, array);
+    }
+
+    private IReadOnlyList<PersonInfo> GetItemPeople(BaseItem item)
+    {
+        if (_libMgrGetPeople == null)
+        {
+            return Array.Empty<PersonInfo>();
+        }
+
+        try
+        {
+            if (_libMgrGetPeople.Invoke(_libraryManager, [item]) is IEnumerable<PersonInfo> people)
+            {
+                return people as IReadOnlyList<PersonInfo> ?? people.ToArray();
+            }
+        }
+        catch (TargetInvocationException ex)
+        {
+            _logger.LogDebug(ex, "Could not read people for '{ItemName}'.", item.Name);
+        }
+
+        return Array.Empty<PersonInfo>();
+    }
+
+    /// <summary>
+    /// Reads cast and crew for a batch of items, one query on Jellyfin 12 and one query per item on
+    /// older servers. The caller keeps the batch small so the fallback stays cheap.
+    /// </summary>
+    private Dictionary<Guid, IReadOnlyList<PersonInfo>> GetPeopleForItems(IReadOnlyList<BaseItem> items)
+    {
+        var result = new Dictionary<Guid, IReadOnlyList<PersonInfo>>(items.Count);
+
+        if (_libMgrGetPeopleByItems != null)
+        {
+            try
+            {
+                IReadOnlyList<Guid> ids = items.Select(i => i.Id).ToArray();
+                if (_libMgrGetPeopleByItems.Invoke(_libraryManager, [ids]) is IReadOnlyDictionary<Guid, IReadOnlyList<PersonInfo>> byItem)
+                {
+                    foreach (var (id, people) in byItem)
+                    {
+                        result[id] = people;
+                    }
+
+                    return result;
+                }
+            }
+            catch (TargetInvocationException ex)
+            {
+                _logger.LogDebug(ex, "Batch people lookup failed, falling back to per item reads.");
+            }
+        }
+
+        foreach (var item in items)
+        {
+            result[item.Id] = GetItemPeople(item);
+        }
+
+        return result;
+    }
+
+    private static void CollectPeople(
+        IEnumerable<PersonInfo> people,
+        HashSet<string> actors,
+        HashSet<string> directors,
+        HashSet<string> writers)
+    {
+        foreach (var person in people)
+        {
+            if (string.IsNullOrEmpty(person.Name)) continue;
+
+            switch (person.Type)
+            {
+                case PersonKind.Actor:
+                case PersonKind.GuestStar:
+                    actors.Add(person.Name);
+                    break;
+                case PersonKind.Director:
+                    directors.Add(person.Name);
+                    break;
+                case PersonKind.Writer:
+                    writers.Add(person.Name);
+                    break;
+            }
+        }
+    }
+
+    private static double ScoreMetadata(BaseItem candidate, SeedProfile seed)
     {
         double score = 0.0;
 
-        // Shared Genres: +3.0 each
-        if (candidate.Genres != null)
+        score += Math.Min(CountOverlap(candidate.Genres, seed.Genres) * GenrePoints, GenreCap);
+        score += Math.Min(CountOverlap(candidate.Tags, seed.Tags) * TagPoints, TagCap);
+        score += Math.Min(CountOverlap(candidate.Studios, seed.Studios) * StudioPoints, StudioCap);
+
+        if (candidate.ProductionYear.HasValue && seed.Year.HasValue)
         {
-            foreach (var g in candidate.Genres)
+            var diff = Math.Abs(candidate.ProductionYear.Value - seed.Year.Value);
+            if (diff < YearDecayRange)
             {
-                if (genres.Contains(g)) score += 3.0;
+                score += YearMaxPoints * (1.0 - ((double)diff / YearDecayRange));
             }
         }
 
-        // Shared Tags: +3.0 each
-        if (candidate.Tags != null)
-        {
-            foreach (var t in candidate.Tags)
-            {
-                if (tags.Contains(t)) score += 3.0;
-            }
-        }
-
-        // Shared People (Actors +5.0, Directors +6.0, Writers +6.0)
-        var candPeople = GetItemPeople(candidate);
-        foreach (var p in candPeople)
-        {
-            var (pName, pRole) = GetPersonDetails(p);
-            if (string.IsNullOrEmpty(pName) || string.IsNullOrEmpty(pRole)) continue;
-
-            if (string.Equals(pRole, "Actor", StringComparison.OrdinalIgnoreCase))
-            {
-                if (actorNames.Contains(pName)) score += 5.0;
-            }
-            else if (string.Equals(pRole, "Director", StringComparison.OrdinalIgnoreCase))
-            {
-                if (directorNames.Contains(pName)) score += 6.0;
-            }
-            else if (string.Equals(pRole, "Writer", StringComparison.OrdinalIgnoreCase))
-            {
-                if (writerNames.Contains(pName)) score += 6.0;
-            }
-        }
-
-        // Shared Studios: +3.0 each
-        if (candidate.Studios != null)
-        {
-            foreach (var s in candidate.Studios)
-            {
-                if (studios.Contains(s)) score += 3.0;
-            }
-        }
-
-        // Production Year: +2.0 same year, +1.0 within 3 years
-        if (candidate.ProductionYear.HasValue && baseYear.HasValue)
-        {
-            var diff = Math.Abs(candidate.ProductionYear.Value - baseYear.Value);
-            if (diff == 0) score += 2.0;
-            else if (diff <= 3) score += 1.0;
-        }
-
-        // Sequel or Similar Title: +10.0
-        if (IsSequelOrSimilarTitle(baseName, candidate.Name ?? string.Empty))
-        {
-            score += 10.0;
-        }
-
-        // Community Rating: +(CommunityRating / 10.0)
         if (candidate.CommunityRating.HasValue)
         {
-            score += candidate.CommunityRating.Value / 10.0;
+            score += seed.CommunityRating.HasValue
+                ? RatingMaxPoints * Math.Max(0.0, 1.0 - (Math.Abs(candidate.CommunityRating.Value - seed.CommunityRating.Value) / 10.0))
+                : RatingMaxPoints * (candidate.CommunityRating.Value / 10.0);
+        }
+
+        if (seed.Keywords.Count > 0 && IsSequelOrSimilarTitle(seed.Keywords, candidate.Name))
+        {
+            score += TitleMatchPoints;
         }
 
         return score;
     }
 
-    private static List<string> ExtractKeyWords(string s)
+    private static double ScorePeople(IEnumerable<PersonInfo> people, SeedProfile seed)
     {
-        if (string.IsNullOrWhiteSpace(s)) return new List<string>();
-        var cleaned = Regex.Replace(s.ToLowerInvariant(), @"[^\w\s]", " ");
-        return cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Where(w => w.Length >= 4 && !StopWords.Contains(w))
-            .ToList();
+        var actors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var directors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var writers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        CollectPeople(people, actors, directors, writers);
+
+        return Math.Min(actors.Count(seed.Actors.Contains) * ActorPoints, ActorCap)
+            + Math.Min(directors.Count(seed.Directors.Contains) * DirectorPoints, DirectorCap)
+            + Math.Min(writers.Count(seed.Writers.Contains) * WriterPoints, WriterCap);
     }
 
-    private static bool IsSequelOrSimilarTitle(string titleA, string titleB)
+    private static int CountOverlap(IReadOnlyList<string>? values, HashSet<string> seedValues)
     {
-        var a = ExtractKeyWords(titleA);
-        var b = ExtractKeyWords(titleB);
-        if (a.Count == 0 || b.Count == 0) return false;
+        if (values == null || seedValues.Count == 0) return 0;
 
-        var setA = new HashSet<string>(a, StringComparer.OrdinalIgnoreCase);
-        var setB = new HashSet<string>(b, StringComparer.OrdinalIgnoreCase);
+        var matches = 0;
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (seedValues.Contains(values[i])) matches++;
+        }
 
-        // One title's keywords are completely contained in the other
-        if (setA.IsSubsetOf(setB) || setB.IsSubsetOf(setA)) return true;
+        return matches;
+    }
 
-        return false;
+    private static HashSet<string> ExtractKeyWords(string? title)
+    {
+        var keywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(title)) return keywords;
+
+        var cleaned = NonWordRegex.Replace(title.ToLowerInvariant(), " ");
+        foreach (var word in cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (word.Length >= 4 && !StopWords.Contains(word)) keywords.Add(word);
+        }
+
+        return keywords;
+    }
+
+    private static bool IsSequelOrSimilarTitle(HashSet<string> seedKeywords, string? candidateTitle)
+    {
+        var candidateKeywords = ExtractKeyWords(candidateTitle);
+        if (candidateKeywords.Count == 0) return false;
+
+        return seedKeywords.IsSubsetOf(candidateKeywords) || candidateKeywords.IsSubsetOf(seedKeywords);
     }
 
     /// <summary>
-    /// Sets OrderBy to (ItemSortBy.PremiereDate, SortOrder.Descending) via reflection
-    /// to avoid compile-time or runtime type mismatches between Jellyfin 10.x, 11.x, and 12.x.
+    /// The seed item's metadata, read once so scoring never touches it again per candidate.
     /// </summary>
-    private static void SetPremiereDateDescending(InternalItemsQuery query)
+    private sealed class SeedProfile
     {
-        try
+        public SeedProfile(BaseItem item, IReadOnlyList<PersonInfo> people)
         {
-            var orderByProp = typeof(InternalItemsQuery).GetProperty(nameof(InternalItemsQuery.OrderBy));
-            if (orderByProp == null) return;
+            Genres = new HashSet<string>(item.Genres ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            Tags = new HashSet<string>(item.Tags ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            Studios = new HashSet<string>(item.Studios ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            Year = item.ProductionYear;
+            CommunityRating = item.CommunityRating;
+            Keywords = ExtractKeyWords(item.Name);
 
-            var elementType = orderByProp.PropertyType.GetGenericArguments()[0];
-            var sortOrderType = elementType.GetGenericArguments()[1];
-            // SortOrder.Descending is enum value 1 (Ascending = 0, Descending = 1)
-            var descending = Enum.ToObject(sortOrderType, 1);
-
-            var tuple = Activator.CreateInstance(elementType, ItemSortBy.PremiereDate, descending);
-            var array = Array.CreateInstance(elementType, 1);
-            array.SetValue(tuple, 0);
-
-            orderByProp.SetValue(query, array);
+            Actors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            Directors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            Writers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            CollectPeople(people, Actors, Directors, Writers);
         }
-        catch
-        {
-            // Silently ignore if order cannot be set dynamically
-        }
+
+        public HashSet<string> Genres { get; }
+
+        public HashSet<string> Tags { get; }
+
+        public HashSet<string> Studios { get; }
+
+        public int? Year { get; }
+
+        public float? CommunityRating { get; }
+
+        public HashSet<string> Keywords { get; }
+
+        public HashSet<string> Actors { get; }
+
+        public HashSet<string> Directors { get; }
+
+        public HashSet<string> Writers { get; }
+
+        public bool HasPeople => Actors.Count > 0 || Directors.Count > 0 || Writers.Count > 0;
     }
 }

--- a/Jellyfin/tests/Moonfin.Server.Tests/FakeLibraryManager.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/FakeLibraryManager.cs
@@ -10,7 +10,8 @@ namespace Moonfin.Server.Tests;
 /// plugin host runs here, so <c>MoonfinPlugin.Instance</c> stays null and configuredIds is empty).
 /// Every other member of the (large, mostly server-internal) interface is stubbed to throw, since
 /// GamesService never reaches them from this path; a test that somehow does exercise one will fail
-/// loudly rather than silently returning bogus data.
+/// loudly rather than silently returning bogus data. The similar items tests opt two of those
+/// members back in by setting <see cref="ItemsResultHandler"/> and <see cref="PeopleHandler"/>.
 /// </summary>
 internal sealed class FakeLibraryManager : ILibraryManager
 {
@@ -22,6 +23,15 @@ internal sealed class FakeLibraryManager : ILibraryManager
         _folders = folders;
         _beforeGetVirtualFolders = beforeGetVirtualFolders;
     }
+
+    public FakeLibraryManager()
+        : this(new List<VirtualFolderInfo>())
+    {
+    }
+
+    internal Func<MediaBrowser.Controller.Entities.InternalItemsQuery, List<MediaBrowser.Controller.Entities.BaseItem>>? ItemsResultHandler { get; set; }
+
+    internal Func<MediaBrowser.Controller.Entities.BaseItem, List<MediaBrowser.Controller.Entities.PersonInfo>>? PeopleHandler { get; set; }
 
     List<VirtualFolderInfo> ILibraryManager.GetVirtualFolders()
     {
@@ -315,7 +325,8 @@ internal sealed class FakeLibraryManager : ILibraryManager
 
     System.Collections.Generic.List<MediaBrowser.Controller.Entities.PersonInfo> ILibraryManager.GetPeople(MediaBrowser.Controller.Entities.BaseItem item)
     {
-        throw new NotImplementedException();
+        if (PeopleHandler == null) throw new NotImplementedException();
+        return PeopleHandler(item);
     }
 
     System.Collections.Generic.List<MediaBrowser.Controller.Entities.PersonInfo> ILibraryManager.GetPeople(MediaBrowser.Controller.Entities.InternalPeopleQuery query)
@@ -380,7 +391,9 @@ internal sealed class FakeLibraryManager : ILibraryManager
 
     MediaBrowser.Model.Querying.QueryResult<MediaBrowser.Controller.Entities.BaseItem> ILibraryManager.GetItemsResult(MediaBrowser.Controller.Entities.InternalItemsQuery query)
     {
-        throw new NotImplementedException();
+        if (ItemsResultHandler == null) throw new NotImplementedException();
+        var items = ItemsResultHandler(query);
+        return new MediaBrowser.Model.Querying.QueryResult<MediaBrowser.Controller.Entities.BaseItem>(items);
     }
 
     System.Boolean ILibraryManager.IgnoreFile(MediaBrowser.Model.IO.FileSystemMetadata file, MediaBrowser.Controller.Entities.BaseItem parent)

--- a/Jellyfin/tests/Moonfin.Server.Tests/SimilarItemsScoringTests.cs
+++ b/Jellyfin/tests/Moonfin.Server.Tests/SimilarItemsScoringTests.cs
@@ -1,0 +1,263 @@
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moonfin.Server.Services;
+using Xunit;
+
+namespace Moonfin.Server.Tests;
+
+/// <summary>
+/// Covers the scoring and candidate selection in <see cref="MoonfinSimilarItemsService"/>. The
+/// service reaches the library through two ILibraryManager members only, so a fixture list plus
+/// a people lookup is enough to drive the whole pipeline.
+/// </summary>
+public class SimilarItemsScoringTests
+{
+    private static Movie MakeMovie(
+        string name,
+        string[]? genres = null,
+        string[]? tags = null,
+        string[]? studios = null,
+        int? year = null,
+        float? rating = null)
+    {
+        return new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Genres = genres ?? [],
+            Tags = tags ?? [],
+            Studios = studios ?? [],
+            ProductionYear = year,
+            CommunityRating = rating
+        };
+    }
+
+    private static (MoonfinSimilarItemsService Service, List<InternalItemsQuery> Queries) Build(
+        IEnumerable<BaseItem> catalog,
+        Func<BaseItem, List<PersonInfo>>? people = null)
+    {
+        var items = catalog.ToList();
+        var queries = new List<InternalItemsQuery>();
+        var library = new FakeLibraryManager
+        {
+            ItemsResultHandler = q =>
+            {
+                queries.Add(q);
+                return items;
+            },
+            PeopleHandler = people
+        };
+
+        return (new MoonfinSimilarItemsService(library, NullLogger<MoonfinSimilarItemsService>.Instance), queries);
+    }
+
+    private static Task<IReadOnlyList<BaseItem>> Run(
+        MoonfinSimilarItemsService service,
+        BaseItem seed,
+        int? limit = null,
+        IReadOnlyList<Guid>? exclude = null)
+    {
+        return service.GetSimilarItemsAsync(seed, null, limit, exclude, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SharedGenresOutrankUnrelatedItems()
+    {
+        var seed = MakeMovie("Seed", genres: ["Science Fiction", "Adventure"], year: 2020);
+        var match = MakeMovie("Match", genres: ["Science Fiction", "Adventure"], year: 2020);
+        var partial = MakeMovie("Partial", genres: ["Adventure"], year: 2020);
+        var unrelated = MakeMovie("Unrelated", genres: ["Romance"], year: 2020);
+
+        var (service, _) = Build([match, partial, unrelated]);
+        var results = await Run(service, seed);
+
+        Assert.Equal(["Match", "Partial", "Unrelated"], results.Select(r => r.Name));
+    }
+
+    [Fact]
+    public async Task GenreScoreIsCappedSoOneSpamEntryCannotDominate()
+    {
+        var shared = Enumerable.Range(0, 12).Select(i => $"Genre{i}").ToArray();
+        var seed = MakeMovie("Seed", genres: shared, year: 2000);
+
+        // Seven shared genres already reaches the cap, so the twelve genre entry can only match
+        // it, never beat it. The newer premiere date is what breaks the tie.
+        var capped = MakeMovie("Capped", genres: shared.Take(7).ToArray(), year: 2000);
+        capped.PremiereDate = new DateTime(2000, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var spammer = MakeMovie("Spammer", genres: shared, year: 2000);
+        spammer.PremiereDate = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var (service, _) = Build([capped, spammer]);
+        var results = await Run(service, seed);
+
+        Assert.Equal("Capped", results[0].Name);
+    }
+
+    [Fact]
+    public async Task CloserProductionYearsRankHigher()
+    {
+        var seed = MakeMovie("Seed", genres: ["Drama"], year: 2010);
+        var near = MakeMovie("Near", genres: ["Drama"], year: 2011);
+        var far = MakeMovie("Far", genres: ["Drama"], year: 1989);
+
+        var (service, _) = Build([far, near]);
+        var results = await Run(service, seed);
+
+        Assert.Equal("Near", results[0].Name);
+    }
+
+    [Fact]
+    public async Task SequelTitlesGetABonus()
+    {
+        var seed = MakeMovie("Blade Runner", genres: ["Science Fiction"], year: 1982);
+        var sequel = MakeMovie("Blade Runner 2049", genres: ["Science Fiction"], year: 1982);
+        var sibling = MakeMovie("Total Recall", genres: ["Science Fiction"], year: 1982);
+
+        var (service, _) = Build([sibling, sequel]);
+        var results = await Run(service, seed);
+
+        Assert.Equal("Blade Runner 2049", results[0].Name);
+    }
+
+    [Fact]
+    public async Task StopWordsAndShortWordsDoNotEarnATitleBonus()
+    {
+        var seed = MakeMovie("The Godfather", genres: ["Crime"], year: 1972);
+        var sequel = MakeMovie("Godfather Part II", genres: ["Crime"], year: 1972);
+        var sharesOnlyAStopWord = MakeMovie("The Notebook", genres: ["Crime"], year: 1972);
+
+        var (service, _) = Build([sharesOnlyAStopWord, sequel]);
+        var results = await Run(service, seed);
+
+        Assert.Equal(["Godfather Part II", "The Notebook"], results.Select(r => r.Name));
+    }
+
+    [Fact]
+    public async Task ATitlelessSeedDoesNotGiveEveryCandidateTheBonus()
+    {
+        // "the" is a stop word and "fly" is under the four character floor, so this seed has no
+        // keywords. An empty keyword set is a subset of everything, so without a guard every
+        // candidate would collect the title bonus and the ordering would collapse.
+        var seed = MakeMovie("The Fly", genres: ["Horror"], year: 1986);
+        var closerYear = MakeMovie("The Thing", genres: ["Horror"], year: 1986);
+        var fartherYear = MakeMovie("Videodrome", genres: ["Horror"], year: 1976);
+
+        var (service, _) = Build([fartherYear, closerYear]);
+        var results = await Run(service, seed);
+
+        Assert.Equal(["The Thing", "Videodrome"], results.Select(r => r.Name));
+    }
+
+    [Fact]
+    public async Task SharedStudiosAndCloseRatingsRankHigher()
+    {
+        var seed = MakeMovie("Seed", genres: ["Drama"], studios: ["A24"], year: 2015, rating: 8.0f);
+        var sameStudio = MakeMovie("SameStudio", genres: ["Drama"], studios: ["A24"], year: 2015, rating: 8.1f);
+        var closeRating = MakeMovie("CloseRating", genres: ["Drama"], studios: ["Other"], year: 2015, rating: 8.1f);
+        var farRating = MakeMovie("FarRating", genres: ["Drama"], studios: ["Other"], year: 2015, rating: 2.0f);
+
+        var (service, _) = Build([farRating, closeRating, sameStudio]);
+        var results = await Run(service, seed);
+
+        Assert.Equal(["SameStudio", "CloseRating", "FarRating"], results.Select(r => r.Name));
+    }
+
+    [Fact]
+    public async Task SharedCastAndCrewRaiseTheRanking()
+    {
+        var seed = MakeMovie("Seed", genres: ["Drama"], year: 2015);
+        var withDirector = MakeMovie("WithDirector", genres: ["Drama"], year: 2015);
+        var withoutDirector = MakeMovie("WithoutDirector", genres: ["Drama"], year: 2015);
+
+        var people = new Dictionary<Guid, List<PersonInfo>>
+        {
+            [seed.Id] = [new PersonInfo { Name = "Denis Villeneuve", Type = PersonKind.Director }],
+            [withDirector.Id] = [new PersonInfo { Name = "Denis Villeneuve", Type = PersonKind.Director }],
+            [withoutDirector.Id] = [new PersonInfo { Name = "Someone Else", Type = PersonKind.Director }]
+        };
+
+        var (service, _) = Build(
+            [withoutDirector, withDirector],
+            item => people.TryGetValue(item.Id, out var list) ? list : []);
+
+        var results = await Run(service, seed);
+
+        Assert.Equal("WithDirector", results[0].Name);
+    }
+
+    [Fact]
+    public async Task SeedAndExcludedItemsAreNeverReturned()
+    {
+        var seed = MakeMovie("Seed", genres: ["Drama"], year: 2015);
+        var excluded = MakeMovie("Excluded", genres: ["Drama"], year: 2015);
+        var kept = MakeMovie("Kept", genres: ["Drama"], year: 2015);
+
+        var (service, _) = Build([seed, excluded, kept]);
+        var results = await Run(service, seed, exclude: [excluded.Id]);
+
+        Assert.Equal(["Kept"], results.Select(r => r.Name));
+    }
+
+    [Fact]
+    public async Task CandidateQueriesAreBoundedAndOrdered()
+    {
+        var seed = MakeMovie("Seed", genres: ["Drama"], tags: ["gritty"], year: 2015);
+        var (service, queries) = Build([MakeMovie("Other", genres: ["Drama"], year: 2015)]);
+
+        await Run(service, seed);
+
+        Assert.NotEmpty(queries);
+        Assert.All(queries, q =>
+        {
+            Assert.True(q.Limit is > 0 and <= 400, $"Query limit was {q.Limit}.");
+            Assert.NotNull(q.OrderBy);
+            Assert.NotEmpty(q.OrderBy);
+            Assert.True(q.Recursive);
+            Assert.False(q.EnableTotalRecordCount);
+        });
+    }
+
+    [Fact]
+    public async Task LimitIsHonouredAndClamped()
+    {
+        var seed = MakeMovie("Seed", genres: ["Drama"], year: 2015);
+        var catalog = Enumerable.Range(0, 50)
+            .Select(i => MakeMovie($"Item{i}", genres: ["Drama"], year: 2015))
+            .Cast<BaseItem>()
+            .ToList();
+
+        var (service, _) = Build(catalog);
+
+        Assert.Equal(5, (await Run(service, seed, limit: 5)).Count);
+        Assert.Equal(20, (await Run(service, seed)).Count);
+        Assert.Equal(50, (await Run(service, seed, limit: 10_000)).Count);
+    }
+
+    [Fact]
+    public async Task UnsupportedItemTypesReturnNothingWithoutQueryingTheLibrary()
+    {
+        var seed = new Episode { Id = Guid.NewGuid(), Name = "Pilot" };
+        var (service, queries) = Build([MakeMovie("Other", genres: ["Drama"])]);
+
+        var results = await Run(service, seed);
+
+        Assert.Empty(results);
+        Assert.Empty(queries);
+    }
+
+    [Fact]
+    public async Task SeriesSeedsQueryForSeries()
+    {
+        var seed = new Series { Id = Guid.NewGuid(), Name = "Seed Show", Genres = ["Drama"], ProductionYear = 2015 };
+        var candidate = new Series { Id = Guid.NewGuid(), Name = "Other Show", Genres = ["Drama"], ProductionYear = 2015 };
+
+        var (service, queries) = Build([candidate]);
+        var results = await Run(service, seed);
+
+        Assert.Equal(["Other Show"], results.Select(r => r.Name));
+        Assert.All(queries, q => Assert.Equal([BaseItemKind.Series], q.IncludeItemTypes));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Implements native support for Jellyfin 12's new extensible recommendation provider backend (`ILocalSimilarItemsProvider`) in Moonbase. This enables Jellyfin 12 servers running Moonbase to register "Moonfin Recommends" directly into Jellyfin's similarity pipeline with built-in server-side 24-hour disk/memory caching (`SimilarItemsManager.TryReadSimilarItemsCacheAsync`).
Additionally, this PR provides:
1. Full library scoring on the server side (removing artificial candidate caps) for comprehensive recommendations across thousands of titles.
2. Support for `bypass=moonfin` query parameters, allowing Moonfin clients to selectively invoke Jellyfin's stock recommendation engine with a boosted candidate pool (5,000 items) so stock similarity does not starve from played/permission filtering.
3. A dedicated `GET /Moonfin/Items/{itemId}/Similar` endpoint and `recommendationsSupported` capability flag in `/Moonfin/Ping` for clean client auto-detection.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1456

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [X] Performance improvement
- [X] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [ ] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [X] Other / shared

## Changes Made
List the key changes included in this PR.

- **Dynamic ILocalSimilarItemsProvider Registration**: Implemented **MoonfinSimilarItemsProviderManager.cs** using runtime reflection and lightweight IL emitting (`TypeBuilder`). This dynamically defines and registers an `ILocalSimilarItemsProvider` implementation if running on Jellyfin 12 without hard compile-time dependencies that would break backwards compatibility on Jellyfin 10.x.
- **Server-Side 9-Factor Similarity Engine**: Implemented **MoonfinSimilarItemsService.cs** providing high-accuracy similarity scoring based on 9 weighted factors:
  - Shared genres (up to 35 pts)
  - Shared tags (up to 20 pts)
  - Shared actors (up to 18 pts)
  - Shared directors (up to 15 pts)
  - Shared writers (up to 8 pts)
  - Shared studios (up to 8 pts)
  - Production year proximity (decay formula within 5-15 years, up to 10 pts)
  - Community rating alignment (up to 5 pts)
  - Premiere date / recency fallback when candidate pool is sparse
- **Full Library Scoring**: Removed arbitrary candidate query limits (`Limit = 50`) on the server. Because Moonbase runs in-process with direct access to SQLite and Entity Framework Core indexes, candidate gathering across the entire library executes in milliseconds. The resulting scored list is cached by Jellyfin 12's `SimilarItemsManager` for 24 hours, making repeat queries instant (< 5 ms).
- **Stock Provider Delegation with Candidate Scaling**: Captured registered stock similarity providers at startup in **MoonfinSimilarItemsProviderManager.cs**. When a client requests `bypass=moonfin`, Moonbase directly delegates to stock Jellyfin providers while boosting the internal candidate query limit to 5,000, preventing Jellyfin's stock `Take(limit)` from prematurely starving candidate pools in libraries where users have already watched many matching titles.
- **Dedicated Endpoint and Capability Announcement**: Added `GET /Moonfin/Items/{itemId}/Similar` in **MoonfinController.cs** and announced `recommendationsSupported = true` in `/Moonfin/Ping` via **PluginServiceRegistrator.cs**.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1456
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Windows Desktop, Android TV
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built **Moonfin.Server.dll** and deployed to Jellyfin 12.0.0 container on Synology NAS.
2. Verified Jellyfin startup logs confirm registration of "Moonfin Recommends" as `ILocalSimilarItemsProvider`.
3. Tested `GET /Moonfin/Items/{id}/Similar` directly to verify 9-factor scored output for movies and series.
4. Tested `GET /Items/{id}/Similar?bypass=moonfin` to verify clean delegation to stock Jellyfin similarity.
5. Tested candidate limits from 30 to 5,000 on large library items to ensure candidate pools do not starve.
6. Ran Moonfin-Core client (`mfdbW -q`) and verified all recommendation sources ("Moonfin Recommends", "Jellyfin Recommends", "TMDb Similarity") render distinct, full lists on both Home screen rows and Details pages.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

### Moonfin Recommends as Vanilla Search Provider!
<img width="1592" height="306" alt="2026-09-08_11-11-24_brave" src="https://github.com/user-attachments/assets/0025585d-b886-4302-a19d-bf031871526b" />
<img width="1505" height="325" alt="2026-09-08_11-11-04_brave" src="https://github.com/user-attachments/assets/a736dd6b-4a23-48d5-80b7-fee9f93659b3" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
