### PR TITLE
feat-settings - Add Show Seerr Availability Badges user default and DTO property

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -10,6 +10,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("seerrApiKey")] public string? SeerrApiKey { get; set; }
         [JsonPropertyName("seerrBlockNsfw")] public bool? SeerrBlockNsfw { get; set; }
         [JsonPropertyName("seerrShowMissingCollectionItems")] public bool? SeerrShowMissingCollectionItems { get; set; }
+        [JsonPropertyName("showSeerrAvailabilityBadges")] public bool? ShowSeerrAvailabilityBadges { get; set; }
         [JsonPropertyName("seerrRows")] public SeerrRowsConfig? SeerrRows { get; set; }
         // Legacy jellyseerr* aliases: read old payloads and keep serializing the old keys for un-migrated clients.
         [JsonPropertyName("jellyseerrEnabled")] public bool? JellyseerrEnabledCompat { get => SeerrEnabled; set { if (value != null) { SeerrEnabled = value; } } }

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -2650,6 +2650,14 @@
                                 <div class="fieldDescription">Include missing items on Collection pages.</div>
                             </div>
                             <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowSeerrAvailabilityBadges">Show Seerr Availability Badges</label>
+                                <select id="DefaultShowSeerrAvailabilityBadges" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused">Seerr Discovery Rows &amp; Order</label>
                                 <div class="fieldDescription">Enable rows to see on Seerr mainpage and use the arrows to set their order.</div>
                                 <div id="DefaultSeerrDiscoveryList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -2042,6 +2042,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             loadRatingSourcesPicker(view, defaults.mdblistRatingSources || null);
             setNullableBoolSelect(view, '#DefaultSeerrBlockNsfw', defaults.seerrBlockNsfw);
             setNullableBoolSelect(view, '#DefaultSeerrShowMissingCollectionItems', defaults.seerrShowMissingCollectionItems);
+            setNullableBoolSelect(view, '#DefaultShowSeerrAvailabilityBadges', defaults.showSeerrAvailabilityBadges);
             var seerrPicker = seerrRowsToPicker(defaults.seerrRows);
             loadSeerrDiscoveryPicker(view, seerrPicker.order, seerrPicker.hidden);
 
@@ -2335,6 +2336,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.mdblistRatingSources = getRatingSourcesValue(view);
             d.seerrBlockNsfw = getNullableBoolSelect(view, '#DefaultSeerrBlockNsfw');
             d.seerrShowMissingCollectionItems = getNullableBoolSelect(view, '#DefaultSeerrShowMissingCollectionItems');
+            d.showSeerrAvailabilityBadges = getNullableBoolSelect(view, '#DefaultShowSeerrAvailabilityBadges');
             // seerrRows carries more than the ordering, so merge rather than replace.
             var seerrRows = Object.assign({}, d.seerrRows || {});
             seerrRows.rowOrder = getSeerrDiscoveryRowOrder(view);

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -24,6 +24,9 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("seerrShowMissingCollectionItems")]
     public bool? SeerrShowMissingCollectionItems { get; set; }
 
+    [JsonPropertyName("showSeerrAvailabilityBadges")]
+    public bool? ShowSeerrAvailabilityBadges { get; set; }
+
     [JsonPropertyName("seerrRows")]
     public SeerrRowsConfig? SeerrRows { get; set; }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -2536,6 +2536,14 @@
                                 <div class="fieldDescription">Include missing items on Collection pages.</div>
                             </div>
                             <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultShowSeerrAvailabilityBadges">Show Seerr Availability Badges</label>
+                                <select id="DefaultShowSeerrAvailabilityBadges" is="emby-select">
+                                    <option value="">Not set (user decides)</option>
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
+                            <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused">Seerr Discovery Rows &amp; Order</label>
                                 <div class="fieldDescription">Enable rows to see on Seerr mainpage and use the arrows to set their order.</div>
                                 <div id="DefaultSeerrDiscoveryList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
@@ -5727,6 +5735,7 @@
                     loadRatingSourcesPicker(defaults.mdblistRatingSources || null);
                     setNullableBoolSelect('#DefaultSeerrBlockNsfw', defaults.seerrBlockNsfw);
                     setNullableBoolSelect('#DefaultSeerrShowMissingCollectionItems', defaults.seerrShowMissingCollectionItems);
+                    setNullableBoolSelect('#DefaultShowSeerrAvailabilityBadges', defaults.showSeerrAvailabilityBadges);
                     var seerrPicker = seerrRowsToPicker(defaults.seerrRows);
                     loadSeerrDiscoveryPicker(seerrPicker.order, seerrPicker.hidden);
 
@@ -6267,6 +6276,7 @@
                         config.DefaultUserSettings.mdblistRatingSources = getRatingSourcesValue();
                         config.DefaultUserSettings.seerrBlockNsfw = getNullableBoolSelect('#DefaultSeerrBlockNsfw');
                         config.DefaultUserSettings.seerrShowMissingCollectionItems = getNullableBoolSelect('#DefaultSeerrShowMissingCollectionItems');
+                        config.DefaultUserSettings.showSeerrAvailabilityBadges = getNullableBoolSelect('#DefaultShowSeerrAvailabilityBadges');
                         // seerrRows carries more than the ordering, so merge rather than replace.
                         var seerrRows = Object.assign({}, config.DefaultUserSettings.seerrRows || {});
                         seerrRows.rowOrder = getSeerrDiscoveryRowOrder();


### PR DESCRIPTION
# Pull Request

## Summary
Adds support for the new showSeerrAvailabilityBadges user preference across Moonbase DTO profiles, admin User Defaults UI, and settings synchronization for both Jellyfin and Emby plugins.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [X] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- Added ShowSeerrAvailabilityBadges (bool?) property to **MoonfinSettingsProfile.cs** in both Jellyfin and Emby backend plugins with JSON wire key showSeerrAvailabilityBadges.
- Added "Show Seerr Availability Badges" dropdown selector and descriptive helper text to **configPage.html** under the User Defaults Seerr section directly below the NSFW filter toggle.
- Bound showSeerrAvailabilityBadges in Jellyfin config page scripts and Emby **moonfin.js** for admin default initialization and save routines.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here:
  - Core: https://github.com/Moonfin-Client/Moonfin-Core/pull/1492
  - Smart-TV: https://github.com/Moonfin-Client/Smart-TV/pull/414
  - Roku: https://github.com/Moonfin-Client/Roku/pull/267
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - showSeerrAvailabilityBadges (boolean)

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [ ] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Android TV and Windows Desktop
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Compiled Release DLL and deployed to Synology NAS Jellyfin server (BrokenClouds).
2. Ran complete test suite (306/306 tests passed).
3. Verified in Jellyfin Admin settings that default dropdown displays with choices "Not set", "Yes", and "No".
4. Confirmed round-trip saving and persistence of the admin default setting.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

<img width="1582" height="656" alt="2026-09-10_21-59-31_brave" src="https://github.com/user-attachments/assets/82ac9625-0f23-4e1f-ad64-f5ff3e6b5f33" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
