### PR TITLE
feat-settings - Add syncing and pushing for Metadata Customizations

### DIFF
--- a/Emby/Emby.Plugins.Moonfin/Api/RatingsRequests.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/RatingsRequests.cs
@@ -59,4 +59,11 @@ namespace Emby.Plugins.Moonfin.Api
     {
         public int CompanyId { get; set; }
     }
+
+    [Route("/Moonfin/Tmdb/NextEpisode", "GET")]
+    [Authenticated]
+    public class GetTmdbNextEpisodeRequest : IReturn<object>
+    {
+        public string? TmdbId { get; set; }
+    }
 }

--- a/Emby/Emby.Plugins.Moonfin/Api/RatingsService.cs
+++ b/Emby/Emby.Plugins.Moonfin/Api/RatingsService.cs
@@ -20,6 +20,8 @@ namespace Emby.Plugins.Moonfin.Api
 
         private static readonly ConcurrentDictionary<string, (object Response, DateTimeOffset CachedAt)> _tmdbSeasonCache = new ConcurrentDictionary<string, (object, DateTimeOffset)>();
         private static readonly ConcurrentDictionary<string, (object Response, DateTimeOffset CachedAt)> _tmdbEpisodeCache = new ConcurrentDictionary<string, (object, DateTimeOffset)>();
+        private static readonly ConcurrentDictionary<string, (object Response, DateTimeOffset CachedAt)> _tmdbNextEpisodeCache = new ConcurrentDictionary<string, (object, DateTimeOffset)>();
+        private static readonly TimeSpan TmdbNextEpisodeCacheTtl = TimeSpan.FromHours(6);
 
         // Remember failed upstream lookups briefly so a burst of requests during a bad-key
         // or rate-limit spell doesn't hammer api.mdblist.com.
@@ -357,6 +359,51 @@ namespace Emby.Plugins.Moonfin.Api
             }
         }
 
+        public async Task<object?> Get(GetTmdbNextEpisodeRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.TmdbId))
+                return Json(400, new { success = false, error = "Missing required parameter: tmdbId" });
+
+            var apiKey = await GetUserTmdbApiKey().ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(apiKey))
+                return Json(new { success = false, error = "No TMDB API key configured." });
+
+            var cacheKey = request.TmdbId.Trim();
+            if (_tmdbNextEpisodeCache.TryGetValue(cacheKey, out var cached) && DateTimeOffset.UtcNow - cached.CachedAt < TmdbNextEpisodeCacheTtl)
+                return Json(cached.Response);
+
+            try
+            {
+                var url = $"https://api.themoviedb.org/3/tv/{Uri.EscapeDataString(cacheKey)}";
+                using var client = CreateTmdbClient();
+                using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                MoonfinHttp.ApplyTmdbAuth(req, apiKey!);
+                using var response = await client.SendAsync(req).ConfigureAwait(false);
+
+                if ((int)response.StatusCode == 429) return Json(new { success = false, error = "TMDB rate limit reached." });
+                if (!response.IsSuccessStatusCode) return Json(new { success = false, error = $"TMDB returned status {(int)response.StatusCode}" });
+
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var data = JsonSerializer.Deserialize<TmdbSeriesApiResponse>(json, JsonOpts);
+                var nextEp = data?.NextEpisodeToAir;
+
+                var result = new
+                {
+                    success = nextEp != null,
+                    airDate = nextEp?.AirDate,
+                    seasonNumber = nextEp?.SeasonNumber,
+                    episodeNumber = nextEp?.EpisodeNumber,
+                    name = nextEp?.Name
+                };
+                _tmdbNextEpisodeCache[cacheKey] = (result, DateTimeOffset.UtcNow);
+                return Json(result);
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException))
+            {
+                return Json(new { success = false, error = "Failed to fetch from TMDB: " + ex.Message });
+            }
+        }
+
         public async Task<object?> Get(GetProductionCompaniesRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.TmdbId))
