### PR TITLE
Round-trip Seerr discover sliders in homeSections

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -351,5 +351,7 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("pluginSection")] public string? PluginSection { get; set; }
         [JsonPropertyName("pluginAdditionalData")] public string? PluginAdditionalData { get; set; }
         [JsonPropertyName("pluginDisplayText")] public string? PluginDisplayText { get; set; }
+        [JsonPropertyName("sliderId")] public string? SliderId { get; set; }
+        [JsonPropertyName("sliderType")] public int? SliderType { get; set; }
     }
 }

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1078,20 +1078,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { type: 'favoritealbums', label: 'Favorite Albums' },
         { type: 'favoritesongs', label: 'Favorite Songs' },
         { type: 'genres', label: 'Genres' },
-        { type: 'playlists', label: 'Playlists' },
-        { type: 'seerr_shortcuts', label: 'Seerr Browse' },
-        { type: 'seerr_recent_requests', label: 'Seerr Recent Requests' },
-        { type: 'seerr_recently_added', label: 'Seerr Recently Added' },
-        { type: 'seerr_popular_movies', label: 'Seerr Popular Movies' },
-        { type: 'seerr_upcoming_movies', label: 'Seerr Upcoming Movies' },
-        { type: 'seerr_popular_series', label: 'Seerr Popular Series' },
-        { type: 'seerr_upcoming_series', label: 'Seerr Upcoming Series' },
-        { type: 'seerr_trending', label: 'Seerr Trending' },
-        { type: 'seerr_movie_genres', label: 'Seerr Movie Genres' },
-        { type: 'seerr_studios', label: 'Seerr Studios' },
-        { type: 'seerr_series_genres', label: 'Seerr Series Genres' },
-        { type: 'seerr_networks', label: 'Seerr Networks' },
-        { type: 'seerr_watchlist', label: 'Seerr Watchlist' }
+        { type: 'playlists', label: 'Playlists' }
     ];
 
     var HOME_LAYOUT_TABS = [
@@ -1101,10 +1088,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { id: 'genres', label: 'Genres' },
         { id: 'seerr', label: 'Seerr' }
     ];
