### PR TITLE
feat-homescreen - Add ModernCardsOnMyMediaRow setting support to Moonbase

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -64,6 +64,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("backdropEnabled")] public bool? BackdropEnabled { get; set; }
         [JsonPropertyName("homeRowsImageTypeOverride")] public bool? HomeRowsImageTypeOverride { get; set; }
         [JsonPropertyName("homeRowsStyle")] public string? HomeRowsStyle { get; set; }
+        [JsonPropertyName("modernCardsOnMyMediaRow")] public bool? ModernCardsOnMyMediaRow { get; set; }
         [JsonPropertyName("modernHomeRowsPadding")] public int? ModernHomeRowsPadding { get; set; }
         [JsonPropertyName("classicHomeRowsPadding")] public int? ClassicHomeRowsPadding { get; set; }
         [JsonPropertyName("fullScreenRows")] public bool? FullScreenRows { get; set; }

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1266,6 +1266,15 @@
                                 </select>
                             </div>
                             <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultModernCardsOnMyMediaRow">Modern cards on My Media row</label>
+                                <select id="DefaultModernCardsOnMyMediaRow" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Display customizable posters that expand on focus. Disable to always show landscape thumbnail.</div>
+                            </div>
+                            <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultMergeContinueWatchingNextUp">Merge Continue Watching and Next Up</label>
                                 <select id="DefaultMergeContinueWatchingNextUp" is="emby-select">
                                     <option value="">Not set (user decides)</option>

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1896,6 +1896,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setNullableBoolSelect(view, '#DefaultCinemaModeEpisodesEnabled', defaults.cinemaModeEpisodesEnabled);
 
             setSelectValue(view, '#DefaultHomeRowsStyle', defaults.homeRowsStyle, 'Configured style');
+            setNullableBoolSelect(view, '#DefaultModernCardsOnMyMediaRow', defaults.modernCardsOnMyMediaRow);
             setNullableBoolSelect(view, '#DefaultFullScreenRows', defaults.fullScreenRows);
             setNullableBoolSelect(view, '#DefaultHomeRowInfoOverlay', defaults.homeRowInfoOverlay);
             bindNullableRangeInput(view, '#DefaultClassicHomeRowsPadding', 'px');
@@ -2167,6 +2168,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             }
 
             d.homeRowsStyle = view.querySelector('#DefaultHomeRowsStyle').value || null;
+            d.modernCardsOnMyMediaRow = getNullableBoolSelect(view, '#DefaultModernCardsOnMyMediaRow');
             d.fullScreenRows = getNullableBoolSelect(view, '#DefaultFullScreenRows');
             d.homeRowInfoOverlay = getNullableBoolSelect(view, '#DefaultHomeRowInfoOverlay');
             d.classicHomeRowsPadding = getNullableRangeInput(view, '#DefaultClassicHomeRowsPadding');

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -197,6 +197,9 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("homeRowsStyle")]
     public string? HomeRowsStyle { get; set; }
 
+    [JsonPropertyName("modernCardsOnMyMediaRow")]
+    public bool? ModernCardsOnMyMediaRow { get; set; }
+
     [JsonPropertyName("modernHomeRowsPadding")]
     public int? ModernHomeRowsPadding { get; set; }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1152,6 +1152,15 @@
                                 </select>
                             </div>
                             <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultModernCardsOnMyMediaRow">Modern cards on My Media row</label>
+                                <select id="DefaultModernCardsOnMyMediaRow" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                                <div class="fieldDescription">Display customizable posters that expand on focus. Disable to always show landscape thumbnail.</div>
+                            </div>
+                            <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultMergeContinueWatchingNextUp">Merge Continue Watching and Next Up</label>
                                 <select id="DefaultMergeContinueWatchingNextUp" is="emby-select">
                                     <option value="">Not set (user decides)</option>
@@ -5382,6 +5391,7 @@
                     setSelectValue('#DefaultSeasonalSurprise', defaults.seasonalSurprise, 'Configured surprise');
 
                     setSelectValue('#DefaultHomeRowsStyle', defaults.homeRowsStyle, 'Configured style');
+                    setNullableBoolSelect('#DefaultModernCardsOnMyMediaRow', defaults.modernCardsOnMyMediaRow);
                     setNullableBoolSelect('#DefaultFullScreenRows', defaults.fullScreenRows);
                     setNullableBoolSelect('#DefaultHomeRowInfoOverlay', defaults.homeRowInfoOverlay);
                     bindNullableRangeInput('#DefaultClassicHomeRowsPadding', 'px');
@@ -5904,6 +5914,7 @@
 
 
                         config.DefaultUserSettings.homeRowsStyle = document.querySelector('#DefaultHomeRowsStyle').value || null;
+                        config.DefaultUserSettings.modernCardsOnMyMediaRow = getNullableBoolSelect('#DefaultModernCardsOnMyMediaRow');
                         config.DefaultUserSettings.fullScreenRows = getNullableBoolSelect('#DefaultFullScreenRows');
                         config.DefaultUserSettings.homeRowInfoOverlay = getNullableBoolSelect('#DefaultHomeRowInfoOverlay');
                         config.DefaultUserSettings.classicHomeRowsPadding = getNullableRangeInput('#DefaultClassicHomeRowsPadding');


### PR DESCRIPTION
# Pull Request

## Summary
Adds support for the new `modernCardsOnMyMediaRow` user preference across Moonbase DTO profiles, admin User Defaults UI, and settings synchronization for Jellyfin and Emby plugins.

## Related Issues
Link related issues or tickets separated by commas.

- Closes # https://github.com/Moonfin-Client/Moonfin-Core/issues/354
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1462 (Core)
- Related to # https://github.com/Moonfin-Client/Smart-TV/pull/409 (Smart-TV)
- Related to # https://github.com/Moonfin-Client/Roku/pull/263 (Roku)

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added `ModernCardsOnMyMediaRow` (`bool?`) to **MoonfinSettingsProfile.cs** for both Jellyfin and Emby plugins.
- Added "Modern cards on My Media row" dropdown selector and descriptive helper text to **configPage.html** under Default User Settings.
- Bound `modernCardsOnMyMediaRow` in **moonfin.js** for profile load and save routines.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here:
    - https://github.com/Moonfin-Client/Moonfin-Core/pull/1462 (Core)
    - https://github.com/Moonfin-Client/Smart-TV/pull/409 (Smart-TV)
    - https://github.com/Moonfin-Client/Roku/pull/263 (Roku)
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `modernCardsOnMyMediaRow` (boolean)
 
## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Windows Desktop (core), Android TV (core), Smart-TV (webOS emulator)
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built release DLL and deployed to server.
2. Verified in Jellyfin Admin settings that default dropdown displays with choices "Not set", "Yes", and "No".
3. Toggled setting and verified round-trip saving and persistence.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

<img width="2350" height="1206" alt="2026-09-08_20-30-15_brave" src="https://github.com/user-attachments/assets/b55d0f97-b527-4cf4-9573-46ed57685e46" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