@@ -445,5 +492,12 @@ namespace Emby.Plugins.Moonfin.Api
     {
         [JsonPropertyName("name")] public string? Name { get; set; }
         [JsonPropertyName("episodes")] public List<TmdbEpisodeApiResponse>? Episodes { get; set; }
+    }
+
+    internal class TmdbSeriesApiResponse
+    {
+        [JsonPropertyName("id")] public int? Id { get; set; }
+        [JsonPropertyName("name")] public string? Name { get; set; }
+        [JsonPropertyName("next_episode_to_air")] public TmdbEpisodeApiResponse? NextEpisodeToAir { get; set; }
     }
 }

--- a/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
+++ b/Emby/Emby.Plugins.Moonfin/Models/MoonfinSettingsProfile.cs
@@ -199,6 +199,12 @@ namespace Emby.Plugins.Moonfin.Models
         [JsonPropertyName("hiddenOsdButtonsTv")] public List<string>? HiddenOsdButtonsTv { get; set; }
         [JsonPropertyName("hiddenOsdButtonsMobile")] public List<string>? HiddenOsdButtonsMobile { get; set; }
         [JsonPropertyName("hiddenOsdButtonsDesktop")] public List<string>? HiddenOsdButtonsDesktop { get; set; }
+        [JsonPropertyName("detailMetadataOrderTv")] public List<string>? DetailMetadataOrderTv { get; set; }
+        [JsonPropertyName("detailMetadataOrderMobile")] public List<string>? DetailMetadataOrderMobile { get; set; }
+        [JsonPropertyName("detailMetadataOrderDesktop")] public List<string>? DetailMetadataOrderDesktop { get; set; }
+        [JsonPropertyName("hiddenDetailMetadataTv")] public List<string>? HiddenDetailMetadataTv { get; set; }
+        [JsonPropertyName("hiddenDetailMetadataMobile")] public List<string>? HiddenDetailMetadataMobile { get; set; }
+        [JsonPropertyName("hiddenDetailMetadataDesktop")] public List<string>? HiddenDetailMetadataDesktop { get; set; }
         [JsonPropertyName("videoStartDelay")] public int? VideoStartDelay { get; set; }
         [JsonPropertyName("liveTvDirectPlayEnabled")] public bool? LiveTvDirectPlayEnabled { get; set; }
         [JsonPropertyName("maxBitrate")] public string? MaxBitrate { get; set; }

--- a/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
+++ b/Emby/Emby.Plugins.Moonfin/Pages/configPage.html
@@ -1190,6 +1190,12 @@
                                 </select>
                                 <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals content without pressing select.</div>
                             </div>
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Metadata Row</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Default Metadata Row &amp; Order</label>
+                                <div class="fieldDescription">Check which metadata items to show on detail pages and use the arrows to set their order.</div>
+                                <div id="DefaultDetailMetadataList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
+                            </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultDetailShowTechnicalDetails">Show Technical Details?</label>
                                 <select id="DefaultDetailShowTechnicalDetails" is="emby-select">

--- a/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
+++ b/Emby/Emby.Plugins.Moonfin/Pages/moonfin.js
@@ -735,6 +735,16 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
         { id: 'floatOnTop', label: 'Float on Top' }
     ];
 
