### PR TITLE
Languages Additions

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -2081,6 +2081,10 @@
                                 <select id="DefaultDefaultAudioLanguage" is="emby-select"></select>
                             </div>
                             <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFallbackAudioLanguage">Fallback Audio Language</label>
+                                <select id="DefaultFallbackAudioLanguage" is="emby-select"></select>
+                            </div>
+                            <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultPreferDefaultAudioTrack">Prefer Default Audio Track</label>
                                 <select id="DefaultPreferDefaultAudioTrack" is="emby-select">
                                     <option value="">Not set (user decides)</option>
@@ -2112,6 +2116,10 @@
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultDefaultSubtitleLanguage">Default Subtitle Language</label>
                                 <select id="DefaultDefaultSubtitleLanguage" is="emby-select"></select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFallbackSubtitleLanguage">Fallback Subtitle Language</label>
+                                <select id="DefaultFallbackSubtitleLanguage" is="emby-select"></select>
                             </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultPreferSdhSubtitles">Prefer SDH Subtitles</label>

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -665,16 +665,48 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     // ISO 639-2 codes, matching the table Core resolves track languages against.
     // The audio and subtitle pickers share the list so the two stay in sync.
     var LANGUAGE_OPTIONS = [
-        ['auto', 'Server Default'], ['eng', 'English'], ['spa', 'Spanish'],
-        ['fra', 'French'], ['deu', 'German'], ['ita', 'Italian'],
-        ['jpn', 'Japanese'], ['kor', 'Korean'], ['zho', 'Chinese'],
-        ['rus', 'Russian'], ['por', 'Portuguese'], ['ara', 'Arabic'],
-        ['hin', 'Hindi'], ['nld', 'Dutch'], ['pol', 'Polish'],
-        ['swe', 'Swedish'], ['nor', 'Norwegian'], ['dan', 'Danish'],
-        ['fin', 'Finnish'], ['tha', 'Thai'], ['tur', 'Turkish'],
-        ['heb', 'Hebrew'], ['ces', 'Czech'], ['ell', 'Greek'],
-        ['ron', 'Romanian'], ['hun', 'Hungarian'], ['ukr', 'Ukrainian'],
-        ['ind', 'Indonesian'], ['vie', 'Vietnamese']
+        ['auto', 'Server Default'],
+        ['ara', 'Arabic'], ['dan', 'Danish'], ['deu', 'German'], ['eng', 'English'],
+        ['fin', 'Finnish'], ['fra', 'French'], ['hin', 'Hindi'], ['ita', 'Italian'],
+        ['jpn', 'Japanese'], ['kor', 'Korean'], ['nld', 'Dutch'], ['nor', 'Norwegian'],
+        ['pol', 'Polish'], ['por', 'Portuguese'], ['rus', 'Russian'], ['spa', 'Spanish'],
+        ['swe', 'Swedish'], ['tha', 'Thai'], ['tur', 'Turkish'], ['zho', 'Chinese'],
+        ['afr', 'Afrikaans'], ['aka', 'Akan'], ['amh', 'Amharic'], ['asm', 'Assamese'],
+        ['aze', 'Azerbaijani'], ['bak', 'Bashkir'], ['bel', 'Belarusian'], ['bem', 'Bemba'],
+        ['ben', 'Bengali'], ['bod', 'Tibetan'], ['bos', 'Bosnian'], ['bre', 'Breton'],
+        ['bul', 'Bulgarian'], ['cat', 'Catalan'], ['ces', 'Czech'], ['cha', 'Chamorro'],
+        ['che', 'Chechen'], ['chv', 'Chuvash'], ['cos', 'Corsican'], ['cre', 'Cree'],
+        ['crh', 'Crimean Tatar'], ['cym', 'Welsh'], ['div', 'Divehi'], ['dzo', 'Dzongkha'],
+        ['ell', 'Greek'], ['est', 'Estonian'], ['eus', 'Basque'], ['ewe', 'Ewe'],
+        ['fao', 'Faroese'], ['fas', 'Persian'], ['fij', 'Fijian'], ['fil', 'Filipino'],
+        ['frc', 'French (Canada)'], ['ful', 'Fulah'], ['gla', 'Scottish Gaelic'], ['gle', 'Irish'],
+        ['glg', 'Galician'], ['grn', 'Guarani'], ['guj', 'Gujarati'], ['hat', 'Haitian Creole'],
+        ['hau', 'Hausa'], ['haw', 'Hawaiian'], ['heb', 'Hebrew'], ['hil', 'Hiligaynon'],
+        ['hmn', 'Hmong'], ['hrv', 'Croatian'], ['hun', 'Hungarian'], ['hye', 'Armenian'],
+        ['ibo', 'Igbo'], ['iii', 'Sichuan Yi'], ['iku', 'Inuktitut'], ['ind', 'Indonesian'],
+        ['isl', 'Icelandic'], ['jav', 'Javanese'], ['kal', 'Kalaallisut'], ['kan', 'Kannada'],
+        ['kas', 'Kashmiri'], ['kat', 'Georgian'], ['kau', 'Kanuri'], ['kaz', 'Kazakh'],
+        ['khm', 'Khmer'], ['kik', 'Kikuyu'], ['kin', 'Kinyarwanda'], ['kir', 'Kyrgyz'],
+        ['kok', 'Konkani'], ['kom', 'Komi'], ['kon', 'Kongo'], ['kua', 'Kuanyama'],
+        ['kur', 'Kurdish'], ['lao', 'Lao'], ['lat', 'Latin'], ['lav', 'Latvian'],
+        ['lim', 'Limburgish'], ['lin', 'Lingala'], ['lit', 'Lithuanian'], ['ltz', 'Luxembourgish'],
+        ['lug', 'Ganda'], ['luo', 'Luo'], ['mal', 'Malayalam'], ['mar', 'Marathi'],
+        ['mkd', 'Macedonian'], ['mlg', 'Malagasy'], ['mlt', 'Maltese'], ['mon', 'Mongolian'],
+        ['mri', 'Maori'], ['msa', 'Malay'], ['mya', 'Burmese'], ['nav', 'Navajo'],
+        ['nbl', 'South Ndebele'], ['nde', 'North Ndebele'], ['ndo', 'Ndonga'], ['nds', 'Low German'],
+        ['nep', 'Nepali'], ['new', 'Newari'], ['nno', 'Norwegian Nynorsk'], ['nob', 'Norwegian Bokmål'],
+        ['nya', 'Chichewa'], ['oci', 'Occitan'], ['oji', 'Ojibwa'], ['ori', 'Oriya'],
+        ['orm', 'Oromo'], ['oss', 'Ossetian'], ['pan', 'Punjabi'], ['pus', 'Pashto'],
+        ['que', 'Quechua'], ['roh', 'Romansh'], ['ron', 'Romanian'], ['run', 'Rundi'],
+        ['san', 'Sanskrit'], ['sin', 'Sinhala'], ['slk', 'Slovak'], ['slv', 'Slovenian'],
+        ['sme', 'Northern Sami'], ['sna', 'Shona'], ['snd', 'Sindhi'], ['som', 'Somali'],
+        ['sot', 'Southern Sotho'], ['sqi', 'Albanian'], ['srd', 'Sardinian'], ['srp', 'Serbian'],
+        ['ssw', 'Swati'], ['sun', 'Sundanese'], ['swa', 'Swahili'], ['syr', 'Syriac'],
+        ['tam', 'Tamil'], ['tat', 'Tatar'], ['tel', 'Telugu'], ['tgk', 'Tajik'],
+        ['tgl', 'Tagalog'], ['tir', 'Tigrinya'], ['tsn', 'Tswana'], ['tso', 'Tsonga'],
+        ['tuk', 'Turkmen'], ['uig', 'Uyghur'], ['ukr', 'Ukrainian'], ['urd', 'Urdu'],
+        ['uzb', 'Uzbek'], ['vie', 'Vietnamese'], ['wol', 'Wolof'], ['xho', 'Xhosa'],
+        ['yid', 'Yiddish'], ['yor', 'Yoruba'], ['zha', 'Zhuang'], ['zul', 'Zulu']
     ];
 
     function fillLanguageSelect(view, selector) {
@@ -1972,12 +2004,16 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
             fillLanguageSelect(view, '#DefaultDefaultAudioLanguage');
             fillLanguageSelect(view, '#DefaultDefaultSubtitleLanguage');
+            fillLanguageSelect(view, '#DefaultFallbackAudioLanguage');
+            fillLanguageSelect(view, '#DefaultFallbackSubtitleLanguage');
             setSelectValue(view, '#DefaultDefaultAudioLanguage', defaults.defaultAudioLanguage, 'Configured language');
+            setSelectValue(view, '#DefaultFallbackAudioLanguage', defaults.fallbackAudioLanguage, 'Configured language');
             setNullableBoolSelect(view, '#DefaultPreferDefaultAudioTrack', defaults.preferDefaultAudioTrack);
             setNullableBoolSelect(view, '#DefaultPreferAudioDescription', defaults.preferAudioDescription);
 
             setSelectValue(view, '#DefaultSubtitleMode', defaults.subtitleMode, 'Configured mode');
             setSelectValue(view, '#DefaultDefaultSubtitleLanguage', defaults.defaultSubtitleLanguage, 'Configured language');
+            setSelectValue(view, '#DefaultFallbackSubtitleLanguage', defaults.fallbackSubtitleLanguage, 'Configured language');
             setNullableBoolSelect(view, '#DefaultPreferSdhSubtitles', defaults.preferSdhSubtitles);
 
             setNullableBoolSelect(view, '#DefaultCinemaModeEnabled', defaults.cinemaModeEnabled);
@@ -2262,11 +2298,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.skipForwardLength = getNullableIntInput(view, '#DefaultSkipForwardLength');
 
             d.defaultAudioLanguage = view.querySelector('#DefaultDefaultAudioLanguage').value.trim() || null;
+            d.fallbackAudioLanguage = view.querySelector('#DefaultFallbackAudioLanguage').value.trim() || null;
             d.preferDefaultAudioTrack = getNullableBoolSelect(view, '#DefaultPreferDefaultAudioTrack');
             d.preferAudioDescription = getNullableBoolSelect(view, '#DefaultPreferAudioDescription');
 
             d.subtitleMode = view.querySelector('#DefaultSubtitleMode').value || null;
             d.defaultSubtitleLanguage = view.querySelector('#DefaultDefaultSubtitleLanguage').value.trim() || null;
+            d.fallbackSubtitleLanguage = view.querySelector('#DefaultFallbackSubtitleLanguage').value.trim() || null;
             d.preferSdhSubtitles = getNullableBoolSelect(view, '#DefaultPreferSdhSubtitles');
 
             d.cinemaModeEnabled = getNullableBoolSelect(view, '#DefaultCinemaModeEnabled');

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1967,6 +1967,10 @@
                                 <select id="DefaultDefaultAudioLanguage" is="emby-select"></select>
                             </div>
                             <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFallbackAudioLanguage">Fallback Audio Language</label>
+                                <select id="DefaultFallbackAudioLanguage" is="emby-select"></select>
+                            </div>
+                            <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultPreferDefaultAudioTrack">Prefer Default Audio Track</label>
                                 <select id="DefaultPreferDefaultAudioTrack" is="emby-select">
                                     <option value="">Not set (user decides)</option>
@@ -1998,6 +2002,10 @@
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultDefaultSubtitleLanguage">Default Subtitle Language</label>
                                 <select id="DefaultDefaultSubtitleLanguage" is="emby-select"></select>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="DefaultFallbackSubtitleLanguage">Fallback Subtitle Language</label>
+                                <select id="DefaultFallbackSubtitleLanguage" is="emby-select"></select>
                             </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultPreferSdhSubtitles">Prefer SDH Subtitles</label>
@@ -3627,16 +3635,48 @@
             // ISO 639-2 codes, matching the table Core resolves track languages against.
             // The audio and subtitle pickers share the list so the two stay in sync.
             var LANGUAGE_OPTIONS = [
-                ['auto', 'Server Default'], ['eng', 'English'], ['spa', 'Spanish'],
-                ['fra', 'French'], ['deu', 'German'], ['ita', 'Italian'],
-                ['jpn', 'Japanese'], ['kor', 'Korean'], ['zho', 'Chinese'],
-                ['rus', 'Russian'], ['por', 'Portuguese'], ['ara', 'Arabic'],
-                ['hin', 'Hindi'], ['nld', 'Dutch'], ['pol', 'Polish'],
-                ['swe', 'Swedish'], ['nor', 'Norwegian'], ['dan', 'Danish'],
-                ['fin', 'Finnish'], ['tha', 'Thai'], ['tur', 'Turkish'],
-                ['heb', 'Hebrew'], ['ces', 'Czech'], ['ell', 'Greek'],
-                ['ron', 'Romanian'], ['hun', 'Hungarian'], ['ukr', 'Ukrainian'],
-                ['ind', 'Indonesian'], ['vie', 'Vietnamese']
+                ['auto', 'Server Default'],
+                ['ara', 'Arabic'], ['dan', 'Danish'], ['deu', 'German'], ['eng', 'English'],
+                ['fin', 'Finnish'], ['fra', 'French'], ['hin', 'Hindi'], ['ita', 'Italian'],
+                ['jpn', 'Japanese'], ['kor', 'Korean'], ['nld', 'Dutch'], ['nor', 'Norwegian'],
+                ['pol', 'Polish'], ['por', 'Portuguese'], ['rus', 'Russian'], ['spa', 'Spanish'],
+                ['swe', 'Swedish'], ['tha', 'Thai'], ['tur', 'Turkish'], ['zho', 'Chinese'],
+                ['afr', 'Afrikaans'], ['aka', 'Akan'], ['amh', 'Amharic'], ['asm', 'Assamese'],
+                ['aze', 'Azerbaijani'], ['bak', 'Bashkir'], ['bel', 'Belarusian'], ['bem', 'Bemba'],
+                ['ben', 'Bengali'], ['bod', 'Tibetan'], ['bos', 'Bosnian'], ['bre', 'Breton'],
+                ['bul', 'Bulgarian'], ['cat', 'Catalan'], ['ces', 'Czech'], ['cha', 'Chamorro'],
+                ['che', 'Chechen'], ['chv', 'Chuvash'], ['cos', 'Corsican'], ['cre', 'Cree'],
+                ['crh', 'Crimean Tatar'], ['cym', 'Welsh'], ['div', 'Divehi'], ['dzo', 'Dzongkha'],
+                ['ell', 'Greek'], ['est', 'Estonian'], ['eus', 'Basque'], ['ewe', 'Ewe'],
+                ['fao', 'Faroese'], ['fas', 'Persian'], ['fij', 'Fijian'], ['fil', 'Filipino'],
+                ['frc', 'French (Canada)'], ['ful', 'Fulah'], ['gla', 'Scottish Gaelic'], ['gle', 'Irish'],
+                ['glg', 'Galician'], ['grn', 'Guarani'], ['guj', 'Gujarati'], ['hat', 'Haitian Creole'],
+                ['hau', 'Hausa'], ['haw', 'Hawaiian'], ['heb', 'Hebrew'], ['hil', 'Hiligaynon'],
+                ['hmn', 'Hmong'], ['hrv', 'Croatian'], ['hun', 'Hungarian'], ['hye', 'Armenian'],
+                ['ibo', 'Igbo'], ['iii', 'Sichuan Yi'], ['iku', 'Inuktitut'], ['ind', 'Indonesian'],
+                ['isl', 'Icelandic'], ['jav', 'Javanese'], ['kal', 'Kalaallisut'], ['kan', 'Kannada'],
+                ['kas', 'Kashmiri'], ['kat', 'Georgian'], ['kau', 'Kanuri'], ['kaz', 'Kazakh'],
+                ['khm', 'Khmer'], ['kik', 'Kikuyu'], ['kin', 'Kinyarwanda'], ['kir', 'Kyrgyz'],
+                ['kok', 'Konkani'], ['kom', 'Komi'], ['kon', 'Kongo'], ['kua', 'Kuanyama'],
+                ['kur', 'Kurdish'], ['lao', 'Lao'], ['lat', 'Latin'], ['lav', 'Latvian'],
+                ['lim', 'Limburgish'], ['lin', 'Lingala'], ['lit', 'Lithuanian'], ['ltz', 'Luxembourgish'],
+                ['lug', 'Ganda'], ['luo', 'Luo'], ['mal', 'Malayalam'], ['mar', 'Marathi'],
+                ['mkd', 'Macedonian'], ['mlg', 'Malagasy'], ['mlt', 'Maltese'], ['mon', 'Mongolian'],
+                ['mri', 'Maori'], ['msa', 'Malay'], ['mya', 'Burmese'], ['nav', 'Navajo'],
+                ['nbl', 'South Ndebele'], ['nde', 'North Ndebele'], ['ndo', 'Ndonga'], ['nds', 'Low German'],
+                ['nep', 'Nepali'], ['new', 'Newari'], ['nno', 'Norwegian Nynorsk'], ['nob', 'Norwegian Bokmål'],
+                ['nya', 'Chichewa'], ['oci', 'Occitan'], ['oji', 'Ojibwa'], ['ori', 'Oriya'],
+                ['orm', 'Oromo'], ['oss', 'Ossetian'], ['pan', 'Punjabi'], ['pus', 'Pashto'],
+                ['que', 'Quechua'], ['roh', 'Romansh'], ['ron', 'Romanian'], ['run', 'Rundi'],
+                ['san', 'Sanskrit'], ['sin', 'Sinhala'], ['slk', 'Slovak'], ['slv', 'Slovenian'],
+                ['sme', 'Northern Sami'], ['sna', 'Shona'], ['snd', 'Sindhi'], ['som', 'Somali'],
+                ['sot', 'Southern Sotho'], ['sqi', 'Albanian'], ['srd', 'Sardinian'], ['srp', 'Serbian'],
+                ['ssw', 'Swati'], ['sun', 'Sundanese'], ['swa', 'Swahili'], ['syr', 'Syriac'],
+                ['tam', 'Tamil'], ['tat', 'Tatar'], ['tel', 'Telugu'], ['tgk', 'Tajik'],
+                ['tgl', 'Tagalog'], ['tir', 'Tigrinya'], ['tsn', 'Tswana'], ['tso', 'Tsonga'],
+                ['tuk', 'Turkmen'], ['uig', 'Uyghur'], ['ukr', 'Ukrainian'], ['urd', 'Urdu'],
+                ['uzb', 'Uzbek'], ['vie', 'Vietnamese'], ['wol', 'Wolof'], ['xho', 'Xhosa'],
+                ['yid', 'Yiddish'], ['yor', 'Yoruba'], ['zha', 'Zhuang'], ['zul', 'Zulu']
             ];
 
             function fillLanguageSelect(selector) {
@@ -5710,12 +5750,16 @@
 
                     fillLanguageSelect('#DefaultDefaultAudioLanguage');
                     fillLanguageSelect('#DefaultDefaultSubtitleLanguage');
+                    fillLanguageSelect('#DefaultFallbackAudioLanguage');
+                    fillLanguageSelect('#DefaultFallbackSubtitleLanguage');
                     setSelectValue('#DefaultDefaultAudioLanguage', defaults.defaultAudioLanguage, 'Configured language');
+                    setSelectValue('#DefaultFallbackAudioLanguage', defaults.fallbackAudioLanguage, 'Configured language');
                     setNullableBoolSelect('#DefaultPreferDefaultAudioTrack', defaults.preferDefaultAudioTrack);
                     setNullableBoolSelect('#DefaultPreferAudioDescription', defaults.preferAudioDescription);
 
                     setSelectValue('#DefaultSubtitleMode', defaults.subtitleMode, 'Configured mode');
                     setSelectValue('#DefaultDefaultSubtitleLanguage', defaults.defaultSubtitleLanguage, 'Configured language');
+                    setSelectValue('#DefaultFallbackSubtitleLanguage', defaults.fallbackSubtitleLanguage, 'Configured language');
                     setNullableBoolSelect('#DefaultPreferSdhSubtitles', defaults.preferSdhSubtitles);
 
                     setNullableBoolSelect('#DefaultCinemaModeEnabled', defaults.cinemaModeEnabled);
@@ -6183,11 +6227,13 @@
                         config.DefaultUserSettings.skipForwardLength = getNullableIntInput('#DefaultSkipForwardLength');
 
                         config.DefaultUserSettings.defaultAudioLanguage = document.querySelector('#DefaultDefaultAudioLanguage').value.trim() || null;
+                        config.DefaultUserSettings.fallbackAudioLanguage = document.querySelector('#DefaultFallbackAudioLanguage').value.trim() || null;
                         config.DefaultUserSettings.preferDefaultAudioTrack = getNullableBoolSelect('#DefaultPreferDefaultAudioTrack');
                         config.DefaultUserSettings.preferAudioDescription = getNullableBoolSelect('#DefaultPreferAudioDescription');
 
                         config.DefaultUserSettings.subtitleMode = document.querySelector('#DefaultSubtitleMode').value || null;
                         config.DefaultUserSettings.defaultSubtitleLanguage = document.querySelector('#DefaultDefaultSubtitleLanguage').value.trim() || null;
+                        config.DefaultUserSettings.fallbackSubtitleLanguage = document.querySelector('#DefaultFallbackSubtitleLanguage').value.trim() || null;
                         config.DefaultUserSettings.preferSdhSubtitles = getNullableBoolSelect('#DefaultPreferSdhSubtitles');
 
                         config.DefaultUserSettings.cinemaModeEnabled = getNullableBoolSelect('#DefaultCinemaModeEnabled');


### PR DESCRIPTION
# Pull Request

## Summary
Admin config changes only, the settings themselves already sync

Adds the complete language codes list offered by core, in the same order as offered by core

Adds fallback audio/sub language options

## Related Issues
Link related issues or tickets separated by commas.

- Closes #277 
- Fixes #276 
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [ ] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [ ] Settings sync / profiles
- [X] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- replace language code list with list from core (same list, same order)
- add fallback language options to config page
- same for emby

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [X] No client changes needed
- [ ] Companion client PR(s) required, linked here:
- [ ] New setting keys added. List each key and confirm it matches the client key exactly, including casing:

## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [ ] Built the plugin and deployed to a Jellyfin server
- [ ] Verified against a live client (which one:)
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
