### PR TITLE
Round-trip Seerr discover sliders in homeSections

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -349,5 +349,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("pluginSection")] public string? PluginSection { get; set; }
         [JsonPropertyName("pluginAdditionalData")] public string? PluginAdditionalData { get; set; }
         [JsonPropertyName("pluginDisplayText")] public string? PluginDisplayText { get; set; }
+        [JsonPropertyName("sliderId")] public string? SliderId { get; set; }
+        [JsonPropertyName("sliderType")] public int? SliderType { get; set; }
     }
 }

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1102,24 +1102,51 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { id: 'seerr', label: 'Seerr' }
     ];
 
-    var HOME_LAYOUT_SEERR_TYPES = {
-        seerr_shortcuts: true,
-        seerr_recent_requests: true,
-        seerr_recently_added: true,
-        seerr_popular_movies: true,
-        seerr_upcoming_movies: true,
-        seerr_popular_series: true,
-        seerr_upcoming_series: true,
-        seerr_trending: true,
-        seerr_movie_genres: true,
-        seerr_studios: true,
-        seerr_series_genres: true,
-        seerr_networks: true,
-        seerr_watchlist: true
-    };
-
     function isSeerrHomeSectionType(type) {
-        return !!HOME_LAYOUT_SEERR_TYPES[type];
+        return !!(type && type.indexOf('seerr_') === 0);
+    }
+
+    function isSeerrSliderSection(section) {
+        return !!section && (section.kind === 'seerrSlider' ||
+            (section.kind === 'pluginDynamic' && section.pluginSource === 'seerr') ||
+            section.type === 'seerr_slider');
+    }
+
+    function seerrSliderIdOf(section) {
+        if (!section) return '';
+        if (section.sliderId) return String(section.sliderId);
+        if (section.pluginAdditionalData) return String(section.pluginAdditionalData);
+        return '';
+    }
+
+    function seerrSliderTypeOf(section) {
+        if (!section || section.sliderType == null || section.sliderType === '') return null;
+        var n = Number(section.sliderType);
+        return Number.isFinite(n) ? n : null;
+    }
+
+    function seerrSliderLiveTitle(view, section) {
+        var state = getHomeLayoutState(view);
+        var sliders = state.seerrDiscoverSliders || [];
+        var id = seerrSliderIdOf(section);
+        for (var i = 0; i < sliders.length; i++) {
+            if (String(sliders[i].id) !== id) continue;
+            return (sliders[i].title || '').trim();
+        }
+        return (section.pluginDisplayText || '').trim();
+    }
+
+    function seerrSliderLabel(slider) {
+        var title = (slider && slider.title ? String(slider.title) : '').trim();
+        return title || 'Seerr slider';
+    }
+
+    function isSeerrCustomSliderType(type) {
+        var n = Number(type);
+        if (!Number.isFinite(n)) return false;
+        if (n >= 1 && n <= 12) return false;
+        if (n >= 38 && n <= 43) return false;
+        return n > 12;
     }
 
     function getHomeLayoutState(view) {
@@ -1139,8 +1166,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         return HOME_SECTION_DEFINITIONS.find(function (row) { return row.type === type; }) || null;
     }
 