-
-    function isSeerrHomeSectionType(type) {
-        return !!(type && type.indexOf('seerr_') === 0);
-    }
 
     function isSeerrSliderSection(section) {
         return !!section && (section.kind === 'seerrSlider' ||
@@ -1129,6 +1112,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         var state = getHomeLayoutState(view);
         var sliders = state.seerrDiscoverSliders || [];
         var id = seerrSliderIdOf(section);
+        if (id === 'shortcuts') {
+            return (section.pluginDisplayText || 'Seerr Browse').trim();
+        }
         for (var i = 0; i < sliders.length; i++) {
             if (String(sliders[i].id) !== id) continue;
             return (sliders[i].title || '').trim();
@@ -1144,7 +1130,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     function isSeerrSliderType(type) {
         var n = Number(type);
         if (!Number.isFinite(n)) return false;
-        return n > 12;
+        if (n >= 1017 && n <= 1022) return false;
+        return n >= 1;
     }
 
     function getHomeLayoutState(view) {
@@ -1180,7 +1167,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function homeSectionMeta(section) {
         if (!section) return 'Basics';
-        if (isSeerrSliderSection(section) || isSeerrHomeSectionType(section.type)) return 'Seerr';
+        if (isSeerrSliderSection(section)) return 'Seerr';
         if (section.kind !== 'pluginDynamic') {
             return 'Basics';
         }
@@ -1192,7 +1179,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     }
 
     function homeSectionBadgeClass(section) {
-        if (isSeerrSliderSection(section) || (section && isSeerrHomeSectionType(section.type))) {
+        if (isSeerrSliderSection(section)) {
             return 'homeLayoutBadge-seerr';
         }
         if (!section || section.kind !== 'pluginDynamic') {
@@ -1207,7 +1194,11 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     function homeSectionKey(section) {
         if (!section) return '';
         if (isSeerrSliderSection(section)) {
-            return 'seerrSlider:' + seerrSliderIdOf(section);
+            var id = seerrSliderIdOf(section);
+            if (id) return 'seerrSlider:' + id;
+            var t = seerrSliderTypeOf(section);
+            if (t != null) return 'seerrSlider:type:' + t;
+            return 'seerrSlider:';
         }
         if (section.kind === 'pluginDynamic') {
             return [
@@ -1274,15 +1265,15 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             var normalized;
             if (isSeerrSliderSection(section)) {
                 var sliderId = seerrSliderIdOf(section);
-                if (!sliderId) return;
                 var sliderType = seerrSliderTypeOf(section);
+                if (!sliderId && sliderType == null) return;
                 normalized = {
                     kind: 'seerrSlider',
                     type: 'seerr_slider',
                     enabled: section.enabled !== false,
-                    order: ordered.length,
-                    sliderId: sliderId
+                    order: ordered.length
                 };
+                if (sliderId) normalized.sliderId = sliderId;
                 if (sliderType != null) normalized.sliderType = sliderType;
                 if (section.pluginDisplayText) {
                     normalized.pluginDisplayText = section.pluginDisplayText;
@@ -1325,8 +1316,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             key: 'builtin:' + definition.type,
             tab: 'builtin',
             label: definition.label,
-            meta: isSeerrHomeSectionType(definition.type) ? 'Seerr' : 'Basics',
-            badgeClass: isSeerrHomeSectionType(definition.type) ? 'homeLayoutBadge-seerr' : 'homeLayoutBadge-builtin',
+            meta: 'Basics',
+            badgeClass: 'homeLayoutBadge-builtin',
             section: {
                 kind: 'builtin',
                 type: definition.type,
@@ -1359,6 +1350,24 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         return candidate;
     }
 
+    function createSeerrShortcutsCandidate() {
+        return {
+            key: 'seerrSlider:shortcuts',
+            tab: 'seerr',
+            label: 'Seerr Browse',
+            meta: 'Seerr',
+            badgeClass: 'homeLayoutBadge-seerr',
+            section: {
+                kind: 'seerrSlider',
+                type: 'seerr_slider',
+                enabled: true,
+                order: 0,
+                sliderId: 'shortcuts',
+                pluginDisplayText: 'Seerr Browse'
+            }
+        };
+    }
+
     function createDynamicCandidate(tab, source, sectionName, id, label, meta, serverId) {
         return {
             key: ['pluginDynamic', source, sectionName, id || ''].join(':'),
@@ -1381,14 +1390,8 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     }
 
     function initializeHomeLayoutAvailableRows(state) {
-        state.available.builtin = HOME_SECTION_DEFINITIONS
-            .filter(function (definition) { return !isSeerrHomeSectionType(definition.type); })
-            .map(createBuiltinCandidate);
-        state.available.seerr = HOME_SECTION_DEFINITIONS
-            .filter(function (definition) {
-                return isSeerrHomeSectionType(definition.type);
-            })
-            .map(createBuiltinCandidate);
+        state.available.builtin = HOME_SECTION_DEFINITIONS.map(createBuiltinCandidate);
+        state.available.seerr = [createSeerrShortcutsCandidate()];
     }
 
     function getHomeLayoutInsertIndex(state) {
@@ -1616,11 +1619,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     }
 
     function seerrBuiltinCandidates() {
-        return HOME_SECTION_DEFINITIONS
-            .filter(function (definition) {
-                return isSeerrHomeSectionType(definition.type);
-            })
-            .map(createBuiltinCandidate);
+        return [createSeerrShortcutsCandidate()];
     }
 
     function loadHomeLayoutSeerrSliders(view) {

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1102,24 +1102,51 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { id: 'seerr', label: 'Seerr' }
     ];
 
-    var HOME_LAYOUT_SEERR_TYPES = {
-        seerr_shortcuts: true,
-        seerr_recent_requests: true,
-        seerr_recently_added: true,
-        seerr_popular_movies: true,
-        seerr_upcoming_movies: true,
-        seerr_popular_series: true,
-        seerr_upcoming_series: true,
-        seerr_trending: true,
-        seerr_movie_genres: true,
-        seerr_studios: true,
-        seerr_series_genres: true,
-        seerr_networks: true,
-        seerr_watchlist: true
-    };
-
     function isSeerrHomeSectionType(type) {
-        return !!HOME_LAYOUT_SEERR_TYPES[type];
+        return !!(type && type.indexOf('seerr_') === 0);
+    }
+
+    function isSeerrSliderSection(section) {
+        return !!section && (section.kind === 'seerrSlider' ||
+            (section.kind === 'pluginDynamic' && section.pluginSource === 'seerr') ||
+            section.type === 'seerr_slider');
+    }
+
+    function seerrSliderIdOf(section) {
+        if (!section) return '';
+        if (section.sliderId) return String(section.sliderId);
+        if (section.pluginAdditionalData) return String(section.pluginAdditionalData);
+        return '';
+    }
+
+    function seerrSliderTypeOf(section) {
+        if (!section || section.sliderType == null || section.sliderType === '') return null;
+        var n = Number(section.sliderType);
+        return Number.isFinite(n) ? n : null;
+    }
+
+    function seerrSliderLiveTitle(view, section) {
+        var state = getHomeLayoutState(view);
+        var sliders = state.seerrDiscoverSliders || [];
+        var id = seerrSliderIdOf(section);
+        for (var i = 0; i < sliders.length; i++) {
+            if (String(sliders[i].id) !== id) continue;
+            return (sliders[i].title || '').trim();
+        }
+        return (section.pluginDisplayText || '').trim();
+    }
+
+    function seerrSliderLabel(slider) {
+        var title = (slider && slider.title ? String(slider.title) : '').trim();
+        return title || 'Seerr slider';
+    }
+
+    function isSeerrCustomSliderType(type) {
+        var n = Number(type);
+        if (!Number.isFinite(n)) return false;
+        if (n >= 1 && n <= 12) return false;
+        if (n >= 38 && n <= 43) return false;
+        return n > 12;
     }
 
     function getHomeLayoutState(view) {
@@ -1139,8 +1166,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         return HOME_SECTION_DEFINITIONS.find(function (row) { return row.type === type; }) || null;
     }
 
-    function homeSectionLabel(section) {
+    function homeSectionLabel(view, section) {
         if (!section) return 'Unknown row';
+        if (isSeerrSliderSection(section)) {
+            return seerrSliderLiveTitle(view, section) ||
+                section.pluginDisplayText ||
+                'Seerr slider';
+        }
         if (section.kind === 'pluginDynamic') {
             return section.pluginDisplayText || section.pluginSection || 'Dynamic row';
         }
@@ -1150,8 +1182,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function homeSectionMeta(section) {
         if (!section) return 'Basics';
+        if (isSeerrSliderSection(section) || isSeerrHomeSectionType(section.type)) return 'Seerr';
         if (section.kind !== 'pluginDynamic') {
-            return isSeerrHomeSectionType(section.type) ? 'Seerr' : 'Basics';
+            return 'Basics';
         }
         if (section.pluginSource === 'collections') return 'Collection';
         if (section.pluginSource === 'playlists') return 'Playlist';
@@ -1161,8 +1194,10 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     }
 
     function homeSectionBadgeClass(section) {
+        if (isSeerrSliderSection(section) || (section && isSeerrHomeSectionType(section.type))) {
+            return 'homeLayoutBadge-seerr';
+        }
         if (!section || section.kind !== 'pluginDynamic') {
-            if (section && isSeerrHomeSectionType(section.type)) return 'homeLayoutBadge-seerr';
             return 'homeLayoutBadge-builtin';
         }
         if (section.pluginSource === 'collections') return 'homeLayoutBadge-collections';
@@ -1173,6 +1208,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function homeSectionKey(section) {
         if (!section) return '';
+        if (isSeerrSliderSection(section)) {
+            return 'seerrSlider:' + seerrSliderIdOf(section);
+        }
         if (section.kind === 'pluginDynamic') {
             return [
                 'pluginDynamic',
@@ -1202,7 +1240,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
 
     function renumberHomeLayoutSections(state) {
         state.sections.forEach(function (section, index) {
-            section.enabled = true;
+            if (section.kind !== 'pluginDynamic' && section.kind !== 'seerrSlider') {
+                section.enabled = true;
+            }
             section.order = index;
         });
     }
@@ -1234,7 +1274,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         }).forEach(function (section) {
             if (!section) return;
             var normalized;
-            if (section.kind === 'pluginDynamic') {
+            if (isSeerrSliderSection(section)) {
+                var sliderId = seerrSliderIdOf(section);
+                if (!sliderId) return;
+                var sliderType = seerrSliderTypeOf(section);
+                normalized = {
+                    kind: 'seerrSlider',
+                    type: 'seerr_slider',
+                    enabled: section.enabled !== false,
+                    order: ordered.length,
+                    sliderId: sliderId
+                };
+                if (sliderType != null) normalized.sliderType = sliderType;
+                if (section.pluginDisplayText) {
+                    normalized.pluginDisplayText = section.pluginDisplayText;
+                }
+            } else if (section.kind === 'pluginDynamic') {
                 normalized = {
                     kind: 'pluginDynamic',
                     type: 'none',
@@ -1283,6 +1338,29 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         };
     }
 
+    function createSeerrSliderCandidate(slider) {
+        var sliderId = String(slider.id);
+        var label = seerrSliderLabel(slider);
+        var candidate = {
+            key: 'seerrSlider:' + sliderId,
+            tab: 'seerr',
+            label: label,
+            meta: 'Seerr',
+            badgeClass: 'homeLayoutBadge-seerr',
+            section: {
+                kind: 'seerrSlider',
+                type: 'seerr_slider',
+                enabled: true,
+                order: 0,
+                sliderId: sliderId,
+                pluginDisplayText: label
+            }
+        };
+        var sliderType = Number(slider.type);
+        if (Number.isFinite(sliderType)) candidate.section.sliderType = sliderType;
+        return candidate;
+    }
+
     function createDynamicCandidate(tab, source, sectionName, id, label, meta, serverId) {
         return {
             key: ['pluginDynamic', source, sectionName, id || ''].join(':'),
@@ -1309,7 +1387,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             .filter(function (definition) { return !isSeerrHomeSectionType(definition.type); })
             .map(createBuiltinCandidate);
         state.available.seerr = HOME_SECTION_DEFINITIONS
-            .filter(function (definition) { return isSeerrHomeSectionType(definition.type); })
+            .filter(function (definition) {
+                return isSeerrHomeSectionType(definition.type);
+            })
             .map(createBuiltinCandidate);
     }
 
@@ -1393,7 +1473,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             row.dataset.index = String(index);
             row.innerHTML =
                 '<div class="homeLayoutRowText">' +
-                '<div class="homeLayoutRowTitle">' + esc(homeSectionLabel(section)) + '</div>' +
+                '<div class="homeLayoutRowTitle">' + esc(homeSectionLabel(view, section)) + '</div>' +
                 '<span class="homeLayoutBadge ' + homeSectionBadgeClass(section) + '">' + esc(homeSectionMeta(section)) + '</span>' +
                 '</div>' +
                 '<button type="button" class="homeLayoutIconButton" data-action="up" title="Move up"' + (index === 0 ? ' disabled' : '') + '>&#x2191;</button>' +
@@ -1534,6 +1614,39 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         loadHomeLayoutCollections(view);
         loadHomeLayoutPlaylists(view);
         loadHomeLayoutGenres(view);
+        loadHomeLayoutSeerrSliders(view);
+    }
+
+    function seerrBuiltinCandidates() {
+        return HOME_SECTION_DEFINITIONS
+            .filter(function (definition) {
+                return isSeerrHomeSectionType(definition.type);
+            })
+            .map(createBuiltinCandidate);
+    }
+
+    function loadHomeLayoutSeerrSliders(view) {
+        var serverId = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+        fetch(serverId + '/Moonfin/Seerr/Api/settings/discover', {
+            method: 'GET',
+            headers: moonfinAuthHeaders()
+        }).then(function (response) {
+            if (!response.ok) return [];
+            return response.json();
+        }).then(function (data) {
+            var sliders = Array.isArray(data) ? data : [];
+            var state = getHomeLayoutState(view);
+            state.seerrDiscoverSliders = sliders;
+            var candidates = sliders.filter(function (slider) {
+                if (!slider || slider.enabled === false || !slider.id) return false;
+                return isSeerrCustomSliderType(slider.type);
+            }).map(createSeerrSliderCandidate);
+            setHomeLayoutAvailable(view, 'seerr', seerrBuiltinCandidates().concat(candidates));
+            renderHomeSectionsEditor(view);
+        }).catch(function () {
+            getHomeLayoutState(view).seerrDiscoverSliders = [];
+            setHomeLayoutAvailable(view, 'seerr', seerrBuiltinCandidates());
+        });
     }
 
     function setHomeLayoutAvailable(view, tab, candidates) {
@@ -1635,15 +1748,22 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         if (state.sections.length === 0) return null;
         renumberHomeLayoutSections(state);
         return state.sections.map(function (section) {
+            var isSlider = section.kind === 'seerrSlider';
             var isDynamic = section.kind === 'pluginDynamic';
             var result = {
-                type: isDynamic ? 'none' : section.type,
+                type: isSlider ? (section.type || 'seerr_slider') : (isDynamic ? 'none' : section.type),
                 // Dynamic rows stay in the editor when disabled, unlike builtins, so writing
                 // them all back as enabled would switch every custom row on.
-                enabled: isDynamic ? section.enabled !== false : true,
+                enabled: (isDynamic || isSlider) ? section.enabled !== false : true,
                 order: section.order
             };
-            if (isDynamic) {
+            if (isSlider) {
+                result.kind = 'seerrSlider';
+                result.type = 'seerr_slider';
+                result.sliderId = section.sliderId;
+                if (section.sliderType != null) result.sliderType = section.sliderType;
+                if (section.pluginDisplayText) result.pluginDisplayText = section.pluginDisplayText;
+            } else if (isDynamic) {
                 result.kind = 'pluginDynamic';
                 result.pluginSource = section.pluginSource || 'hss';
                 // Custom rows have no server of their own and the client keys them on this,

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1144,8 +1144,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     function isSeerrSliderType(type) {
         var n = Number(type);
         if (!Number.isFinite(n)) return false;
-        if (n >= 1 && n <= 12) return false;
-        if (n >= 38 && n <= 43) return false;
         return n > 12;
     }
 

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1130,7 +1130,6 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
     function isSeerrSliderType(type) {
         var n = Number(type);
         if (!Number.isFinite(n)) return false;
-        if (n >= 1017 && n <= 1022) return false;
         return n >= 1;
     }
 

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -1141,7 +1141,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         return title || 'Seerr slider';
     }
 
-    function isSeerrCustomSliderType(type) {
+    function isSeerrSliderType(type) {
         var n = Number(type);
         if (!Number.isFinite(n)) return false;
         if (n >= 1 && n <= 12) return false;
@@ -1639,7 +1639,7 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             state.seerrDiscoverSliders = sliders;
             var candidates = sliders.filter(function (slider) {
                 if (!slider || slider.enabled === false || !slider.id) return false;
-                return isSeerrCustomSliderType(slider.type);
+                return isSeerrSliderType(slider.type);
             }).map(createSeerrSliderCandidate);
             setHomeLayoutAvailable(view, 'seerr', seerrBuiltinCandidates().concat(candidates));
             renderHomeSectionsEditor(view);

--- a/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
+++ b/Emby/Emby.Plugins.Moonfin/PluginConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Emby.Plugins.Moonfin.Models;
+using Emby.Plugins.Moonfin.Services;
 using MediaBrowser.Model.Plugins;
 
 namespace Emby.Plugins.Moonfin
@@ -187,6 +188,11 @@ namespace Emby.Plugins.Moonfin
                 JellyseerrUrl = null;
                 JellyseerrEnabled = false;
                 JellyseerrDisplayName = null;
+                changed = true;
+            }
+
+            if (MoonfinSettingsService.MigrateSeerrHomeSections(DefaultUserSettings))
+            {
                 changed = true;
             }
 

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -212,10 +212,13 @@ namespace Emby.Plugins.Moonfin.Services
             if (profile.HomeSections == null) return null;
 
             var homeRowOrder = profile.HomeSections
-                .Where(section => !string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase))
+                .Where(section =>
+                    string.IsNullOrEmpty(section.Kind) ||
+                    string.Equals(section.Kind, "builtin", StringComparison.OrdinalIgnoreCase))
                 .Where(section => section.Enabled != false)
                 .Where(section => !string.IsNullOrWhiteSpace(section.Type) &&
-                    !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(section.Type, "seerr_slider", StringComparison.OrdinalIgnoreCase))
                 .OrderBy(section => section.Order ?? int.MaxValue)
                 .Select(section => section.Type!)
                 .ToList();

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -1030,12 +1030,62 @@ namespace Emby.Plugins.Moonfin.Services
             }
 
             if (profile.HomeRowOrder == null) return changed;
-            var filtered = profile.HomeRowOrder.FindAll(name =>
-                string.IsNullOrEmpty(name) ||
-                !name.StartsWith("seerr_", StringComparison.OrdinalIgnoreCase));
-            if (filtered.Count == profile.HomeRowOrder.Count) return changed;
-            profile.HomeRowOrder = filtered.Count > 0 ? filtered : null;
-            return true;
+            var kept = new List<string>();
+            foreach (var name in profile.HomeRowOrder)
+            {
+                if (string.IsNullOrEmpty(name) ||
+                    !name.StartsWith("seerr_", StringComparison.OrdinalIgnoreCase))
+                {
+                    kept.Add(name);
+                    continue;
+                }
+
+                profile.HomeSections ??= new List<MoonfinHomeSectionConfig>();
+                var section = new MoonfinHomeSectionConfig
+                {
+                    Type = name,
+                    Enabled = true,
+                    Order = profile.HomeSections.Count,
+                };
+                if (!RewriteDeletedSeerrHomeType(section)) continue;
+                if (HasMatchingSeerrHomeSection(profile.HomeSections, section)) continue;
+                profile.HomeSections.Add(section);
+                changed = true;
+            }
+
+            if (kept.Count != profile.HomeRowOrder.Count)
+            {
+                profile.HomeRowOrder = kept.Count > 0 ? kept : null;
+                changed = true;
+            }
+
+            return changed;
+        }
+
+        static bool HasMatchingSeerrHomeSection(
+            List<MoonfinHomeSectionConfig> sections,
+            MoonfinHomeSectionConfig incoming)
+        {
+            foreach (var existing in sections)
+            {
+                if (!string.Equals(existing.Kind, "seerrSlider", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(incoming.SliderId) &&
+                    string.Equals(existing.SliderId, incoming.SliderId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                if (incoming.SliderType is int type && existing.SliderType == type)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         static bool RewriteDeletedSeerrHomeType(MoonfinHomeSectionConfig section)

--- a/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Services/MoonfinSettingsService.cs
@@ -73,10 +73,18 @@ namespace Emby.Plugins.Moonfin.Services
                 var settings = await Task.Run(() => ReadSettingsWithRecovery(filePath)).ConfigureAwait(false);
                 if (settings == null) return null;
 
+                var persist = false;
                 if (settings.NeedsMigration)
                 {
                     _logger.Info("Migrating v1 settings to v2 for user " + userId, 0);
                     settings = MigrateV1ToV2(settings);
+                    persist = true;
+                }
+
+                if (MigrateSeerrHomeSections(settings)) persist = true;
+
+                if (persist)
+                {
                     var migratedJson = JsonSerializer.Serialize(settings, _jsonOptions);
                     await Task.Run(() => AtomicFile.WriteAllText(filePath, migratedJson)).ConfigureAwait(false);
                 }
@@ -289,6 +297,8 @@ namespace Emby.Plugins.Moonfin.Services
                     finalSettings = settings;
                 }
 
+                MigrateSeerrHomeSections(finalSettings);
+
                 StripServerWideKeys(finalSettings);
                 finalSettings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 finalSettings.LastUpdatedBy = clientId ?? "unknown";
@@ -335,6 +345,8 @@ namespace Emby.Plugins.Moonfin.Services
                     MergeProfile(existingProfile, profile);
                 else
                     settings.SetProfile(profileName, profile);
+
+                MigrateSeerrHomeSections(settings);
 
                 StripServerWideKeys(settings);
                 settings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -988,6 +1000,104 @@ namespace Emby.Plugins.Moonfin.Services
             }
 
             return existing;
+        }
+
+        /// <summary>
+        /// Rewrites stored <c>seerr_trending</c> home types to sliders. Called from
+        /// the same persist-on-load path as <see cref="MigrateV1ToV2"/>.
+        /// </summary>
+        internal static bool MigrateSeerrHomeSections(MoonfinUserSettings? settings)
+        {
+            if (settings == null) return false;
+            var changed = false;
+            changed |= MigrateSeerrHomeSections(settings.Global);
+            changed |= MigrateSeerrHomeSections(settings.Desktop);
+            changed |= MigrateSeerrHomeSections(settings.Mobile);
+            changed |= MigrateSeerrHomeSections(settings.Tv);
+            return changed;
+        }
+
+        internal static bool MigrateSeerrHomeSections(MoonfinSettingsProfile? profile)
+        {
+            if (profile == null) return false;
+            var changed = false;
+            if (profile.HomeSections != null)
+            {
+                foreach (var section in profile.HomeSections)
+                {
+                    if (RewriteDeletedSeerrHomeType(section)) changed = true;
+                }
+            }
+
+            if (profile.HomeRowOrder == null) return changed;
+            var filtered = profile.HomeRowOrder.FindAll(name =>
+                string.IsNullOrEmpty(name) ||
+                !name.StartsWith("seerr_", StringComparison.OrdinalIgnoreCase));
+            if (filtered.Count == profile.HomeRowOrder.Count) return changed;
+            profile.HomeRowOrder = filtered.Count > 0 ? filtered : null;
+            return true;
+        }
+
+        static bool RewriteDeletedSeerrHomeType(MoonfinHomeSectionConfig section)
+        {
+            var id = section.SliderId;
+            if (!string.IsNullOrEmpty(id) &&
+                id.StartsWith("legacy:", StringComparison.OrdinalIgnoreCase))
+            {
+                if (int.TryParse(id.Substring("legacy:".Length), out var fromId))
+                {
+                    section.SliderType ??= fromId;
+                }
+
+                section.SliderId = null;
+                return true;
+            }
+
+            var type = section.Type;
+            if (string.IsNullOrEmpty(type) ||
+                string.Equals(section.Kind, "seerrSlider", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "seerr_slider", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (type.Equals("seerr_shortcuts", StringComparison.OrdinalIgnoreCase))
+            {
+                section.Kind = "seerrSlider";
+                section.Type = "seerr_slider";
+                section.SliderId = "shortcuts";
+                section.SliderType = null;
+                if (string.IsNullOrWhiteSpace(section.PluginDisplayText))
+                {
+                    section.PluginDisplayText = "Seerr Browse";
+                }
+
+                return true;
+            }
+
+            int sliderType;
+            switch (type)
+            {
+                case "seerr_recently_added": sliderType = 1; break;
+                case "seerr_recent_requests": sliderType = 2; break;
+                case "seerr_watchlist": sliderType = 3; break;
+                case "seerr_trending": sliderType = 4; break;
+                case "seerr_popular_movies": sliderType = 5; break;
+                case "seerr_movie_genres": sliderType = 6; break;
+                case "seerr_upcoming_movies": sliderType = 7; break;
+                case "seerr_studios": sliderType = 8; break;
+                case "seerr_popular_series": sliderType = 9; break;
+                case "seerr_series_genres": sliderType = 10; break;
+                case "seerr_upcoming_series": sliderType = 11; break;
+                case "seerr_networks": sliderType = 12; break;
+                default: return false;
+            }
+
+            section.Kind = "seerrSlider";
+            section.Type = "seerr_slider";
+            section.SliderId = null;
+            section.SliderType = sliderType;
+            return true;
         }
 
         private static bool HasAnyProfileValues(MoonfinSettingsProfile profile)

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -979,4 +979,10 @@ public class MoonfinHomeSectionConfig
 
     [JsonPropertyName("pluginDisplayText")]
     public string? PluginDisplayText { get; set; }
+
+    [JsonPropertyName("sliderId")]
+    public string? SliderId { get; set; }
+
+    [JsonPropertyName("sliderType")]
+    public int? SliderType { get; set; }
 }

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -4026,24 +4026,6 @@
                 { id: 'external', label: 'External Lists' }
             ];
 
-            var HOME_LAYOUT_SEERR_TYPES = {
-                seerr_shortcuts: true,
-                seerr_recent_requests: true,
-                seerr_recently_added: true,
-                seerr_popular_movies: true,
-                seerr_upcoming_movies: true,
-                seerr_popular_series: true,
-                seerr_upcoming_series: true,
-                seerr_trending: true,
-                seerr_movie_genres: true,
-                seerr_studios: true,
-                seerr_series_genres: true,
-                seerr_networks: true,
-                seerr_watchlist: true,
-                radarr_calendar: true,
-                sonarr_calendar: true
-            };
-
             var HOME_LAYOUT_EXTERNAL_LISTS = {
                 imdb_top_250_movies: true,
                 imdb_top_250_tv_shows: true,
@@ -4067,7 +4049,51 @@
             };
 
             function isSeerrHomeSectionType(type) {
-                return !!HOME_LAYOUT_SEERR_TYPES[type];
+                return (type && type.indexOf('seerr_') === 0) ||
+                    type === 'radarr_calendar' ||
+                    type === 'sonarr_calendar';
+            }
+
+            function isSeerrSliderSection(section) {
+                return !!section && (section.kind === 'seerrSlider' ||
+                    (section.kind === 'pluginDynamic' && section.pluginSource === 'seerr') ||
+                    section.type === 'seerr_slider');
+            }
+
+            function seerrSliderIdOf(section) {
+                if (!section) return '';
+                if (section.sliderId) return String(section.sliderId);
+                if (section.pluginAdditionalData) return String(section.pluginAdditionalData);
+                return '';
+            }
+
+            function seerrSliderTypeOf(section) {
+                if (!section || section.sliderType == null || section.sliderType === '') return null;
+                var n = Number(section.sliderType);
+                return Number.isFinite(n) ? n : null;
+            }
+
+            function seerrSliderLiveTitle(section) {
+                var sliders = HOME_LAYOUT_STATE.seerrDiscoverSliders || [];
+                var id = seerrSliderIdOf(section);
+                for (var i = 0; i < sliders.length; i++) {
+                    if (String(sliders[i].id) !== id) continue;
+                    return (sliders[i].title || '').trim();
+                }
+                return (section.pluginDisplayText || '').trim();
+            }
+
+            function seerrSliderLabel(slider) {
+                var title = (slider && slider.title ? String(slider.title) : '').trim();
+                return title || 'Seerr slider';
+            }
+
+            function isSeerrCustomSliderType(type) {
+                var n = Number(type);
+                if (!Number.isFinite(n)) return false;
+                if (n >= 1 && n <= 12) return false;
+                if (n >= 38 && n <= 43) return false;
+                return n > 12;
             }
 
             function isExternalHomeSectionType(type) {
@@ -4103,6 +4129,11 @@
 
             function homeSectionLabel(section) {
                 if (!section) return 'Unknown row';
+                if (isSeerrSliderSection(section)) {
+                    return seerrSliderLiveTitle(section) ||
+                        section.pluginDisplayText ||
+                        'Seerr slider';
+                }
                 if (section.kind === 'pluginDynamic') {
                     return section.pluginDisplayText || section.pluginSection || 'Dynamic row';
                 }
@@ -4112,8 +4143,9 @@
 
             function homeSectionMeta(section) {
                 if (!section) return 'Basics';
+                if (isSeerrSliderSection(section) || isSeerrHomeSectionType(section.type)) return 'Seerr';
                 if (section.kind !== 'pluginDynamic') {
-                    return isSeerrHomeSectionType(section.type) ? 'Seerr' : (isExternalHomeSectionType(section.type) ? 'External Lists' : 'Basics');
+                    return isExternalHomeSectionType(section.type) ? 'External Lists' : 'Basics';
                 }
                 if (section.pluginSource === 'collections') return 'Collection';
                 if (section.pluginSource === 'playlists') return 'Playlist';
@@ -4122,8 +4154,10 @@
             }
 
             function homeSectionBadgeClass(section) {
+                if (isSeerrSliderSection(section) || (section && isSeerrHomeSectionType(section.type))) {
+                    return 'homeLayoutBadge-seerr';
+                }
                 if (!section || section.kind !== 'pluginDynamic') {
-                    if (section && isSeerrHomeSectionType(section.type)) return 'homeLayoutBadge-seerr';
                     if (section && isExternalHomeSectionType(section.type)) return 'homeLayoutBadge-external';
                     return 'homeLayoutBadge-builtin';
                 }
@@ -4135,6 +4169,9 @@
 
             function homeSectionKey(section) {
                 if (!section) return '';
+                if (isSeerrSliderSection(section)) {
+                    return 'seerrSlider:' + seerrSliderIdOf(section);
+                }
                 if (section.kind === 'pluginDynamic') {
                     return [
                         'pluginDynamic',
@@ -4164,7 +4201,9 @@
 
             function renumberHomeLayoutSections() {
                 HOME_LAYOUT_STATE.sections.forEach(function(section, index) {
-                    section.enabled = true;
+                    if (section.kind !== 'pluginDynamic' && section.kind !== 'seerrSlider') {
+                        section.enabled = true;
+                    }
                     section.order = index;
                 });
             }
@@ -4196,7 +4235,22 @@
                 }).forEach(function(section) {
                     if (!section) return;
                     var normalized;
-                    if (section.kind === 'pluginDynamic') {
+                    if (isSeerrSliderSection(section)) {
+                        var sliderId = seerrSliderIdOf(section);
+                        if (!sliderId) return;
+                        var sliderType = seerrSliderTypeOf(section);
+                        normalized = {
+                            kind: 'seerrSlider',
+                            type: 'seerr_slider',
+                            enabled: section.enabled !== false,
+                            order: ordered.length,
+                            sliderId: sliderId
+                        };
+                        if (sliderType != null) normalized.sliderType = sliderType;
+                        if (section.pluginDisplayText) {
+                            normalized.pluginDisplayText = section.pluginDisplayText;
+                        }
+                    } else if (section.kind === 'pluginDynamic') {
                         normalized = {
                             kind: 'pluginDynamic',
                             type: 'none',
@@ -4245,6 +4299,29 @@
                 };
             }
 
+            function createSeerrSliderCandidate(slider) {
+                var sliderId = String(slider.id);
+                var label = seerrSliderLabel(slider);
+                var candidate = {
+                    key: 'seerrSlider:' + sliderId,
+                    tab: 'seerr',
+                    label: label,
+                    meta: 'Seerr',
+                    badgeClass: 'homeLayoutBadge-seerr',
+                    section: {
+                        kind: 'seerrSlider',
+                        type: 'seerr_slider',
+                        enabled: true,
+                        order: 0,
+                        sliderId: sliderId,
+                        pluginDisplayText: label
+                    }
+                };
+                var sliderType = Number(slider.type);
+                if (Number.isFinite(sliderType)) candidate.section.sliderType = sliderType;
+                return candidate;
+            }
+
             function createDynamicCandidate(tab, source, sectionName, id, label, meta, serverId) {
                 return {
                     key: ['pluginDynamic', source, sectionName, id || ''].join(':'),
@@ -4271,7 +4348,9 @@
                     .filter(function(definition) { return (!isSeerrHomeSectionType(definition.type) && !isExternalHomeSectionType(definition.type)); })
                     .map(createBuiltinCandidate);
                 HOME_LAYOUT_STATE.available.seerr = HOME_SECTION_DEFINITIONS
-                    .filter(function(definition) { return isSeerrHomeSectionType(definition.type); })
+                    .filter(function(definition) {
+                        return isSeerrHomeSectionType(definition.type);
+                    })
                     .map(createBuiltinCandidate);
                 HOME_LAYOUT_STATE.available.external = HOME_SECTION_DEFINITIONS
                     .filter(function(definition) { return isExternalHomeSectionType(definition.type); })
@@ -4499,6 +4578,38 @@
                 loadHomeLayoutCollections();
                 loadHomeLayoutPlaylists();
                 loadHomeLayoutGenres();
+                loadHomeLayoutSeerrSliders();
+            }
+
+            function seerrBuiltinCandidates() {
+                return HOME_SECTION_DEFINITIONS
+                    .filter(function(definition) {
+                        return isSeerrHomeSectionType(definition.type);
+                    })
+                    .map(createBuiltinCandidate);
+            }
+
+            function loadHomeLayoutSeerrSliders() {
+                var serverId = ApiClient.serverAddress ? ApiClient.serverAddress() : '';
+                fetch(serverId + '/Moonfin/Seerr/Api/settings/discover', {
+                    method: 'GET',
+                    headers: getMoonfinAuthHeaders()
+                }).then(function(response) {
+                    if (!response.ok) return [];
+                    return response.json();
+                }).then(function(data) {
+                    var sliders = Array.isArray(data) ? data : [];
+                    HOME_LAYOUT_STATE.seerrDiscoverSliders = sliders;
+                    var candidates = sliders.filter(function(slider) {
+                        if (!slider || slider.enabled === false || !slider.id) return false;
+                        return isSeerrCustomSliderType(slider.type);
+                    }).map(createSeerrSliderCandidate);
+                    setHomeLayoutAvailable('seerr', seerrBuiltinCandidates().concat(candidates));
+                    renderHomeSectionsEditor();
+                }).catch(function() {
+                    HOME_LAYOUT_STATE.seerrDiscoverSliders = [];
+                    setHomeLayoutAvailable('seerr', seerrBuiltinCandidates());
+                });
             }
 
             function setHomeLayoutAvailable(tab, candidates) {
@@ -4598,15 +4709,22 @@
                 if (HOME_LAYOUT_STATE.sections.length === 0) return null;
                 renumberHomeLayoutSections();
                 return HOME_LAYOUT_STATE.sections.map(function(section) {
+                    var isSlider = section.kind === 'seerrSlider';
                     var isDynamic = section.kind === 'pluginDynamic';
                     var result = {
-                        type: isDynamic ? 'none' : section.type,
+                        type: isSlider ? (section.type || 'seerr_slider') : (isDynamic ? 'none' : section.type),
                         // Dynamic rows stay in the editor when disabled, unlike builtins, so
                         // writing them all back as enabled would switch every custom row on.
-                        enabled: isDynamic ? section.enabled !== false : true,
+                        enabled: (isDynamic || isSlider) ? section.enabled !== false : true,
                         order: section.order
                     };
-                    if (isDynamic) {
+                    if (isSlider) {
+                        result.kind = 'seerrSlider';
+                        result.type = 'seerr_slider';
+                        result.sliderId = section.sliderId;
+                        if (section.sliderType != null) result.sliderType = section.sliderType;
+                        if (section.pluginDisplayText) result.pluginDisplayText = section.pluginDisplayText;
+                    } else if (isDynamic) {
                         result.kind = 'pluginDynamic';
                         result.pluginSource = section.pluginSource;
                         // Custom rows have no server of their own and the client keys them on

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -4089,8 +4089,6 @@
             function isSeerrSliderType(type) {
                 var n = Number(type);
                 if (!Number.isFinite(n)) return false;
-                if (n >= 1 && n <= 12) return false;
-                if (n >= 38 && n <= 43) return false;
                 return n > 12;
             }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -4049,9 +4049,7 @@
             };
 
             function isSeerrHomeSectionType(type) {
-                return (type && type.indexOf('seerr_') === 0) ||
-                    type === 'radarr_calendar' ||
-                    type === 'sonarr_calendar';
+                return !!(type && type.indexOf('seerr_') === 0);
             }
 
             function isSeerrSliderSection(section) {
@@ -4088,7 +4086,7 @@
                 return title || 'Seerr slider';
             }
 
-            function isSeerrCustomSliderType(type) {
+            function isSeerrSliderType(type) {
                 var n = Number(type);
                 if (!Number.isFinite(n)) return false;
                 if (n >= 1 && n <= 12) return false;
@@ -4602,7 +4600,7 @@
                     HOME_LAYOUT_STATE.seerrDiscoverSliders = sliders;
                     var candidates = sliders.filter(function(slider) {
                         if (!slider || slider.enabled === false || !slider.id) return false;
-                        return isSeerrCustomSliderType(slider.type);
+                        return isSeerrSliderType(slider.type);
                     }).map(createSeerrSliderCandidate);
                     setHomeLayoutAvailable('seerr', seerrBuiltinCandidates().concat(candidates));
                     renderHomeSectionsEditor();

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -4075,7 +4075,6 @@
             function isSeerrSliderType(type) {
                 var n = Number(type);
                 if (!Number.isFinite(n)) return false;
-                if (n >= 1017 && n <= 1022) return false;
                 return n >= 1;
             }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -3414,19 +3414,6 @@
                 { type: 'sinceyouwatched4', label: "Since You Watched 4" },
                 { type: 'sinceyouwatched5', label: "Since You Watched 5" },
                 { type: 'rewatch', label: "Rewatch" },
-                { type: 'seerr_shortcuts', label: 'Seerr Browse' },
-                { type: 'seerr_recent_requests', label: 'Seerr Recent Requests' },
-                { type: 'seerr_recently_added', label: 'Seerr Recently Added' },
-                { type: 'seerr_popular_movies', label: 'Seerr Popular Movies' },
-                { type: 'seerr_upcoming_movies', label: 'Seerr Upcoming Movies' },
-                { type: 'seerr_popular_series', label: 'Seerr Popular Series' },
-                { type: 'seerr_upcoming_series', label: 'Seerr Upcoming Series' },
-                { type: 'seerr_trending', label: 'Seerr Trending' },
-                { type: 'seerr_movie_genres', label: 'Seerr Movie Genres' },
-                { type: 'seerr_studios', label: 'Seerr Studios' },
-                { type: 'seerr_series_genres', label: 'Seerr Series Genres' },
-                { type: 'seerr_networks', label: 'Seerr Networks' },
-                { type: 'seerr_watchlist', label: 'Seerr Watchlist' },
                 { type: 'imdb_top_250_movies', label: 'IMDB Top 250 Movies' },
                 { type: 'imdb_top_250_tv_shows', label: 'IMDB Top 250 Shows' },
                 { type: 'imdb_most_popular_movies', label: 'IMDB Most Popular Movies' },
@@ -4048,10 +4035,6 @@
                 tmdb_trending_all_weekly: true
             };
 
-            function isSeerrHomeSectionType(type) {
-                return !!(type && type.indexOf('seerr_') === 0);
-            }
-
             function isSeerrSliderSection(section) {
                 return !!section && (section.kind === 'seerrSlider' ||
                     (section.kind === 'pluginDynamic' && section.pluginSource === 'seerr') ||
@@ -4074,6 +4057,9 @@
             function seerrSliderLiveTitle(section) {
                 var sliders = HOME_LAYOUT_STATE.seerrDiscoverSliders || [];
                 var id = seerrSliderIdOf(section);
+                if (id === 'shortcuts') {
+                    return (section.pluginDisplayText || 'Seerr Browse').trim();
+                }
                 for (var i = 0; i < sliders.length; i++) {
                     if (String(sliders[i].id) !== id) continue;
                     return (sliders[i].title || '').trim();
@@ -4089,7 +4075,8 @@
             function isSeerrSliderType(type) {
                 var n = Number(type);
                 if (!Number.isFinite(n)) return false;
-                return n > 12;
+                if (n >= 1017 && n <= 1022) return false;
+                return n >= 1;
             }
 
             function isExternalHomeSectionType(type) {
@@ -4139,7 +4126,7 @@
 
             function homeSectionMeta(section) {
                 if (!section) return 'Basics';
-                if (isSeerrSliderSection(section) || isSeerrHomeSectionType(section.type)) return 'Seerr';
+                if (isSeerrSliderSection(section)) return 'Seerr';
                 if (section.kind !== 'pluginDynamic') {
                     return isExternalHomeSectionType(section.type) ? 'External Lists' : 'Basics';
                 }
@@ -4150,7 +4137,7 @@
             }
 
             function homeSectionBadgeClass(section) {
-                if (isSeerrSliderSection(section) || (section && isSeerrHomeSectionType(section.type))) {
+                if (isSeerrSliderSection(section)) {
                     return 'homeLayoutBadge-seerr';
                 }
                 if (!section || section.kind !== 'pluginDynamic') {
@@ -4166,7 +4153,11 @@
             function homeSectionKey(section) {
                 if (!section) return '';
                 if (isSeerrSliderSection(section)) {
-                    return 'seerrSlider:' + seerrSliderIdOf(section);
+                    var id = seerrSliderIdOf(section);
+                    if (id) return 'seerrSlider:' + id;
+                    var t = seerrSliderTypeOf(section);
+                    if (t != null) return 'seerrSlider:type:' + t;
+                    return 'seerrSlider:';
                 }
                 if (section.kind === 'pluginDynamic') {
                     return [
@@ -4233,15 +4224,15 @@
                     var normalized;
                     if (isSeerrSliderSection(section)) {
                         var sliderId = seerrSliderIdOf(section);
-                        if (!sliderId) return;
                         var sliderType = seerrSliderTypeOf(section);
+                        if (!sliderId && sliderType == null) return;
                         normalized = {
                             kind: 'seerrSlider',
                             type: 'seerr_slider',
                             enabled: section.enabled !== false,
-                            order: ordered.length,
-                            sliderId: sliderId
+                            order: ordered.length
                         };
+                        if (sliderId) normalized.sliderId = sliderId;
                         if (sliderType != null) normalized.sliderType = sliderType;
                         if (section.pluginDisplayText) {
                             normalized.pluginDisplayText = section.pluginDisplayText;
@@ -4284,8 +4275,8 @@
                     key: 'builtin:' + definition.type,
                     tab: 'builtin',
                     label: definition.label,
-                    meta: isSeerrHomeSectionType(definition.type) ? 'Seerr' : (isExternalHomeSectionType(definition.type) ? 'External Lists' : 'Basics'),
-                    badgeClass: isSeerrHomeSectionType(definition.type) ? 'homeLayoutBadge-seerr' : (isExternalHomeSectionType(definition.type) ? 'homeLayoutBadge-external' : 'homeLayoutBadge-builtin'),
+                    meta: isExternalHomeSectionType(definition.type) ? 'External Lists' : 'Basics',
+                    badgeClass: isExternalHomeSectionType(definition.type) ? 'homeLayoutBadge-external' : 'homeLayoutBadge-builtin',
                     section: {
                         kind: 'builtin',
                         type: definition.type,
@@ -4318,6 +4309,24 @@
                 return candidate;
             }
 
+            function createSeerrShortcutsCandidate() {
+                return {
+                    key: 'seerrSlider:shortcuts',
+                    tab: 'seerr',
+                    label: 'Seerr Browse',
+                    meta: 'Seerr',
+                    badgeClass: 'homeLayoutBadge-seerr',
+                    section: {
+                        kind: 'seerrSlider',
+                        type: 'seerr_slider',
+                        enabled: true,
+                        order: 0,
+                        sliderId: 'shortcuts',
+                        pluginDisplayText: 'Seerr Browse'
+                    }
+                };
+            }
+
             function createDynamicCandidate(tab, source, sectionName, id, label, meta, serverId) {
                 return {
                     key: ['pluginDynamic', source, sectionName, id || ''].join(':'),
@@ -4341,13 +4350,9 @@
 
             function initializeHomeLayoutAvailableRows() {
                 HOME_LAYOUT_STATE.available.builtin = HOME_SECTION_DEFINITIONS
-                    .filter(function(definition) { return (!isSeerrHomeSectionType(definition.type) && !isExternalHomeSectionType(definition.type)); })
+                    .filter(function(definition) { return !isExternalHomeSectionType(definition.type); })
                     .map(createBuiltinCandidate);
-                HOME_LAYOUT_STATE.available.seerr = HOME_SECTION_DEFINITIONS
-                    .filter(function(definition) {
-                        return isSeerrHomeSectionType(definition.type);
-                    })
-                    .map(createBuiltinCandidate);
+                HOME_LAYOUT_STATE.available.seerr = [createSeerrShortcutsCandidate()];
                 HOME_LAYOUT_STATE.available.external = HOME_SECTION_DEFINITIONS
                     .filter(function(definition) { return isExternalHomeSectionType(definition.type); })
                     .map(createBuiltinCandidate);
@@ -4578,11 +4583,7 @@
             }
 
             function seerrBuiltinCandidates() {
-                return HOME_SECTION_DEFINITIONS
-                    .filter(function(definition) {
-                        return isSeerrHomeSectionType(definition.type);
-                    })
-                    .map(createBuiltinCandidate);
+                return [createSeerrShortcutsCandidate()];
             }
 
             function loadHomeLayoutSeerrSliders() {

--- a/Jellyfin/backend/PluginConfiguration.cs
+++ b/Jellyfin/backend/PluginConfiguration.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using MediaBrowser.Model.Plugins;
 using Moonfin.Server.Models;
+using Moonfin.Server.Services;
 
 namespace Moonfin.Server;
 
@@ -314,6 +315,11 @@ public class PluginConfiguration : BasePluginConfiguration
             JellyseerrUrl = null;
             JellyseerrEnabled = false;
             JellyseerrDisplayName = null;
+            changed = true;
+        }
+
+        if (MoonfinSettingsService.MigrateSeerrHomeSections(DefaultUserSettings))
+        {
             changed = true;
         }
 

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -84,12 +84,18 @@ public class MoonfinSettingsService
                 return null;
             }
 
+            var persist = false;
             if (settings.NeedsMigration)
             {
                 _logger.LogInformation("Migrating v1 settings to v2 for user {UserId}", userId);
                 settings = MigrateV1ToV2(settings);
+                persist = true;
+            }
 
-                // Persist the migrated version
+            if (MigrateSeerrHomeSections(settings)) persist = true;
+
+            if (persist)
+            {
                 var migratedJson = JsonSerializer.Serialize(settings, _jsonOptions);
                 AtomicFile.WriteAllText(filePath, migratedJson);
             }
@@ -302,6 +308,8 @@ public class MoonfinSettingsService
                 finalSettings = settings;
             }
 
+            MigrateSeerrHomeSections(finalSettings);
+
             // Update metadata
             StripServerWideKeys(finalSettings);
             finalSettings.LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -380,6 +388,8 @@ public class MoonfinSettingsService
             }
 
             var savedProfile = existingProfile ?? profile;
+
+            MigrateSeerrHomeSections(settings);
 
             // Update metadata
             StripServerWideKeys(settings);
@@ -1352,5 +1362,103 @@ public class MoonfinSettingsService
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Rewrites stored <c>seerr_trending</c> home types to sliders. Called from
+    /// the same persist-on-load path as <see cref="MigrateV1ToV2"/>.
+    /// </summary>
+    internal static bool MigrateSeerrHomeSections(MoonfinUserSettings? settings)
+    {
+        if (settings == null) return false;
+        var changed = false;
+        changed |= MigrateSeerrHomeSections(settings.Global);
+        changed |= MigrateSeerrHomeSections(settings.Desktop);
+        changed |= MigrateSeerrHomeSections(settings.Mobile);
+        changed |= MigrateSeerrHomeSections(settings.Tv);
+        return changed;
+    }
+
+    internal static bool MigrateSeerrHomeSections(MoonfinSettingsProfile? profile)
+    {
+        if (profile == null) return false;
+        var changed = false;
+        if (profile.HomeSections != null)
+        {
+            foreach (var section in profile.HomeSections)
+            {
+                if (RewriteDeletedSeerrHomeType(section)) changed = true;
+            }
+        }
+
+        if (profile.HomeRowOrder == null) return changed;
+        var filtered = profile.HomeRowOrder.FindAll(name =>
+            string.IsNullOrEmpty(name) ||
+            !name.StartsWith("seerr_", StringComparison.OrdinalIgnoreCase));
+        if (filtered.Count == profile.HomeRowOrder.Count) return changed;
+        profile.HomeRowOrder = filtered.Count > 0 ? filtered : null;
+        return true;
+    }
+
+    static bool RewriteDeletedSeerrHomeType(MoonfinHomeSectionConfig section)
+    {
+        var id = section.SliderId;
+        if (!string.IsNullOrEmpty(id) &&
+            id.StartsWith("legacy:", StringComparison.OrdinalIgnoreCase))
+        {
+            if (int.TryParse(id.AsSpan("legacy:".Length), out var fromId))
+            {
+                section.SliderType ??= fromId;
+            }
+
+            section.SliderId = null;
+            return true;
+        }
+
+        var type = section.Type;
+        if (string.IsNullOrEmpty(type) ||
+            string.Equals(section.Kind, "seerrSlider", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(type, "seerr_slider", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (type.Equals("seerr_shortcuts", StringComparison.OrdinalIgnoreCase))
+        {
+            section.Kind = "seerrSlider";
+            section.Type = "seerr_slider";
+            section.SliderId = "shortcuts";
+            section.SliderType = null;
+            if (string.IsNullOrWhiteSpace(section.PluginDisplayText))
+            {
+                section.PluginDisplayText = "Seerr Browse";
+            }
+
+            return true;
+        }
+
+        int sliderType;
+        switch (type)
+        {
+            case "seerr_recently_added": sliderType = 1; break;
+            case "seerr_recent_requests": sliderType = 2; break;
+            case "seerr_watchlist": sliderType = 3; break;
+            case "seerr_trending": sliderType = 4; break;
+            case "seerr_popular_movies": sliderType = 5; break;
+            case "seerr_movie_genres": sliderType = 6; break;
+            case "seerr_upcoming_movies": sliderType = 7; break;
+            case "seerr_studios": sliderType = 8; break;
+            case "seerr_popular_series": sliderType = 9; break;
+            case "seerr_series_genres": sliderType = 10; break;
+            case "seerr_upcoming_series": sliderType = 11; break;
+            case "seerr_networks": sliderType = 12; break;
+            default: return false;
+        }
+
+        section.Kind = "seerrSlider";
+        section.Type = "seerr_slider";
+        section.SliderId = null;
+        section.SliderType = sliderType;
+        return true;
     }
 }

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -1392,12 +1392,62 @@ public class MoonfinSettingsService
         }
 
         if (profile.HomeRowOrder == null) return changed;
-        var filtered = profile.HomeRowOrder.FindAll(name =>
-            string.IsNullOrEmpty(name) ||
-            !name.StartsWith("seerr_", StringComparison.OrdinalIgnoreCase));
-        if (filtered.Count == profile.HomeRowOrder.Count) return changed;
-        profile.HomeRowOrder = filtered.Count > 0 ? filtered : null;
-        return true;
+        var kept = new List<string>();
+        foreach (var name in profile.HomeRowOrder)
+        {
+            if (string.IsNullOrEmpty(name) ||
+                !name.StartsWith("seerr_", StringComparison.OrdinalIgnoreCase))
+            {
+                kept.Add(name);
+                continue;
+            }
+
+            profile.HomeSections ??= new List<MoonfinHomeSectionConfig>();
+            var section = new MoonfinHomeSectionConfig
+            {
+                Type = name,
+                Enabled = true,
+                Order = profile.HomeSections.Count,
+            };
+            if (!RewriteDeletedSeerrHomeType(section)) continue;
+            if (HasMatchingSeerrHomeSection(profile.HomeSections, section)) continue;
+            profile.HomeSections.Add(section);
+            changed = true;
+        }
+
+        if (kept.Count != profile.HomeRowOrder.Count)
+        {
+            profile.HomeRowOrder = kept.Count > 0 ? kept : null;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    static bool HasMatchingSeerrHomeSection(
+        List<MoonfinHomeSectionConfig> sections,
+        MoonfinHomeSectionConfig incoming)
+    {
+        foreach (var existing in sections)
+        {
+            if (!string.Equals(existing.Kind, "seerrSlider", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(incoming.SliderId) &&
+                string.Equals(existing.SliderId, incoming.SliderId, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (incoming.SliderType is int type && existing.SliderType == type)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     static bool RewriteDeletedSeerrHomeType(MoonfinHomeSectionConfig section)

--- a/Jellyfin/backend/Services/MoonfinSettingsService.cs
+++ b/Jellyfin/backend/Services/MoonfinSettingsService.cs
@@ -251,10 +251,13 @@ public class MoonfinSettingsService
         }
 
         var homeRowOrder = profile.HomeSections
-            .Where(section => !string.Equals(section.Kind, "pluginDynamic", StringComparison.OrdinalIgnoreCase))
+            .Where(section =>
+                string.IsNullOrEmpty(section.Kind) ||
+                string.Equals(section.Kind, "builtin", StringComparison.OrdinalIgnoreCase))
             .Where(section => section.Enabled != false)
             .Where(section => !string.IsNullOrWhiteSpace(section.Type) &&
-                !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(section.Type, "none", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(section.Type, "seerr_slider", StringComparison.OrdinalIgnoreCase))
             .OrderBy(section => section.Order ?? int.MaxValue)
             .Select(section => section.Type!)
             .ToList();


### PR DESCRIPTION
# Pull Request

## Summary

Supersedes draft [#280](https://github.com/Moonfin-Client/Plugin/pull/280). Companion client: [Moonfin-Core #1520](https://github.com/Moonfin-Client/Moonfin-Core/pull/1520), which replaces closed [Moonfin-Core #1407](https://github.com/Moonfin-Client/Moonfin-Core/pull/1407).

Persist Seerr discover sliders in `homeSections` as `kind: seerrSlider` (`sliderId` / `sliderType`) instead of a plugin type table. List any discover type `n >= 1` (stock 1–12 and admin custom 13+). Unknown types stay displayable; Core decides what to fetch. One-shot migrate rewrites stored `seerr_trending` / `seerr_shortcuts` (and the other deleted `seerr_*` home types) into sliders, including `homeRowOrder`-only profiles so those rows are not dropped. Foreseerr is **not** in this PR.

The Jellyfin Seerr home-layout tab only treats Seerr slider rows as Seerr, matching Emby, so Radarr/Sonarr calendars stay off that tab.

## Related Issues

- Related to https://github.com/Moonfin-Client/Plugin/pull/280 (draft; this replaces it)
- Related to https://github.com/Moonfin-Client/Moonfin-Core/pull/1520
- Related to https://github.com/Moonfin-Client/Moonfin-Core/pull/1407

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] API / endpoint change
- [x] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [x] Settings sync / profiles
- [x] Admin defaults / config page
- [ ] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [x] Seerr integration
- [ ] Games / Emulators
- [x] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made

- Additive `sliderId` / `sliderType` on home section config for Jellyfin and Emby.
- Admin JS round-trips discover sliders as `kind: seerrSlider` without a type enum. Unbound rows (`sliderType` only) keep a stable key.
- List any discover slider with `type >= 1`. Shortcuts are a Moonfin-only candidate (`sliderId: shortcuts`), not a DiscoverSliderType.
- One-shot `MigrateSeerrHomeSections` on load/save: rewrite deleted `seerr_*` types, unbind leftover `legacy:` ids, and convert `homeRowOrder` `seerr_*` names into `homeSections` sliders instead of deleting them.
- Derive `homeRowOrder` from builtin sections only (skip `seerr_slider`).
- Jellyfin Seerr tab uses the same Seerr-only rule as Emby (no Radarr/Sonarr there).

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [x] Companion client PR(s) required, linked here: https://github.com/Moonfin-Client/Moonfin-Core/pull/1520
- [x] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `sliderId` (string)
  - `sliderType` (int)
  - `kind: seerrSlider` on `homeSections` entries
  - `type: seerr_slider` wire type for those entries

## Compatibility
- [x] Change to the settings profile is additive only, no renamed or removed properties
- [x] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [x] Migration added for any renamed or removed settings
- [x] Older clients still work, unknown fields are ignored and no keys were removed

The deleted `seerr_*` builtin names are rewritten to sliders on load/save. Older clients that ignore `kind: seerrSlider` still round-trip the extra fields.

## Testing
Describe how this change was tested.

- [x] Built the plugin and deployed to a Jellyfin server
- [x] Verified against a live client (which one: Moonfin-Core Linux desktop on `feat/seerr-slider-home-kind`)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Dashboard → Moonbase → Home layout / Seerr and confirm discover sliders list (types 1–12 and 13+), plus Seerr Browse.
2. Enable a slider, save, and confirm `homeSections` stores `kind: seerrSlider` with `sliderId` / `sliderType`.
3. Load a profile that still has `seerr_trending` in `homeSections` or only in `homeRowOrder`. Confirm it becomes a slider and is not dropped.
4. Confirm Radarr/Sonarr rows do not appear on the Jellyfin Seerr tab.
5. Confirm a Moonfin client on [Core #1520](https://github.com/Moonfin-Client/Moonfin-Core/pull/1520) can show enabled slider rows on Home.

## Screenshots (if applicable)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
- [x] Any new setting keys match the client-side keys exactly

Made with [Cursor](https://cursor.com)