+    var DETAIL_METADATA = [
+        { id: 'year', label: 'Release Year' },
+        { id: 'parentalRating', label: 'Parental Rating' },
+        { id: 'runtimeAndSeasons', label: 'Runtime & Seasons' },
+        { id: 'status', label: 'Series Status' },
+        { id: 'upcomingEpisodeDate', label: 'Upcoming Episodes' },
+        { id: 'genres', label: 'Genres' },
+        { id: 'seerrAvailability', label: 'Seerr Availability' }
+    ];
+
     function loadButtonPicker(view, selector, buttons, order, hidden) {
         var container = view.querySelector(selector);
         if (!container) return;
@@ -1906,6 +1916,9 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             setSelectValue(view, '#DefaultRecommendationSystemSource', defaults.recommendationSystemSource, 'Configured source');
             setNullableBoolSelect(view, '#DefaultRecommendationsApplyParentalRatingCap', defaults.recommendationsApplyParentalRatingCap);
             // One picker stands in for all three form factors.
+            loadButtonPicker(view, '#DefaultDetailMetadataList', DETAIL_METADATA,
+                defaults.detailMetadataOrderTv || defaults.detailMetadataOrderMobile || defaults.detailMetadataOrderDesktop || null,
+                defaults.hiddenDetailMetadataTv || defaults.hiddenDetailMetadataMobile || defaults.hiddenDetailMetadataDesktop || null);
             loadButtonPicker(view, '#DefaultDetailButtonsList', DETAIL_BUTTONS,
                 defaults.detailButtonOrderTv || defaults.detailButtonOrderMobile || defaults.detailButtonOrderDesktop || null,
                 defaults.hiddenDetailButtonsTv || defaults.hiddenDetailButtonsMobile || defaults.hiddenDetailButtonsDesktop || null);
@@ -2185,6 +2198,13 @@ define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'em
             d.detailShowTechnicalDetails = getNullableBoolSelect(view, '#DefaultDetailShowTechnicalDetails');
             d.recommendationSystemSource = view.querySelector('#DefaultRecommendationSystemSource').value || null;
             d.recommendationsApplyParentalRatingCap = getNullableBoolSelect(view, '#DefaultRecommendationsApplyParentalRatingCap');
+            var metaVal = getButtonPickerValue(view, '#DefaultDetailMetadataList');
+            d.detailMetadataOrderTv = metaVal.order;
+            d.detailMetadataOrderMobile = metaVal.order;
+            d.detailMetadataOrderDesktop = metaVal.order;
+            d.hiddenDetailMetadataTv = metaVal.hidden;
+            d.hiddenDetailMetadataMobile = metaVal.hidden;
+            d.hiddenDetailMetadataDesktop = metaVal.hidden;
             var btnVal = getButtonPickerValue(view, '#DefaultDetailButtonsList');
             // Clients read a different key per form factor, so one arrangement covers all three.
             d.detailButtonOrderTv = btnVal.order;

--- a/Jellyfin/backend/Api/TmdbController.cs
+++ b/Jellyfin/backend/Api/TmdbController.cs
@@ -28,6 +28,9 @@ public class TmdbController : ControllerBase
     // Cache: key = "tmdbId:season:episode" => (response, timestamp)
     private static readonly ConcurrentDictionary<string, (TmdbEpisodeRatingResponse Response, DateTimeOffset CachedAt)> _episodeCache = new();
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+    // Cache: key = "tmdbId" => (response, timestamp)
+    private static readonly ConcurrentDictionary<string, (TmdbNextEpisodeResponse Response, DateTimeOffset CachedAt)> _nextEpisodeCache = new();
+    private static readonly TimeSpan NextEpisodeCacheTtl = TimeSpan.FromHours(6);
 
     private static TimeSpan StudioCacheMaxAge =>
         TimeSpan.FromDays(MoonfinPlugin.Instance?.Configuration?.StudioLogosMaxAgeDays ?? 30);
@@ -264,6 +267,99 @@ public class TmdbController : ControllerBase
     }
 
     /// <summary>