-    function homeSectionLabel(section) {
+    function homeSectionLabel(view, section) {
         if (!section) return 'Unknown row';
+        if (isSeerrSliderSection(section)) {
+            return seerrSliderLiveTitle(view, section) ||
+                section.pluginDisplayText ||
+                'Seerr slider';
+        }
         if (section.kind === 'pluginDynamic') {
             return section.pluginDisplayText || section.pluginSection || 'Dynamic row';
         }
@@ -1150,8 +1182,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function homeSectionMeta(section) {
         if (!section) return 'Basics';
+        if (isSeerrSliderSection(section) || isSeerrHomeSectionType(section.type)) return 'Seerr';
         if (section.kind !== 'pluginDynamic') {
-            return isSeerrHomeSectionType(section.type) ? 'Seerr' : 'Basics';
+            return 'Basics';
         }
         if (section.pluginSource === 'collections') return 'Collection';
         if (section.pluginSource === 'playlists') return 'Playlist';
@@ -1161,8 +1194,10 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     }
 
     function homeSectionBadgeClass(section) {
+        if (isSeerrSliderSection(section) || (section && isSeerrHomeSectionType(section.type))) {
+            return 'homeLayoutBadge-seerr';
+        }
         if (!section || section.kind !== 'pluginDynamic') {
-            if (section && isSeerrHomeSectionType(section.type)) return 'homeLayoutBadge-seerr';
             return 'homeLayoutBadge-builtin';
         }
         if (section.pluginSource === 'collections') return 'homeLayoutBadge-collections';
@@ -1173,6 +1208,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function homeSectionKey(section) {
         if (!section) return '';
+        if (isSeerrSliderSection(section)) {
+            return 'seerrSlider:' + seerrSliderIdOf(section);
+        }
         if (section.kind === 'pluginDynamic') {
             return [
                 'pluginDynamic',
@@ -1202,7 +1240,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function renumberHomeLayoutSections(state) {
         state.sections.forEach(function (section, index) {
-            section.enabled = true;
+            if (section.kind !== 'pluginDynamic' && section.kind !== 'seerrSlider') {
+                section.enabled = true;
+            }
             section.order = index;
         });
     }
@@ -1234,7 +1274,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         }).forEach(function (section) {
             if (!section) return;
             var normalized;
-            if (section.kind === 'pluginDynamic') {
+            if (isSeerrSliderSection(section)) {
+                var sliderId = seerrSliderIdOf(section);
+                if (!sliderId) return;
+                var sliderType = seerrSliderTypeOf(section);
+                normalized = {
+                    kind: 'seerrSlider',
+                    type: 'seerr_slider',
+                    enabled: section.enabled !== false,
+                    order: ordered.length,
+                    sliderId: sliderId
+                };
+                if (sliderType != null) normalized.sliderType = sliderType;
+                if (section.pluginDisplayText) {
+                    normalized.pluginDisplayText = section.pluginDisplayText;
+                }
+            } else if (section.kind === 'pluginDynamic') {
                 normalized = {
                     kind: 'pluginDynamic',
                     type: 'none',
@@ -1283,6 +1338,29 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         };
     }
 
+    function createSeerrSliderCandidate(slider) {
+        var sliderId = String(slider.id);
+        var label = seerrSliderLabel(slider);
+        var candidate = {
+            key: 'seerrSlider:' + sliderId,
+            tab: 'seerr',
+            label: label,
+            meta: 'Seerr',
+            badgeClass: 'homeLayoutBadge-seerr',
+            section: {
+                kind: 'seerrSlider',
+                type: 'seerr_slider',
+                enabled: true,
+                order: 0,
+                sliderId: sliderId,
+                pluginDisplayText: label
+            }
+        };
+        var sliderType = Number(slider.type);
+        if (Number.isFinite(sliderType)) candidate.section.sliderType = sliderType;
+        return candidate;
+    }
+
     function createDynamicCandidate(tab, source, sectionName, id, label, meta, serverId) {
         return {
             key: ['pluginDynamic', source, sectionName, id || ''].join(':'),
@@ -1309,7 +1387,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             .filter(function (definition) { return !isSeerrHomeSectionType(definition.type); })
             .map(createBuiltinCandidate);
         state.available.seerr = HOME_SECTION_DEFINITIONS
-            .filter(function (definition) { return isSeerrHomeSectionType(definition.type); })
+            .filter(function (definition) {
+                return isSeerrHomeSectionType(definition.type);
+            })
             .map(createBuiltinCandidate);
     }
 
@@ -1393,7 +1473,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             row.dataset.index = String(index);
             row.innerHTML =
                 '<div class="homeLayoutRowText">' +
-                '<div class="homeLayoutRowTitle">' + esc(homeSectionLabel(section)) + '</div>' +
+                '<div class="homeLayoutRowTitle">' + esc(homeSectionLabel(view, section)) + '</div>' +
                 '<span class="homeLayoutBadge ' + homeSectionBadgeClass(section) + '">' + esc(homeSectionMeta(section)) + '</span>' +
                 '</div>' +
                 '<button type="button" class="homeLayoutIconButton" data-action="up" title="Move up"' + (index === 0 ? ' disabled' : '') + '>&#x2191;</button>' +
@@ -1534,6 +1614,39 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         loadHomeLayoutCollections(view);
         loadHomeLayoutPlaylists(view);
         loadHomeLayoutGenres(view);
+        loadHomeLayoutSeerrSliders(view);
+    }
+
+    function seerrBuiltinCandidates() {
+        return HOME_SECTION_DEFINITIONS
+            .filter(function (definition) {
+                return isSeerrHomeSectionType(definition.type);
+            })
+            .map(createBuiltinCandidate);
+    }
+
+    function loadHomeLayoutSeerrSliders(view) {
+        var serverId = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+        fetch(serverId + '/Moonfin/Seerr/Api/settings/discover', {
+            method: 'GET',
+            headers: moonfinAuthHeaders()
+        }).then(function (response) {
+            if (!response.ok) return [];
+            return response.json();
+        }).then(function (data) {
+            var sliders = Array.isArray(data) ? data : [];
+            var state = getHomeLayoutState(view);
+            state.seerrDiscoverSliders = sliders;
+            var candidates = sliders.filter(function (slider) {
+                if (!slider || slider.enabled === false || !slider.id) return false;
+                return isSeerrCustomSliderType(slider.type);
+            }).map(createSeerrSliderCandidate);
+            setHomeLayoutAvailable(view, 'seerr', seerrBuiltinCandidates().concat(candidates));
+            renderHomeSectionsEditor(view);
+        }).catch(function () {
+            getHomeLayoutState(view).seerrDiscoverSliders = [];
+            setHomeLayoutAvailable(view, 'seerr', seerrBuiltinCandidates());
+        });
     }
 
     function setHomeLayoutAvailable(view, tab, candidates) {
@@ -1635,15 +1748,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         if (state.sections.length === 0) return null;
         renumberHomeLayoutSections(state);
         return state.sections.map(function (section) {
+            var isSlider = section.kind === 'seerrSlider';
             var isDynamic = section.kind === 'pluginDynamic';
             var result = {
-                type: isDynamic ? 'none' : section.type,
+                type: isSlider ? (section.type || 'seerr_slider') : (isDynamic ? 'none' : section.type),
                 // Dynamic rows stay in the editor when disabled, unlike builtins, so writing
                 // them all back as enabled would switch every custom row on.
-                enabled: isDynamic ? section.enabled !== false : true,
+                enabled: (isDynamic || isSlider) ? section.enabled !== false : true,
                 order: section.order
             };
-            if (isDynamic) {
+            if (isSlider) {
+                result.kind = 'seerrSlider';
+                result.type = 'seerr_slider';
+                result.sliderId = section.sliderId;
+                if (section.sliderType != null) result.sliderType = section.sliderType;
+                if (section.pluginDisplayText) result.pluginDisplayText = section.pluginDisplayText;
+            } else if (isDynamic) {
                 result.kind = 'pluginDynamic';
                 result.pluginSource = section.pluginSource || 'hss';
                 // Custom rows have no server of their own and the client keys them on this,

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1141,7 +1141,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         return title || 'Seerr slider';
     }
 
-    function isSeerrCustomSliderType(type) {
+    function isSeerrSliderType(type) {
         var n = Number(type);
         if (!Number.isFinite(n)) return false;
         if (n >= 1 && n <= 12) return false;
@@ -1639,7 +1639,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             state.seerrDiscoverSliders = sliders;
             var candidates = sliders.filter(function (slider) {
                 if (!slider || slider.enabled === false || !slider.id) return false;
-                return isSeerrCustomSliderType(slider.type);
+                return isSeerrSliderType(slider.type);
             }).map(createSeerrSliderCandidate);
             setHomeLayoutAvailable(view, 'seerr', seerrBuiltinCandidates().concat(candidates));
             renderHomeSectionsEditor(view);

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -212,10 +212,13 @@ namespace Emby.Plugins.Moonfin.Services
             if (profile.HomeSections == null) return null;
 
             var homeRowOrder = profile.HomeSections
-                .Where(section => !string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase))
+                .Where(section =>
+                    string.IsNullOrEmpty(section.Kind) ||
+                    string.Equals(section.Kind, "builtin", StringComparison.OrdinalIgnoreCase))
                 .Where(section => section.Enabled != false)
                 .Where(section => !string.IsNullOrWhiteSpace(section.Type) &&
-                    !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(section.Type, "seerr_slider", StringComparison.OrdinalIgnoreCase))
                 .OrderBy(section => section.Order ?? int.MaxValue)
                 .Select(section => section.Type!)
                 .ToList();

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -973,4 +973,10 @@ public class MoonfinHomeSectionConfig
 
     [JsonPropertyName("pluginDisplayText")]
     public string? PluginDisplayText { get; set; }
+
+    [JsonPropertyName("sliderId")]
+    public string? SliderId { get; set; }
+
+    [JsonPropertyName("sliderType")]
+    public int? SliderType { get; set; }
 }

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -4009,24 +4009,6 @@
                 { id: 'external', label: 'External Lists' }
             ];
 
-            var HOME_LAYOUT_SEERR_TYPES = {
-                seerr_shortcuts: true,
-                seerr_recent_requests: true,
-                seerr_recently_added: true,
-                seerr_popular_movies: true,
-                seerr_upcoming_movies: true,
-                seerr_popular_series: true,
-                seerr_upcoming_series: true,
-                seerr_trending: true,
-                seerr_movie_genres: true,
-                seerr_studios: true,
-                seerr_series_genres: true,
-                seerr_networks: true,
-                seerr_watchlist: true,
-                radarr_calendar: true,
-                sonarr_calendar: true
-            };
-
             var HOME_LAYOUT_EXTERNAL_LISTS = {
                 imdb_top_250_movies: true,
                 imdb_top_250_tv_shows: true,
@@ -4050,7 +4032,51 @@
             };
 
             function isSeerrHomeSectionType(type) {
-                return !!HOME_LAYOUT_SEERR_TYPES[type];
+                return (type && type.indexOf('seerr_') === 0) ||
+                    type === 'radarr_calendar' ||
+                    type === 'sonarr_calendar';
+            }
+
+            function isSeerrSliderSection(section) {
+                return !!section && (section.kind === 'seerrSlider' ||
+                    (section.kind === 'pluginDynamic' && section.pluginSource === 'seerr') ||
+                    section.type === 'seerr_slider');
+            }
+
+            function seerrSliderIdOf(section) {
+                if (!section) return '';
+                if (section.sliderId) return String(section.sliderId);
+                if (section.pluginAdditionalData) return String(section.pluginAdditionalData);
+                return '';
+            }
+
+            function seerrSliderTypeOf(section) {
+                if (!section || section.sliderType == null || section.sliderType === '') return null;
+                var n = Number(section.sliderType);
+                return Number.isFinite(n) ? n : null;
+            }
+
+            function seerrSliderLiveTitle(section) {
+                var sliders = HOME_LAYOUT_STATE.seerrDiscoverSliders || [];
+                var id = seerrSliderIdOf(section);
+                for (var i = 0; i < sliders.length; i++) {
+                    if (String(sliders[i].id) !== id) continue;
+                    return (sliders[i].title || '').trim();
+                }
+                return (section.pluginDisplayText || '').trim();
+            }
+
+            function seerrSliderLabel(slider) {
+                var title = (slider && slider.title ? String(slider.title) : '').trim();
+                return title || 'Seerr slider';
+            }
+
+            function isSeerrCustomSliderType(type) {
+                var n = Number(type);
+                if (!Number.isFinite(n)) return false;
+                if (n >= 1 && n <= 12) return false;
+                if (n >= 38 && n <= 43) return false;
+                return n > 12;
             }
 
             function isExternalHomeSectionType(type) {
@@ -4086,6 +4112,11 @@
 
             function homeSectionLabel(section) {
                 if (!section) return 'Unknown row';
+                if (isSeerrSliderSection(section)) {
+                    return seerrSliderLiveTitle(section) ||
+                        section.pluginDisplayText ||
+                        'Seerr slider';
+                }
                 if (section.kind === 'pluginDynamic') {
                     return section.pluginDisplayText || section.pluginSection || 'Dynamic row';
                 }
@@ -4095,8 +4126,9 @@
 
             function homeSectionMeta(section) {
                 if (!section) return 'Basics';
+                if (isSeerrSliderSection(section) || isSeerrHomeSectionType(section.type)) return 'Seerr';
                 if (section.kind !== 'pluginDynamic') {
-                    return isSeerrHomeSectionType(section.type) ? 'Seerr' : (isExternalHomeSectionType(section.type) ? 'External Lists' : 'Basics');
+                    return isExternalHomeSectionType(section.type) ? 'External Lists' : 'Basics';
                 }
                 if (section.pluginSource === 'collections') return 'Collection';
                 if (section.pluginSource === 'playlists') return 'Playlist';
@@ -4105,8 +4137,10 @@
             }
 
             function homeSectionBadgeClass(section) {
+                if (isSeerrSliderSection(section) || (section && isSeerrHomeSectionType(section.type))) {
+                    return 'homeLayoutBadge-seerr';
+                }
                 if (!section || section.kind !== 'pluginDynamic') {
-                    if (section && isSeerrHomeSectionType(section.type)) return 'homeLayoutBadge-seerr';
                     if (section && isExternalHomeSectionType(section.type)) return 'homeLayoutBadge-external';
                     return 'homeLayoutBadge-builtin';
                 }
@@ -4118,6 +4152,9 @@
 
             function homeSectionKey(section) {
                 if (!section) return '';
+                if (isSeerrSliderSection(section)) {
+                    return 'seerrSlider:' + seerrSliderIdOf(section);
+                }
                 if (section.kind === 'pluginDynamic') {
                     return [
                         'pluginDynamic',
@@ -4147,7 +4184,9 @@
 
             function renumberHomeLayoutSections() {
                 HOME_LAYOUT_STATE.sections.forEach(function(section, index) {
-                    section.enabled = true;
+                    if (section.kind !== 'pluginDynamic' && section.kind !== 'seerrSlider') {
+                        section.enabled = true;
+                    }
                     section.order = index;
                 });
             }
@@ -4179,7 +4218,22 @@
                 }).forEach(function(section) {
                     if (!section) return;
                     var normalized;
-                    if (section.kind === 'pluginDynamic') {
+                    if (isSeerrSliderSection(section)) {
+                        var sliderId = seerrSliderIdOf(section);
+                        if (!sliderId) return;
+                        var sliderType = seerrSliderTypeOf(section);
+                        normalized = {
+                            kind: 'seerrSlider',
+                            type: 'seerr_slider',
+                            enabled: section.enabled !== false,
+                            order: ordered.length,
+                            sliderId: sliderId
+                        };
+                        if (sliderType != null) normalized.sliderType = sliderType;
+                        if (section.pluginDisplayText) {
+                            normalized.pluginDisplayText = section.pluginDisplayText;
+                        }
+                    } else if (section.kind === 'pluginDynamic') {
                         normalized = {
                             kind: 'pluginDynamic',
                             type: 'none',
@@ -4228,6 +4282,29 @@
                 };
             }
 
+            function createSeerrSliderCandidate(slider) {
+                var sliderId = String(slider.id);
+                var label = seerrSliderLabel(slider);
+                var candidate = {
+                    key: 'seerrSlider:' + sliderId,
+                    tab: 'seerr',
+                    label: label,
+                    meta: 'Seerr',
+                    badgeClass: 'homeLayoutBadge-seerr',
+                    section: {
+                        kind: 'seerrSlider',
+                        type: 'seerr_slider',
+                        enabled: true,
+                        order: 0,
+                        sliderId: sliderId,
+                        pluginDisplayText: label
+                    }
+                };
+                var sliderType = Number(slider.type);
+                if (Number.isFinite(sliderType)) candidate.section.sliderType = sliderType;
+                return candidate;
+            }
+
             function createDynamicCandidate(tab, source, sectionName, id, label, meta, serverId) {
                 return {
                     key: ['pluginDynamic', source, sectionName, id || ''].join(':'),
@@ -4254,7 +4331,9 @@
                     .filter(function(definition) { return (!isSeerrHomeSectionType(definition.type) && !isExternalHomeSectionType(definition.type)); })
                     .map(createBuiltinCandidate);
                 HOME_LAYOUT_STATE.available.seerr = HOME_SECTION_DEFINITIONS
-                    .filter(function(definition) { return isSeerrHomeSectionType(definition.type); })
+                    .filter(function(definition) {
+                        return isSeerrHomeSectionType(definition.type);
+                    })
                     .map(createBuiltinCandidate);
                 HOME_LAYOUT_STATE.available.external = HOME_SECTION_DEFINITIONS
                     .filter(function(definition) { return isExternalHomeSectionType(definition.type); })
@@ -4482,6 +4561,38 @@
                 loadHomeLayoutCollections();
                 loadHomeLayoutPlaylists();
                 loadHomeLayoutGenres();
+                loadHomeLayoutSeerrSliders();
+            }
+
+            function seerrBuiltinCandidates() {
+                return HOME_SECTION_DEFINITIONS
+                    .filter(function(definition) {
+                        return isSeerrHomeSectionType(definition.type);
+                    })
+                    .map(createBuiltinCandidate);
+            }
+
+            function loadHomeLayoutSeerrSliders() {
+                var serverId = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+                fetch(serverId + '/Moonfin/Seerr/Api/settings/discover', {
+                    method: 'GET',
+                    headers: getMoonfinAuthHeaders()
+                }).then(function(response) {
+                    if (!response.ok) return [];
+                    return response.json();
+                }).then(function(data) {
+                    var sliders = Array.isArray(data) ? data : [];
+                    HOME_LAYOUT_STATE.seerrDiscoverSliders = sliders;
+                    var candidates = sliders.filter(function(slider) {
+                        if (!slider || slider.enabled === false || !slider.id) return false;
+                        return isSeerrCustomSliderType(slider.type);
+                    }).map(createSeerrSliderCandidate);
+                    setHomeLayoutAvailable('seerr', seerrBuiltinCandidates().concat(candidates));
+                    renderHomeSectionsEditor();
+                }).catch(function() {
+                    HOME_LAYOUT_STATE.seerrDiscoverSliders = [];
+                    setHomeLayoutAvailable('seerr', seerrBuiltinCandidates());
+                });
             }
 
             function setHomeLayoutAvailable(tab, candidates) {
@@ -4581,15 +4692,22 @@
                 if (HOME_LAYOUT_STATE.sections.length === 0) return null;
                 renumberHomeLayoutSections();
                 return HOME_LAYOUT_STATE.sections.map(function(section) {
+                    var isSlider = section.kind === 'seerrSlider';
                     var isDynamic = section.kind === 'pluginDynamic';
                     var result = {
-                        type: isDynamic ? 'none' : section.type,
+                        type: isSlider ? (section.type || 'seerr_slider') : (isDynamic ? 'none' : section.type),
                         // Dynamic rows stay in the editor when disabled, unlike builtins, so
                         // writing them all back as enabled would switch every custom row on.
-                        enabled: isDynamic ? section.enabled !== false : true,
+                        enabled: (isDynamic || isSlider) ? section.enabled !== false : true,
                         order: section.order
                     };
-                    if (isDynamic) {
+                    if (isSlider) {
+                        result.kind = 'seerrSlider';
+                        result.type = 'seerr_slider';
+                        result.sliderId = section.sliderId;
+                        if (section.sliderType != null) result.sliderType = section.sliderType;
+                        if (section.pluginDisplayText) result.pluginDisplayText = section.pluginDisplayText;
+                    } else if (isDynamic) {
                         result.kind = 'pluginDynamic';
                         result.pluginSource = section.pluginSource;
                         // Custom rows have no server of their own and the client keys them on

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -4032,9 +4032,7 @@
             };
 
             function isSeerrHomeSectionType(type) {
-                return (type && type.indexOf('seerr_') === 0) ||
-                    type === 'radarr_calendar' ||
-                    type === 'sonarr_calendar';
+                return !!(type && type.indexOf('seerr_') === 0);
             }
 
             function isSeerrSliderSection(section) {
@@ -4071,7 +4069,7 @@
                 return title || 'Seerr slider';
             }
 
-            function isSeerrCustomSliderType(type) {
+            function isSeerrSliderType(type) {
                 var n = Number(type);
                 if (!Number.isFinite(n)) return false;
                 if (n >= 1 && n <= 12) return false;
@@ -4585,7 +4583,7 @@
                     HOME_LAYOUT_STATE.seerrDiscoverSliders = sliders;
                     var candidates = sliders.filter(function(slider) {
                         if (!slider || slider.enabled === false || !slider.id) return false;
-                        return isSeerrCustomSliderType(slider.type);
+                        return isSeerrSliderType(slider.type);
                     }).map(createSeerrSliderCandidate);
                     setHomeLayoutAvailable('seerr', seerrBuiltinCandidates().concat(candidates));
                     renderHomeSectionsEditor();

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -251,10 +251,13 @@ public class MoonfinSettingsService
         }
 
         var homeRowOrder = profile.HomeSections
-            .Where(section => !string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase))
+            .Where(section =>
+                string.IsNullOrEmpty(section.Kind) ||
+                string.Equals(section.Kind, "builtin", StringComparison.OrdinalIgnoreCase))
             .Where(section => section.Enabled != false)
             .Where(section => !string.IsNullOrWhiteSpace(section.Type) &&
-                !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(section.Type, "seerr_slider", StringComparison.OrdinalIgnoreCase))
             .OrderBy(section => section.Order ?? int.MaxValue)
             .Select(section => section.Type!)
             .ToList();


### PR DESCRIPTION
# Pull Request

## Summary
Persist Foreseerr/Seerr discover sliders in `homeSections` as `kind: seerrSlider` (with `sliderId` / `sliderType`) instead of inventing a plugin type table. The Jellyfin Seerr home-layout tab only treats `seerr_` types as Seerr rows, matching Emby, so Radarr/Sonarr calendars stay off that tab.

Companion client: Moonfin-Core #1407 (draft).

## Related Issues

- Related to Moonfin-Client/Moonfin-Core#1407

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [x] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [x] Settings sync / profiles
- [x] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [x] Seerr integration
- [ ] Games / Emulators
- [x] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made

- Add additive `sliderId` / `sliderType` on home section config for Jellyfin and Emby.
- Admin JS round-trips discover sliders as `kind: seerrSlider` without a type enum.
- Derive `homeRowOrder` from builtin sections only (skip `seerr_slider` / non-builtin kinds).
- Jellyfin Seerr tab uses the same `seerr_` prefix rule as Emby (no Radarr/Sonarr there).

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [x] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1407
- [x] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `sliderId` (string)
  - `sliderType` (int)
  - `kind: seerrSlider` on `homeSections` entries

## Compatibility
- [x] Change to the settings profile is additive only, no renamed or removed properties
- [x] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [x] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [x] Built the plugin and deployed to a Jellyfin server
- [x] Verified against a live client (which one: Moonfin-Core Linux desktop on `feat/seerr-custom-sliders`)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Dashboard → Moonbase → Home layout / Seerr and confirm Foreseerr discover sliders list.
2. Enable a slider, save, and confirm `homeSections` stores `kind: seerrSlider` with `sliderId` / `sliderType`.
3. Confirm Radarr/Sonarr rows do not appear on the Jellyfin Seerr tab.
4. Confirm a Moonfin client on the companion branch can show enabled slider rows on Home.

## Screenshots (if applicable)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
- [x] Any new setting keys match the client-side keys exactly

Made with [Cursor](https://cursor.com)