+    /// Fetches the next episode to air for a TV series from TMDB.
+    /// Uses the authenticated user's TMDB API key from their settings or server default.
+    /// </summary>
+    /// <param name="tmdbId">TMDB series ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    [HttpGet("NextEpisode")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<TmdbNextEpisodeResponse>> GetNextEpisode(
+        [FromQuery] string tmdbId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(tmdbId))
+        {
+            return BadRequest(new { Error = "Missing required parameter: tmdbId" });
+        }
+
+        var apiKey = await GetUserApiKey();
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return Ok(new TmdbNextEpisodeResponse
+            {
+                Success = false,
+                Error = "No TMDB API key configured. Add your key in Moonfin Settings, or ask your server admin to set a server-wide key."
+            });
+        }
+
+        var cacheKey = tmdbId.Trim();
+        if (_nextEpisodeCache.TryGetValue(cacheKey, out var cached) && DateTimeOffset.UtcNow - cached.CachedAt < NextEpisodeCacheTtl)
+        {
+            return Ok(cached.Response);
+        }
+
+        try
+        {
+            var url = $"https://api.themoviedb.org/3/tv/{Uri.EscapeDataString(cacheKey)}";
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            ApplyAuth(request, apiKey);
+
+            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if ((int)response.StatusCode == 429)
+            {
+                return Ok(new TmdbNextEpisodeResponse
+                {
+                    Success = false,
+                    Error = "TMDB rate limit reached. Try again later."
+                });
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return Ok(new TmdbNextEpisodeResponse
+                {
+                    Success = false,
+                    Error = $"TMDB returned status {(int)response.StatusCode}"
+                });
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var data = JsonSerializer.Deserialize<TmdbSeriesApiResponse>(json, JsonOptions);
+            var nextEp = data?.NextEpisodeToAir;
+
+            var result = new TmdbNextEpisodeResponse
+            {
+                Success = nextEp != null,
+                AirDate = nextEp?.AirDate,
+                SeasonNumber = nextEp?.SeasonNumber,
+                EpisodeNumber = nextEp?.EpisodeNumber,
+                Name = nextEp?.Name
+            };
+
+            _nextEpisodeCache[cacheKey] = (result, DateTimeOffset.UtcNow);
+            return Ok(result);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Ok(new TmdbNextEpisodeResponse
+            {
+                Success = false,
+                Error = $"Failed to fetch from TMDB: {ex.Message}"
+            });
+        }
+    }
+
+    /// <summary>
     /// Returns the TMDB production companies (studios) for a movie or show, serving
     /// from the server-side cache and filling it from TMDB on a miss. Each company
     /// reports whether a logo is available via <c>StudioImage/{companyId}</c>.
@@ -467,7 +563,43 @@ public class StudioCompaniesResponse
     public List<StudioCompanyInfo> Companies { get; set; } = new();
 }
 
+/// <summary>
+/// Next episode to air response returned to the client.
+/// </summary>
+public class TmdbNextEpisodeResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("airDate")]
+    public string? AirDate { get; set; }
+
+    [JsonPropertyName("seasonNumber")]
+    public int? SeasonNumber { get; set; }
+
+    [JsonPropertyName("episodeNumber")]
+    public int? EpisodeNumber { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}
+
 // ===== Raw TMDB API Models =====
+
+internal class TmdbSeriesApiResponse
+{
+    [JsonPropertyName("id")]
+    public int? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("next_episode_to_air")]
+    public TmdbEpisodeApiResponse? NextEpisodeToAir { get; set; }
+}
 
 internal class TmdbEpisodeApiResponse
 {

--- a/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
+++ b/Jellyfin/backend/Models/MoonfinSettingsProfile.cs
@@ -556,6 +556,24 @@ public class MoonfinSettingsProfile
     [JsonPropertyName("hiddenOsdButtonsDesktop")]
     public List<string>? HiddenOsdButtonsDesktop { get; set; }
 
+    [JsonPropertyName("detailMetadataOrderTv")]
+    public List<string>? DetailMetadataOrderTv { get; set; }
+
+    [JsonPropertyName("detailMetadataOrderMobile")]
+    public List<string>? DetailMetadataOrderMobile { get; set; }
+
+    [JsonPropertyName("detailMetadataOrderDesktop")]
+    public List<string>? DetailMetadataOrderDesktop { get; set; }
+
+    [JsonPropertyName("hiddenDetailMetadataTv")]
+    public List<string>? HiddenDetailMetadataTv { get; set; }
+
+    [JsonPropertyName("hiddenDetailMetadataMobile")]
+    public List<string>? HiddenDetailMetadataMobile { get; set; }
+
+    [JsonPropertyName("hiddenDetailMetadataDesktop")]
+    public List<string>? HiddenDetailMetadataDesktop { get; set; }
+
     [JsonPropertyName("videoStartDelay")]
     public int? VideoStartDelay { get; set; }
 

--- a/Jellyfin/backend/Pages/configPage.html
+++ b/Jellyfin/backend/Pages/configPage.html
@@ -1068,6 +1068,12 @@
                                 </select>
                                 <div class="fieldDescription">When on, detail screen tabs start expanded and moving focus between them reveals content without pressing select.</div>
                             </div>
+                            <h4 style="margin: 1.5em 0 0.5em; font-size: 0.95em; color: #00a4dc;">Metadata Row</h4>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused">Default Metadata Row &amp; Order</label>
+                                <div class="fieldDescription">Check which metadata items to show on detail pages and use the arrows to set their order.</div>
+                                <div id="DefaultDetailMetadataList" style="max-height:260px;overflow-y:auto;border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px;margin-top:6px;"></div>
+                            </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="DefaultDetailShowTechnicalDetails">Show Technical Details?</label>
                                 <select id="DefaultDetailShowTechnicalDetails" is="emby-select">
@@ -3697,6 +3703,16 @@
                 { id: 'floatOnTop', label: 'Float on Top' }
             ];
 
+            var DETAIL_METADATA = [
+                { id: 'year', label: 'Release Year' },
+                { id: 'parentalRating', label: 'Parental Rating' },
+                { id: 'runtimeAndSeasons', label: 'Runtime & Seasons' },
+                { id: 'status', label: 'Series Status' },
+                { id: 'upcomingEpisodeDate', label: 'Upcoming Episodes' },
+                { id: 'genres', label: 'Genres' },
+                { id: 'seerrAvailability', label: 'Seerr Availability' }
+            ];
+
             function loadButtonPicker(selector, buttons, order, hidden) {
                 var container = document.querySelector(selector);
                 if (!container) return;
@@ -5598,6 +5614,9 @@
                     setSelectValue('#DefaultRecommendationSystemSource', defaults.recommendationSystemSource, 'Configured source');
                     setNullableBoolSelect('#DefaultRecommendationsApplyParentalRatingCap', defaults.recommendationsApplyParentalRatingCap);
                     // One picker stands in for all three form factors.
+                    loadButtonPicker('#DefaultDetailMetadataList', DETAIL_METADATA,
+                        defaults.detailMetadataOrderTv || defaults.detailMetadataOrderMobile || defaults.detailMetadataOrderDesktop || null,
+                        defaults.hiddenDetailMetadataTv || defaults.hiddenDetailMetadataMobile || defaults.hiddenDetailMetadataDesktop || null);
                     loadButtonPicker('#DefaultDetailButtonsList', DETAIL_BUTTONS,
                         defaults.detailButtonOrderTv || defaults.detailButtonOrderMobile || defaults.detailButtonOrderDesktop || null,
                         defaults.hiddenDetailButtonsTv || defaults.hiddenDetailButtonsMobile || defaults.hiddenDetailButtonsDesktop || null);
@@ -6091,6 +6110,13 @@
                         config.DefaultUserSettings.recommendationSystemSource = document.querySelector('#DefaultRecommendationSystemSource').value || null;
                         config.DefaultUserSettings.recommendationsApplyParentalRatingCap = getNullableBoolSelect('#DefaultRecommendationsApplyParentalRatingCap');
                         // Clients read a different key per form factor, so one arrangement covers all three.
+                        var metaVal = getButtonPickerValue('#DefaultDetailMetadataList');
+                        config.DefaultUserSettings.detailMetadataOrderTv = metaVal.order;
+                        config.DefaultUserSettings.detailMetadataOrderMobile = metaVal.order;
+                        config.DefaultUserSettings.detailMetadataOrderDesktop = metaVal.order;
+                        config.DefaultUserSettings.hiddenDetailMetadataTv = metaVal.hidden;
+                        config.DefaultUserSettings.hiddenDetailMetadataMobile = metaVal.hidden;
+                        config.DefaultUserSettings.hiddenDetailMetadataDesktop = metaVal.hidden;
                         var btnVal = getButtonPickerValue('#DefaultDetailButtonsList');
                         config.DefaultUserSettings.detailButtonOrderTv = btnVal.order;
                         config.DefaultUserSettings.detailButtonOrderMobile = btnVal.order;


### PR DESCRIPTION
# Pull Request

## Summary
Adds server-side settings synchronization and Web Admin panel defaults management for the new customizable Details screen Metadata Row introduced in Moonfin-Core PR #1526. Also implements a TMDB next episode proxy endpoint (`GET /Moonfin/Tmdb/NextEpisode`) with 6-hour caching to support client air date fallback when Sonarr is not configured.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1526

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] API / endpoint change
- [X] Settings schema change
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Area
- [X] Settings sync / profiles
- [X] Admin defaults / config page
- [X] Ratings (MDBList / TMDB)
- [ ] Notifications / Push (FCM / relay)
- [ ] Seerr integration
- [ ] Games / Emulators
- [ ] Custom home rows
- [ ] Web Client (Go to Moonfin-Core repo)
- [ ] Other / shared

## Changes Made
List the key changes included in this PR.

- **Settings Profile Schema**: Added **DetailMetadataOrderTv**, **DetailMetadataOrderMobile**, **DetailMetadataOrderDesktop**, and matching **HiddenDetailMetadata** (`Tv`, `Mobile`, `Desktop`) properties to **MoonfinSettingsProfile.cs** across both Jellyfin and Emby plugins.
- **Web Admin Defaults Interface**: Added a dedicated, reorderable, and toggleable **Metadata Row** section under Details Screen defaults in **configPage.html** and **moonfin.js** right above the "Show Technical Details?" toggle.
- **Settings Push & Sync**: Fully wired **loadButtonPicker** and **getButtonPickerValue** to allow administrators to configure default metadata ordering/visibility per client platform and push changes to clients.
- **TMDB Next Episode Endpoint**: Added `GET /Moonfin/Tmdb/NextEpisode?tmdbId={tmdbId}` to **TmdbController.cs** (Jellyfin) and **RatingsService.cs** (Emby), returning next episode air dates with in-memory 6-hour TTL caching for client upcoming episode fallback.

## Client Impact
Does this need matching changes in a client repo (Core, Smart-TV, Roku)?

- [ ] No client changes needed
- [X] Companion client PR(s) required, linked here:
  - Core: https://github.com/Moonfin-Client/Moonfin-Core/pull/1526
  - Smart-TV: https://github.com/Moonfin-Client/Smart-TV/pull/422
  - Roku: https://github.com/Moonfin-Client/Roku/pull/273
- [X] New setting keys added. List each key and confirm it matches the client key exactly, including casing:
  - `DetailMetadataOrderTv` (matches client `detailMetadataOrderTv`)
  - `DetailMetadataOrderMobile` (matches client `detailMetadataOrderMobile`)
  - `DetailMetadataOrderDesktop` (matches client `detailMetadataOrderDesktop`)
  - `HiddenDetailMetadataTv` (matches client `hiddenDetailMetadataTv`)
  - `HiddenDetailMetadataMobile` (matches client `hiddenDetailMetadataMobile`)
  - `HiddenDetailMetadataDesktop` (matches client `hiddenDetailMetadataDesktop`)
  
## Compatibility
- [X] Change to the settings profile is additive only, no renamed or removed properties
- [X] New properties use the same type the client sends (a client bool maps to `bool?`, an int to `int?`)
- [X] Migration added for any renamed or removed settings
- [X] Older clients still work, unknown fields are ignored and no keys were removed

## Testing
Describe how this change was tested.

- [X] Built the plugin and deployed to a Jellyfin server
- [X] Verified against a live client (which one:) Desktop
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built release DLL and deployed to Jellyfin 10.10.x test server on Synology NAS.
2. Verified the Moonbase plugin loads cleanly on server startup.
3. Opened Moonbase Admin Dashboard -> Defaults -> Details Screen.
4. Verified that the Metadata Row button picker renders directly above "Show Technical Details?".
5. Tested reordering items, toggling visibility, and saving/pushing defaults.
6. Verified `GET /Moonfin/Tmdb/NextEpisode?tmdbId=1399` endpoint returns formatted next episode metadata.

## Screenshots (if applicable)
Include config page screenshots or request/response samples where relevant.

### Default Values
<img width="1457" height="703" alt="2026-09-12_12-19-20_brave" src="https://github.com/user-attachments/assets/801d0dc2-30b6-40b8-9c85-7e85311527e7" />

### Modified Values
<img width="1460" height="675" alt="2026-09-12_12-19-54_brave" src="https://github.com/user-attachments/assets/8d042114-c907-4e61-b4ae-fa879837d722" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Any new setting keys match the client-side keys exactly
